### PR TITLE
rm iota-conversion from Cargo.toml

### DIFF
--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -14,6 +14,3 @@ crate-type = ["cdylib"]
 iota-core = { version = "0.2.0-alpha.1", path = "../../iota-core" }
 smol = {version = "0.1.18", features = ["tokio02"] }
 anyhow = "1.0.31"
-
-#tmp
-iota-conversion = "0.5.0"

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -16,7 +16,6 @@ crate-type = ["cdylib"]
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4"
 iota-core = { path = "../../iota-core", features = ["wasm"] }
-iota-conversion = { version = "0.5.0", path = "../../iota-conversion" }
 iota-bundle-preview = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 console_error_panic_hook = "0.1.6"


### PR DESCRIPTION
https://github.com/iotaledger/iota.rs/commit/ea50d361a60f435845bf66a57c0f152c88b6081c removes `iota-conversion` crate.

keeping it listed on `Cargo.toml` breaks integration.