### PR TITLE
fix(crate) compilation for android targets

### DIFF
--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -17,7 +17,7 @@ bee-transaction = { git = "https://github.com/Alex6323/bee-p.git" }
 bee-ternary = { version = "0.3.1-alpha", git = "https://github.com/iotaledger/bee.git", features = ["serde1"] }
 bee-signing = { git = "https://github.com/iotaledger/bee.git" }
 bee-crypto = { git = "https://github.com/iotaledger/bee.git" }
-reqwest = { version = "0.10.6", features = ["json"] }
+reqwest = { version = "0.10.6", features = ["json"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4.12"

--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -17,7 +17,7 @@ bee-transaction = { git = "https://github.com/Alex6323/bee-p.git" }
 bee-ternary = { version = "0.3.1-alpha", git = "https://github.com/iotaledger/bee.git", features = ["serde1"] }
 bee-signing = { git = "https://github.com/iotaledger/bee.git" }
 bee-crypto = { git = "https://github.com/iotaledger/bee.git" }
-reqwest = { version = "0.10.6", features = ["json"], default-features = false }
+reqwest = { version = "0.10.6", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4.12"


### PR DESCRIPTION
The `openssl` crate (a dependency of reqwest) doesn't cross-compile well, so this PR disables it. @wusyong is this ok to do? maybe we should pick another TLS solution from reqwest? https://github.com/seanmonstar/reqwest/blob/83fa93ccafe1ec5044f2edd118006edf4faa28b2/Cargo.toml#L25

Also tried to disable it only when compiling to Android (using the `[target.cfg().dependencies]` option) but somehow it didn't work.