### PR TITLE
fix(ci): Use env files for setting env vars

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,7 +26,7 @@ jobs:
         override: true
 
     - name: Get current date
-      run: echo "::set-env name=CURRENT_DATE::$(date +'%Y-%m-%d')"
+      run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
     - name: Cache cargo registry
       uses: actions/cache@v2


### PR DESCRIPTION
The `set-env` command is now deprecated (see [GitHub blog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/))﻿