### PR TITLE
fix(wasm): Patch WASM support for ed25519-dalek

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -17,3 +17,6 @@ iota-conversion = { version = "0.5.0", path = "../../iota-conversion" }
 iota-bundle-preview = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 console_error_panic_hook = "0.1.6"
+
+[patch.crates-io]
+ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek", rev = "7c38546" }


### PR DESCRIPTION
`clear_on_drop` was replaced by `zeroize` in dalek-cryptography/ed25519-dalek@7c38546, which allows us to use `ed25519-dalek` in the WASM bindings

Fixes #67 