### PR TITLE
feat(client): add fields in get_node_info response (#126)

### DIFF
--- a/iota-client/src/response.rs
+++ b/iota-client/src/response.rs
@@ -370,6 +370,17 @@ pub struct GetNodeInfoResponse {
     /// IRI version
     #[serde(rename = "appVersion")]
     pub app_version: String,
+    /// Address of coordinator
+    #[serde(rename = "coordinatorAddress")]
+    pub coordinator_address: String,
+    /// Features owned by node
+    pub features: Vec<String>,
+    /// Node Synchronization with network
+    #[serde(rename = "isSynced")]
+    pub is_sync: bool,
+    /// Is Node synced, has active neighbors and fresh latest milestone
+    #[serde(rename = "isHealthy")]
+    pub is_healthy: bool,
     /// Number of threads IRI is using
     #[serde(rename = "jreAvailableProcessors")]
     pub jre_available_processors: Option<u16>,
@@ -391,6 +402,9 @@ pub struct GetNodeInfoResponse {
     /// Latest milestone index on IRI node
     #[serde(rename = "latestMilestoneIndex")]
     pub latest_milestone_index: u32,
+    /// Latest solid subtangle milestone index on IRI node
+    #[serde(rename = "lastSnapshottedMilestoneIndex")]
+    pub last_snapshotted_milestone_index: u32,
     /// Latest solid subtangle milestone on IRI node
     #[serde(rename = "latestSolidSubtangleMilestone")]
     pub latest_solid_subtangle_milestone: String,


### PR DESCRIPTION
Now :
```
$ cargo run --example get_node_info
GetNodeInfoResponse {
    app_name: "HORNET Comnet",
    app_version: "0.5.3",
    coordinator_address: "UOMFQOULWQLXQQHFMFRQQTRDKDHVMRFFEGZ9LDU9TFZZ9CHDLZSIAHA9MXNSLYOERCHDUVDFEEZAEOBEW",
    features: [
        "LoadBalancer",
        "RemotePOW",
        "WereAddressesSpentFrom",
        "testnet",
    ],
    is_sync: true,
    is_healthy: true,
    jre_available_processors: None,
    jre_free_memory: None,
    jre_max_memory: None,
    jre_total_memory: None,
    jre_version: None,
    latest_milestone: "DZHPBFZVUMJRPTIZJQVLWCDAZLLHLIMALBJTCOMAWUWGGHUIIKF9VYKEGAAWERRBVFMBHYQTWGNZTA999",
    latest_milestone_index: 1150887,
    last_snapshotted_milestone_index: 1148721,
    latest_solid_subtangle_milestone: "DZHPBFZVUMJRPTIZJQVLWCDAZLLHLIMALBJTCOMAWUWGGHUIIKF9VYKEGAAWERRBVFMBHYQTWGNZTA999",
    latest_solid_subtangle_milestone_index: 1150887,
    milestone_start_index: 1148721,
    neighbors: 8,
    packets_queue_size: None,
    time: 1601625141463,
    tips: 3,
    transactions_to_request: 0,
}
```

Edit : I recreated a PR with a signed commit