### PR TITLE
fix(client): Make seed as Option

### DIFF
--- a/bindings/c/src/api/send_transfers.rs
+++ b/bindings/c/src/api/send_transfers.rs
@@ -33,7 +33,7 @@ fn send_transfers(
     };
 
     let tx = smol::block_on(async move {
-        iota::Client::send_transfers(&seed)
+        iota::Client::send_transfers(Some(&seed))
             .transfers(transfers)
             .min_weight_magnitude(mwm)
             .send()

--- a/bindings/c/src/api/traverse_bundle.rs
+++ b/bindings/c/src/api/traverse_bundle.rs
@@ -2,17 +2,11 @@ use crate::{Bundle, Hash};
 use anyhow::Result;
 
 #[no_mangle]
-pub extern "C" fn iota_traverse_bundle(
-    hash: *const Hash,
-    bundle: *mut Bundle,
-) -> u8 {
+pub extern "C" fn iota_traverse_bundle(hash: *const Hash, bundle: *mut Bundle) -> u8 {
     traverse_bundle(hash, bundle).unwrap_or(1)
 }
 
-fn traverse_bundle(
-    hash: *const Hash,
-    bundle: *mut Bundle,
-) -> Result<u8> {
+fn traverse_bundle(hash: *const Hash, bundle: *mut Bundle) -> Result<u8> {
     let hash = unsafe {
         assert!(!hash.is_null());
         &*hash
@@ -23,10 +17,7 @@ fn traverse_bundle(
         &mut *bundle
     };
 
-    let res = smol::block_on(async move {
-        iota::Client::traverse_bundle(hash)
-            .await
-    })?;
+    let res = smol::block_on(async move { iota::Client::traverse_bundle(hash).await })?;
 
     *bundle = Bundle(res);
 

--- a/bindings/c/src/models.rs
+++ b/bindings/c/src/models.rs
@@ -110,7 +110,7 @@ pub extern "C" fn iota_bundle_dbg(ptr: *mut Bundle) {
         assert!(!ptr.is_null());
         &mut *ptr
     };
-    
+
     dbg!(ptr.0[0].bundle().to_inner().as_i8_slice().trytes().unwrap());
 }
 

--- a/examples/message_transfers.rs
+++ b/examples/message_transfers.rs
@@ -9,9 +9,7 @@ use anyhow::Result;
 use iota::{
     bundle::{Address, Tag, TransactionField},
     client::Transfer,
-    crypto::Kerl,
-    signing::{IotaSeed, Seed},
-    ternary::{T1B1Buf, TryteBuf},
+    ternary::TryteBuf,
 };
 use iota_conversion::Trinary;
 
@@ -55,24 +53,14 @@ async fn main() -> Result<()> {
     // Call send_transfers api
     // Below is just a dummy seed which just serves as an example.
     // If you want to replace your own. It probably should be a seed with balance on comnet/devnet.
-    let res = iota::Client::send_transfers(
-        &IotaSeed::<Kerl>::from_buf(
-            TryteBuf::try_from_str(
-                "RVORZ9SIIP9RCYMREUIXXVPQIPHVCNPQ9HZWYKFWYWZRE9JQKG9REPKIASHUUECPSQO9JT9XNMVKWYGVA",
-            )
-            .unwrap()
-            .as_trits()
-            .encode::<T1B1Buf>(),
-        )
-        .unwrap(),
-    )
-    // Input the transfers
-    .transfers(transfers)
-    // We are sending to comnet, so mwm should be 10. It's 14 by default if you don't call this.
-    .min_weight_magnitude(10)
-    // Sending to the node and receive the response
-    .send()
-    .await?;
+    let res = iota::Client::send_transfers(None)
+        // Input the transfers
+        .transfers(transfers)
+        // We are sending to comnet, so mwm should be 10. It's 14 by default if you don't call this.
+        .min_weight_magnitude(10)
+        // Sending to the node and receive the response
+        .send()
+        .await?;
 
     // The response of send_transfers is vector of Transaction type. We choose the first one and see what is its bundle hash
     println!("{:?}", res[0].bundle().to_inner().as_i8_slice().trytes());

--- a/examples/send_transfers.rs
+++ b/examples/send_transfers.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
     // Call send_transfers api
     // Below is just a dummy seed which just serves as an example.
     // If you want to replace your own. It probably should be a seed with balance on comnet/devnet.
-    let res = iota::Client::send_transfers(
+    let res = iota::Client::send_transfers(Some(
         &IotaSeed::<Kerl>::from_buf(
             TryteBuf::try_from_str(
                 "RVORZ9SIIP9RCYMREUIXXVPQIPHVCNPQ9HZWYKFWYWZRE9JQKG9REPKIASHUUECPSQO9JT9XNMVKWYGVA",
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
             .encode::<T1B1Buf>(),
         )
         .unwrap(),
-    )
+    ))
     // Input the transfers
     .transfers(transfers)
     // We are sending to comnet, so mwm should be 10. It's 14 by default if you don't call this.

--- a/iota-client/client.rs
+++ b/iota-client/client.rs
@@ -468,7 +468,7 @@ impl Client {
     /// [`inputs`]: ../extended/struct.PrepareTransfersBuilder.html#method.inputs
     /// [`remainder`]: ../extended/struct.PrepareTransfersBuilder.html#method.remainder
     /// [`security`]: ../extended/struct.PrepareTransfersBuilder.html#method.security
-    pub fn prepare_transfers(seed: &IotaSeed<Kerl>) -> PrepareTransfersBuilder<'_> {
+    pub fn prepare_transfers(seed: Option<&IotaSeed<Kerl>>) -> PrepareTransfersBuilder<'_> {
         PrepareTransfersBuilder::new(seed)
     }
 
@@ -531,7 +531,7 @@ impl Client {
     /// [`depth`]: ../extended/struct.SendTransfersBuilder.html#method.depth
     /// [`min_weight_magnitude`]: ../extended/struct.SendTransfersBuilder.html#method.min_weight_magnitude
     /// [`reference`]: ../extended/struct.SendTransfersBuilder.html#method.reference
-    pub fn send_transfers(seed: &IotaSeed<Kerl>) -> SendTransfersBuilder<'_> {
+    pub fn send_transfers(seed: Option<&IotaSeed<Kerl>>) -> SendTransfersBuilder<'_> {
         SendTransfersBuilder::new(seed)
     }
 

--- a/iota-client/extended/send_transfers.rs
+++ b/iota-client/extended/send_transfers.rs
@@ -9,7 +9,7 @@ use crate::Client;
 /// Builder to construct SendTransfers API
 //#[derive(Debug)]
 pub struct SendTransfersBuilder<'a> {
-    seed: &'a IotaSeed<Kerl>,
+    seed: Option<&'a IotaSeed<Kerl>>,
     transfers: Vec<Transfer>,
     security: u8,
     inputs: Option<Vec<Input>>,
@@ -20,9 +20,9 @@ pub struct SendTransfersBuilder<'a> {
 }
 
 impl<'a> SendTransfersBuilder<'a> {
-    pub(crate) fn new(seed: &'a IotaSeed<Kerl>) -> Self {
+    pub(crate) fn new(seed: Option<&'a IotaSeed<Kerl>>) -> Self {
         Self {
-            seed: seed,
+            seed,
             transfers: Default::default(),
             security: 2,
             inputs: None,

--- a/iota-client/tests/apis.rs
+++ b/iota-client/tests/apis.rs
@@ -362,7 +362,7 @@ async fn test_prepare_transfers_no_value() {
     }
 
     client_init();
-    let _ = Client::prepare_transfers(
+    let _ = Client::prepare_transfers(Some(
         &IotaSeed::<Kerl>::from_buf(
             TryteBuf::try_from_str(TEST_BUNDLE_TX_0)
                 .unwrap()
@@ -370,7 +370,7 @@ async fn test_prepare_transfers_no_value() {
                 .encode::<T1B1Buf>(),
         )
         .unwrap(),
-    )
+    ))
     .transfers(transfers)
     .build()
     .await
@@ -425,7 +425,7 @@ async fn test_send_transfers_no_value() {
     }
 
     client_init();
-    let _ = Client::send_transfers(
+    let _ = Client::send_transfers(Some(
         &IotaSeed::<Kerl>::from_buf(
             TryteBuf::try_from_str(TEST_BUNDLE_TX_0)
                 .unwrap()
@@ -433,7 +433,7 @@ async fn test_send_transfers_no_value() {
                 .encode::<T1B1Buf>(),
         )
         .unwrap(),
-    )
+    ))
     .transfers(transfers)
     .min_weight_magnitude(10)
     .send()


### PR DESCRIPTION
When transfer value is zero, there's no need to pass the seed. So this
PR makes seed argument in prepare transfer & send transfers Option.

fix #52 