### PR TITLE
feat(quorum): add quorum feature flag and update with better node sync schedule

### DIFF
--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 iota-core = { version = "0.2.0-alpha.1", path = "../../iota-core" }
-smol = {version = "=0.1.7", features = ["tokio02"] }
+smol = {version = "0.1.18", features = ["tokio02"] }
 anyhow = "1.0.31"
 
 #tmp

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 anyhow = "1.0.28"
 iota-core = { path = "../iota-core" }
 iota-conversion = { version = "0.5.0", path = "../iota-conversion" }
-smol = {version = "=0.1.7", features = ["tokio02"] }
+smol = {version = "0.1.18", features = ["tokio02"] }
 smol-potat = "0.3.1"
 
 [[example]]

--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -25,11 +25,14 @@ iota-signing-preview = "0.1"
 iota-crypto-preview = "0.1"
 iota-conversion = { version = "0.5.1", path = "../iota-conversion" }
 once_cell = "1.4.0"
-slab = "0.4.2"
+smol = {version = "0.1.18", features = ["tokio02"] }
+#futures = "0.3.5"
+
 
 [dev-dependencies]
 smol = {version = "0.1.18", features = ["tokio02"] }
 smol-potat = "0.2.1"
 
 [features]
+quorum = []
 wasm = ["chrono/wasmbind"]

--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -28,7 +28,7 @@ once_cell = "1.4.0"
 slab = "0.4.2"
 
 [dev-dependencies]
-smol = {version = "=0.1.7", features = ["tokio02"] }
+smol = {version = "0.1.18", features = ["tokio02"] }
 smol-potat = "0.2.1"
 
 [features]

--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -25,14 +25,16 @@ iota-signing-preview = "0.1"
 iota-crypto-preview = "0.1"
 iota-conversion = { version = "0.5.1", path = "../iota-conversion" }
 once_cell = "1.4.0"
-smol = {version = "0.1.18", features = ["tokio02"] }
-#futures = "0.3.5"
-
+smol = {version = "0.1.18", features = ["tokio02"], optional = true }
 
 [dev-dependencies]
 smol = {version = "0.1.18", features = ["tokio02"] }
 smol-potat = "0.2.1"
 
 [features]
-quorum = []
+quorum = ["smol"]
 wasm = ["chrono/wasmbind"]
+
+[[test]]
+name = "quorum"
+required-features = ["quorum"]

--- a/iota-client/lib.rs
+++ b/iota-client/lib.rs
@@ -19,6 +19,7 @@ extern crate serde_json;
 pub mod client;
 pub mod core;
 pub mod extended;
+//#[cfg(feature = "quorum")]
 pub mod quorum;
 pub mod response;
 mod util;

--- a/iota-client/lib.rs
+++ b/iota-client/lib.rs
@@ -19,7 +19,7 @@ extern crate serde_json;
 pub mod client;
 pub mod core;
 pub mod extended;
-//#[cfg(feature = "quorum")]
+#[cfg(feature = "quorum")]
 pub mod quorum;
 pub mod response;
 mod util;

