### PR TITLE
client: Expose extended API to public

### DIFF
--- a/iota-client/extended/mod.rs
+++ b/iota-client/extended/mod.rs
@@ -1,8 +1,16 @@
-pub(crate) mod get_bundle;
-pub(crate) mod get_inputs;
-pub(crate) mod get_new_address;
-pub(crate) mod prepare_transfers;
-pub(crate) mod send_transfers;
-pub(crate) mod send_trytes;
-pub(crate) mod store_and_broadcast;
-pub(crate) mod traverse_bundle;
+/// Get Bundle Extended API
+pub mod get_bundle;
+/// Get Inputs Extended API
+pub mod get_inputs;
+/// Get New Address Extended API
+pub mod get_new_address;
+/// Prepare Transfer Extended API
+pub mod prepare_transfers;
+/// Send Transfer Extended API
+pub mod send_transfers;
+/// Send Trytes Extended API
+pub mod send_trytes;
+/// Store & Broadcast Extended API
+pub mod store_and_broadcast;
+/// Travers Bundle Extended API
+pub mod traverse_bundle;

--- a/iota-client/lib.rs
+++ b/iota-client/lib.rs
@@ -21,7 +21,7 @@ extern crate serde_json;
 mod core;
 mod extended;
 use crate::core::*;
-use crate::extended::*;
+pub use crate::extended::*;
 
 /// The Client strcut to connect through IRI with API usage
 pub mod client;


### PR DESCRIPTION
Extended API currently only have visibility in its own crate. Expose
them by re-export the APIs.