--- a/iota-client/quorum.rs
+++ b/iota-client/quorum.rs
@@ -11,6 +11,7 @@ use iota_ternary_preview::TryteBuf;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use once_cell::sync::Lazy;
@@ -19,7 +20,9 @@ use reqwest::Url;
 macro_rules! get_synced_nodes {
     () => {{
         // TODO smarter sync
-        refresh_synced_nodes().await?;
+        if Quorum::get().time.elapsed() >= Duration::from_secs(300) {
+            refresh_synced_nodes().await?;
+        }
         Quorum::get()
             .pool
             .clone()
@@ -37,6 +40,8 @@ pub struct Quorum {
     pub(crate) threshold: AtomicU8,
     /// Minimum nodes quired to satisfy quorum threshold
     pub(crate) min: AtomicUsize,
+    /// Timestamp of last syncing process
+    pub(crate) time: Instant,
 }
 
 impl Quorum {
@@ -46,6 +51,7 @@ impl Quorum {
             pool: Arc::new(RwLock::new(HashSet::new())),
             threshold: AtomicU8::new(66),
             min: AtomicUsize::new(0),
+            time: Instant::now(),
         });
 
         &QUORUM
@@ -54,12 +60,12 @@ impl Quorum {
 
 /// Refresh synced nodes in quorum. This will replace whole set in the quorum pool.
 pub async fn refresh_synced_nodes() -> Result<()> {
+    let quorum = Quorum::get();
     let body = json!( {
         "command": "getNodeInfo",
     });
-
     let mut result = HashMap::new();
-    let quorum = Quorum::get();
+
     for ref_node in Client::get()
         .pool
         .clone()
@@ -76,6 +82,7 @@ pub async fn refresh_synced_nodes() -> Result<()> {
                 .as_trits()
                 .encode(),
         );
+        // TODO Better scope
         let set = result.entry(hash).or_insert(HashSet::new());
         set.insert(ref_node.clone());
     }

--- a/iota-client/tests/quorum.rs
+++ b/iota-client/tests/quorum.rs
@@ -5,8 +5,9 @@ use iota_client::quorum;
 use iota_ternary_preview::*;
 
 #[smol_potat::test]
-async fn test_get_balances() {
+async fn quorum_get_balances() {
     client_init();
+    quorum::refresh_synced_nodes().await.unwrap();
     let _ = quorum::get_balances()
         .addresses(&[Address::from_inner_unchecked(
             TryteBuf::try_from_str(TEST_ADDRESS_0)
@@ -20,8 +21,9 @@ async fn test_get_balances() {
 }
 
 #[smol_potat::test]
-async fn test_get_inclusion_states() {
+async fn quorum_get_inclusion_states() {
     client_init();
+    quorum::refresh_synced_nodes().await.unwrap();
     let res = quorum::get_inclusion_states()
         .transactions(&[
             Hash::from_inner_unchecked(
@@ -45,8 +47,9 @@ async fn test_get_inclusion_states() {
 }
 
 #[smol_potat::test]
-async fn test_get_latest_inclusion() {
+async fn quorum_get_latest_inclusion() {
     client_init();
+    quorum::refresh_synced_nodes().await.unwrap();
     let _ = quorum::get_latest_inclusion(&[
         Hash::from_inner_unchecked(
             TryteBuf::try_from_str(TEST_BUNDLE_TX_0)
@@ -64,8 +67,9 @@ async fn test_get_latest_inclusion() {
     .await;
 }
 #[smol_potat::test]
-async fn test_were_addresses_spent_from() {
+async fn quorum_were_addresses_spent_from() {
     client_init();
+    quorum::refresh_synced_nodes().await.unwrap();
     let res = quorum::were_addresses_spent_from(&[Address::from_inner_unchecked(
         TryteBuf::try_from_str(TEST_ADDRESS_0)
             .unwrap()

--- a/iota-conversion/trytes_converter.rs
+++ b/iota-conversion/trytes_converter.rs
@@ -1,7 +1,7 @@
 use std::convert::TryInto;
-use std::str;
 use std::error;
 use std::fmt;
+use std::str;
 
 use iota_constants;
 
@@ -20,8 +20,8 @@ pub fn bytes_to_trytes(input: &[u8]) -> String {
 
 #[derive(Debug)]
 /// Dummy error for the string to trytes conversion
-pub struct ToTrytesError{}
-impl error::Error for ToTrytesError { }
+pub struct ToTrytesError {}
+impl error::Error for ToTrytesError {}
 impl fmt::Display for ToTrytesError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Trytes could not be converted to string")
@@ -39,37 +39,55 @@ pub enum TrytesToBytesError {
     /// Since two trytes can encode up to 27*27 values, not everey pair of trytes is valid for conversion
     InvalidTrytePair,
     /// A character was not a valid tryte
-    StringNotTrytes(char)
+    StringNotTrytes(char),
 }
-impl std::error::Error for TrytesToBytesError { }
+impl std::error::Error for TrytesToBytesError {}
 impl std::fmt::Display for TrytesToBytesError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use TrytesToBytesError::*;
         match self {
             InvalidTrytePair => write!(f, "Got an invalid tryte pair with value > 255"),
-            StringNotTrytes(c) => write!(f, "The input string did not consist of trytes (Invalid char: {})", c),
+            StringNotTrytes(c) => write!(
+                f,
+                "The input string did not consist of trytes (Invalid char: {})",
+                c
+            ),
         }
     }
 }
 
 /// Convert a single character tryte to its numerical equivalent
 fn tryte_to_val(tryte: char) -> std::result::Result<usize, TrytesToBytesError> {
-        iota_constants::TRYTE_ALPHABET.iter()
-            .position(|&x| x == tryte)
-            .map(|x| x as usize)
-            .ok_or_else(|| TrytesToBytesError::StringNotTrytes(tryte))
+    iota_constants::TRYTE_ALPHABET
+        .iter()
+        .position(|&x| x == tryte)
+        .map(|x| x as usize)
+        .ok_or_else(|| TrytesToBytesError::StringNotTrytes(tryte))
 }
 
 /// Converts a sequence of trytes into bytes
-pub fn trytes_to_bytes(input: &str, buf: &mut[u8]) -> std::result::Result<(), TrytesToBytesError> {
+pub fn trytes_to_bytes(input: &str, buf: &mut [u8]) -> std::result::Result<(), TrytesToBytesError> {
     // We have to add one here because the input may contain an uneven amount of trytes
-    assert!(buf.len() * 2 + 1>= input.len(), "Buffer to short (buffer length: {}, number of trytes: {})", buf.len(), input.len());
-    for (idx, pair) in input.chars().collect::<Vec<char>>().chunks(2).filter(|pair| pair.len() == 2).enumerate() {
+    assert!(
+        buf.len() * 2 + 1 >= input.len(),
+        "Buffer to short (buffer length: {}, number of trytes: {})",
+        buf.len(),
+        input.len()
+    );
+    for (idx, pair) in input
+        .chars()
+        .collect::<Vec<char>>()
+        .chunks(2)
+        .filter(|pair| pair.len() == 2)
+        .enumerate()
+    {
         let first = tryte_to_val(pair[0])?;
         let second = tryte_to_val(pair[1])?;
 
         let decimal = first + second * 27;
-        buf[idx] = decimal.try_into().map_err(|_| TrytesToBytesError::InvalidTrytePair)?;
+        buf[idx] = decimal
+            .try_into()
+            .map_err(|_| TrytesToBytesError::InvalidTrytePair)?;
     }
     Ok(())
 }
@@ -82,12 +100,14 @@ pub enum TrytesToStringError {
     /// The encoded bytes are not valid utf-8
     Utf8Error(str::Utf8Error),
 }
-impl error::Error for TrytesToStringError { }
+impl error::Error for TrytesToStringError {}
 impl fmt::Display for TrytesToStringError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use TrytesToStringError::*;
         match self {
-            TryteFormatError(e) => write!(f, "Trytes could not be converted to bytes. Cause:\n{}", e),
+            TryteFormatError(e) => {
+                write!(f, "Trytes could not be converted to bytes. Cause:\n{}", e)
+            }
             Utf8Error(e) => write!(f, "Bytes contained invalid UTF-8 data:\n{}", e),
         }
     }

--- a/iota-core/Cargo.toml
+++ b/iota-core/Cargo.toml
@@ -18,4 +18,5 @@ iota-client = { version = "0.5.0-alpha", path = "../iota-client" }
 iota-conversion = { version = "0.5.1", path = "../iota-conversion" }
 
 [features]
+quorum = ["iota-client/quorum"]
 wasm = ["iota-client/wasm"]


### PR DESCRIPTION
This PR add a feature flag to separate quorum module. Users are required to specify the flag to use it.
Furthermore, the node sync process is no longer called per API. It is now called only when it elapses more than five minutes from last syncing. 