### PR TITLE
feat(client) add MQTT subscribe/unsubscribe APIs

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,3 +24,7 @@ path = "indexation.rs"
 [[example]]
 name = "transaction"
 path = "transaction.rs"
+
+[[example]]
+name = "mqtt"
+path = "mqtt.rs"

--- a/examples/mqtt.rs
+++ b/examples/mqtt.rs
@@ -1,0 +1,27 @@
+use iota::{Client, Topic};
+use std::sync::{mpsc::channel, Arc, Mutex};
+
+fn main() {
+  let mut iota = Client::new() // Crate a client instance builder
+    .node("http://0.0.0.0:14265") // Insert the node here
+    .unwrap()
+    .build()
+    .unwrap();
+
+  let (tx, rx) = channel();
+  let tx = Arc::new(Mutex::new(tx));
+
+  iota
+    .subscriber()
+    .topic(Topic::new("milestones/latest").unwrap())
+    .subscribe(move |event| {
+      println!("{:?}", event);
+      tx.lock().unwrap().send(()).unwrap();
+    })
+    .unwrap();
+
+  rx.recv().unwrap();
+  iota.subscriber().disconnect().unwrap();
+  // alternatively
+  // iota.subscriber().unsubscribe().unwrap();
+}

--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0.58"
 chrono = "0.4.12"
 hex = "0.4.2"
 blake2 = "0.9"
-rumqttc = "0.2"
+paho-mqtt = "0.7"
 regex = "1.4"
 
 [dev-dependencies]

--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0.58"
 chrono = "0.4.12"
 hex = "0.4.2"
 blake2 = "0.9"
-paho-mqtt = "0.7"
+paho-mqtt = "0.8"
 regex = "1.4"
 
 [dev-dependencies]

--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -24,6 +24,8 @@ serde_json = "1.0.58"
 chrono = "0.4.12"
 hex = "0.4.2"
 blake2 = "0.9"
+rumqttc = "0.2"
+regex = "1.4"
 
 [dev-dependencies]
 tokio = { version = "0.2.22", features = ["macros"] }

--- a/iota-client/src/builder.rs
+++ b/iota-client/src/builder.rs
@@ -106,6 +106,8 @@ impl ClientBuilder {
             mwm,
             quorum_size,
             quorum_threshold,
+            mqtt_client: None,
+            mqtt_topic_handlers: Default::default(),
         };
 
         // let mut sync = client.clone();

--- a/iota-client/src/builder.rs
+++ b/iota-client/src/builder.rs
@@ -1,6 +1,6 @@
 //! Builder of the Clinet Instnace
 
-use crate::client::Client;
+use crate::client::{BrokerOptions, Client};
 use crate::error::*;
 
 use std::collections::HashSet;
@@ -26,6 +26,7 @@ pub struct ClientBuilder {
     network: Network,
     quorum_size: u8,
     quorum_threshold: u8,
+    broker_options: BrokerOptions,
 }
 
 impl ClientBuilder {
@@ -36,6 +37,7 @@ impl ClientBuilder {
             network: Network::Mainnet,
             quorum_size: 3,
             quorum_threshold: 50,
+            broker_options: Default::default(),
         }
     }
 
@@ -77,6 +79,12 @@ impl ClientBuilder {
         self
     }
 
+    /// Sets the MQTT broker options.
+    pub fn broker_options(mut self, options: BrokerOptions) -> Self {
+        self.broker_options = options;
+        self
+    }
+
     /// Build the Client instance.
     pub fn build(self) -> Result<Client> {
         if self.nodes.is_empty() {
@@ -108,6 +116,7 @@ impl ClientBuilder {
             quorum_threshold,
             mqtt_client: None,
             mqtt_topic_handlers: Default::default(),
+            broker_options: self.broker_options,
         };
 
         // let mut sync = client.clone();

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -29,6 +29,32 @@ pub struct TopicEvent {
     pub payload: String,
 }
 
+/// The MQTT broker options.
+pub struct BrokerOptions {
+    pub(crate) automatic_disconnect: bool,
+}
+
+impl Default for BrokerOptions {
+    fn default() -> Self {
+        Self {
+            automatic_disconnect: true,
+        }
+    }
+}
+
+impl BrokerOptions {
+    /// Creates the default broker options.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Whether the MQTT broker should be automatically disconnected when all topics are unsubscribed or not.
+    pub fn automatic_disconnect(mut self, automatic_disconnect: bool) -> Self {
+        self.automatic_disconnect = automatic_disconnect;
+        self
+    }
+}
+
 /// An instance of the client using IRI URI
 pub struct Client {
     /// Node pool of IOTA nodes
@@ -42,6 +68,7 @@ pub struct Client {
     /// A MQTT client to subscribe/unsubscribe to topics.
     pub(crate) mqtt_client: Option<MqttClient>,
     pub(crate) mqtt_topic_handlers: Arc<Mutex<TopicHandlerMap>>,
+    pub(crate) broker_options: BrokerOptions,
 }
 
 impl std::fmt::Debug for Client {

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -11,7 +11,7 @@ use bee_signing_ext::Seed;
 
 use reqwest::{IntoUrl, Url};
 
-use rumqttc::Client as MqttClient;
+use paho_mqtt::Client as MqttClient;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -30,7 +30,6 @@ pub struct TopicEvent {
 }
 
 /// An instance of the client using IRI URI
-#[derive(Clone)]
 pub struct Client {
     /// Node pool of IOTA nodes
     pub(crate) pool: Arc<RwLock<HashSet<Url>>>,
@@ -391,9 +390,9 @@ impl Client {
     pub async fn retry(&self, message_id: &MessageId) -> Result<(MessageId, Message)> {
         // Get the metadata to check if it needs to promote or reattach
         let message_metadata = self.get_message().metadata(message_id).await?;
-        if message_metadata.should_promote {
+        if message_metadata.should_promote.unwrap_or(false) {
             return self.promote(message_id).await;
-        } else if message_metadata.should_reattach {
+        } else if message_metadata.should_reattach.unwrap_or(false) {
             return self.reattach(message_id).await;
         } else {
             return Err(Error::NoNeedPromoteOrReattach(message_id.to_string()));

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -9,11 +9,12 @@ use crate::types::*;
 use bee_message::prelude::{Address, Ed25519Address, Message, MessageId, UTXOInput};
 use bee_signing_ext::Seed;
 
+use paho_mqtt::Client as MqttClient;
 use reqwest::{IntoUrl, Url};
 
-use paho_mqtt::Client as MqttClient;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::Duration;
 
 const ADDRESS_LENGTH: usize = 32;
 
@@ -32,12 +33,14 @@ pub struct TopicEvent {
 /// The MQTT broker options.
 pub struct BrokerOptions {
     pub(crate) automatic_disconnect: bool,
+    pub(crate) timeout: Duration,
 }
 
 impl Default for BrokerOptions {
     fn default() -> Self {
         Self {
             automatic_disconnect: true,
+            timeout: Duration::from_secs(30),
         }
     }
 }
@@ -51,6 +54,12 @@ impl BrokerOptions {
     /// Whether the MQTT broker should be automatically disconnected when all topics are unsubscribed or not.
     pub fn automatic_disconnect(mut self, automatic_disconnect: bool) -> Self {
         self.automatic_disconnect = automatic_disconnect;
+        self
+    }
+
+    /// Sets the timeout used for the MQTT operations.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
         self
     }
 }

--- a/iota-client/src/error.rs
+++ b/iota-client/src/error.rs
@@ -30,6 +30,10 @@ pub enum Error {
     FromHexError(hex::FromHexError),
     /// Message types error
     MessageError(bee_message::Error),
+    /// Mqtt client error
+    MqttClientError(rumqttc::ClientError),
+    /// Invalid MQTT topic.
+    InvalidMqttTopic(String),
 }
 
 impl fmt::Display for Error {
@@ -50,6 +54,8 @@ impl fmt::Display for Error {
             Error::FromHexError(e) => e.fmt(f),
             Error::ResponseError(s) => write!(f, "Response error with status code {}", s),
             Error::MessageError(e) => e.fmt(f),
+            Error::MqttClientError(e) => e.fmt(f),
+            Error::InvalidMqttTopic(topic) => write!(f, "The topic {} is invalid", topic),
         }
     }
 }
@@ -71,5 +77,11 @@ impl From<hex::FromHexError> for Error {
 impl From<bee_message::Error> for Error {
     fn from(error: bee_message::Error) -> Self {
         Error::MessageError(error)
+    }
+}
+
+impl From<rumqttc::ClientError> for Error {
+    fn from(error: rumqttc::ClientError) -> Self {
+        Error::MqttClientError(error)
     }
 }

--- a/iota-client/src/error.rs
+++ b/iota-client/src/error.rs
@@ -33,7 +33,7 @@ pub enum Error {
     /// The message cannot be promoted or reattached
     NoNeedPromoteOrReattach(String),
     /// Mqtt client error
-    MqttClientError(paho_mqtt::MqttError),
+    MqttClientError(paho_mqtt::errors::Error),
     /// Invalid MQTT topic.
     InvalidMqttTopic(String),
     /// MQTT connection not found (all nodes MQTT's are disabled)
@@ -91,8 +91,8 @@ impl From<bee_message::Error> for Error {
     }
 }
 
-impl From<paho_mqtt::MqttError> for Error {
-    fn from(error: paho_mqtt::MqttError) -> Self {
+impl From<paho_mqtt::errors::Error> for Error {
+    fn from(error: paho_mqtt::errors::Error) -> Self {
         Error::MqttClientError(error)
     }
 }

--- a/iota-client/src/error.rs
+++ b/iota-client/src/error.rs
@@ -33,9 +33,11 @@ pub enum Error {
     /// The message cannot be promoted or reattached
     NoNeedPromoteOrReattach(String),
     /// Mqtt client error
-    MqttClientError(rumqttc::ClientError),
+    MqttClientError(paho_mqtt::MqttError),
     /// Invalid MQTT topic.
     InvalidMqttTopic(String),
+    /// MQTT connection not found (all nodes MQTT's are disabled)
+    MqttConnectionNotFound,
 }
 
 impl fmt::Display for Error {
@@ -61,6 +63,10 @@ impl fmt::Display for Error {
             }
             Error::MqttClientError(e) => e.fmt(f),
             Error::InvalidMqttTopic(topic) => write!(f, "The topic {} is invalid", topic),
+            Error::MqttConnectionNotFound => write!(
+                f,
+                "MQTT connection not found (all nodes have the MQTT plugin disabled)"
+            ),
         }
     }
 }
@@ -85,8 +91,8 @@ impl From<bee_message::Error> for Error {
     }
 }
 
-impl From<rumqttc::ClientError> for Error {
-    fn from(error: rumqttc::ClientError) -> Self {
+impl From<paho_mqtt::MqttError> for Error {
+    fn from(error: paho_mqtt::MqttError) -> Self {
         Error::MqttClientError(error)
     }
 }

--- a/iota-client/src/lib.rs
+++ b/iota-client/src/lib.rs
@@ -14,7 +14,7 @@ pub mod node;
 pub mod types;
 
 pub use builder::ClientBuilder;
-pub use client::{Client, Topic, TopicEvent};
+pub use client::{BrokerOptions, Client, Topic, TopicEvent};
 pub use error::*;
 pub use reqwest::Url;
 pub use types::*;

--- a/iota-client/src/lib.rs
+++ b/iota-client/src/lib.rs
@@ -14,7 +14,7 @@ pub mod node;
 pub mod types;
 
 pub use builder::ClientBuilder;
-pub use client::{Client, Topic};
+pub use client::{Client, Topic, TopicEvent};
 pub use error::*;
 pub use reqwest::Url;
 pub use types::*;

--- a/iota-client/src/lib.rs
+++ b/iota-client/src/lib.rs
@@ -14,7 +14,7 @@ pub mod node;
 pub mod types;
 
 pub use builder::ClientBuilder;
-pub use client::Client;
+pub use client::{Client, Topic};
 pub use error::*;
 pub use reqwest::Url;
 pub use types::*;

--- a/iota-client/src/node/message.rs
+++ b/iota-client/src/node/message.rs
@@ -1,4 +1,6 @@
-use crate::{ChildrenMessageIds, Client, Error, MessageIds, MessageJson, Response, Result};
+use crate::{
+    ChildrenMessageIds, Client, Error, MessageIds, MessageJson, MessageMetadata, Response, Result,
+};
 
 use bee_message::{Message, MessageId};
 
@@ -58,14 +60,14 @@ impl<'a> GetMessageBuilder<'a> {
 
     /// GET /api/v1/messages/{messageID}/metadata endpoint
     /// Consume the builder and find a message by its identifer. This method returns the given message metadata.
-    pub async fn metadata(self, message_id: &MessageId) -> Result<serde_json::Value> {
+    pub async fn metadata(self, message_id: &MessageId) -> Result<MessageMetadata> {
         let mut url = self.client.get_node()?;
         url.set_path(&format!("api/v1/messages/{}/metadata", message_id));
         let resp = reqwest::get(url).await?;
 
         match resp.status().as_u16() {
             200 => {
-                let meta = resp.json::<serde_json::Value>().await?;
+                let meta = resp.json::<MessageMetadata>().await?;
                 Ok(meta)
             }
             status => Err(Error::ResponseError(status)),

--- a/iota-client/src/node/mod.rs
+++ b/iota-client/src/node/mod.rs
@@ -2,6 +2,8 @@
 
 mod address;
 mod message;
+mod mqtt;
 
 pub use address::*;
 pub use message::*;
+pub use mqtt::*;

--- a/iota-client/src/node/mqtt.rs
+++ b/iota-client/src/node/mqtt.rs
@@ -71,7 +71,7 @@ pub(crate) fn get_mqtt_client(client: &mut Client) -> Result<&MqttClient> {
             "ws"
           },
           node.host_str().unwrap(),
-          node.port().unwrap_or(14265)
+          node.port_or_known_default().unwrap()
         );
         let mqtt_options = CreateOptionsBuilder::new()
           .server_uri(uri)

--- a/iota-client/src/node/mqtt.rs
+++ b/iota-client/src/node/mqtt.rs
@@ -151,7 +151,7 @@ impl<'a> MqttManager<'a> {
   /// Disconnects the broker.
   /// This will clear the stored topic handlers and close the MQTT connection.
   pub fn disconnect(mut self) -> Result<()> {
-    let timeout = { self.client.broker_options.timeout };
+    let timeout = self.client.broker_options.timeout;
     let client = get_mqtt_client(&mut self.client)?;
 
     let disconnect_options = DisconnectOptionsBuilder::new().timeout(timeout).finalize();

--- a/iota-client/src/node/mqtt.rs
+++ b/iota-client/src/node/mqtt.rs
@@ -151,11 +151,10 @@ impl<'a> MqttManager<'a> {
   /// Disconnects the broker.
   /// This will clear the stored topic handlers and close the MQTT connection.
   pub fn disconnect(mut self) -> Result<()> {
+    let timeout = { self.client.broker_options.timeout };
     let client = get_mqtt_client(&mut self.client)?;
 
-    let disconnect_options = DisconnectOptionsBuilder::new()
-      .timeout(self.client.broker_options.timeout)
-      .finalize();
+    let disconnect_options = DisconnectOptionsBuilder::new().timeout(timeout).finalize();
     client.disconnect(disconnect_options)?;
     self.client.mqtt_client = None;
 

--- a/iota-client/src/node/mqtt.rs
+++ b/iota-client/src/node/mqtt.rs
@@ -84,6 +84,7 @@ pub(crate) fn get_mqtt_client(client: &mut Client) -> Result<&MqttClient> {
           .keep_alive_interval(Duration::from_secs(20))
           .mqtt_version(MQTT_VERSION_3_1_1)
           .clean_session(true)
+          .connect_timeout(client.broker_options.timeout)
           .finalize();
 
         if let Ok(_) = mqtt_client.connect(conn_opts) {
@@ -152,7 +153,9 @@ impl<'a> MqttManager<'a> {
   pub fn disconnect(mut self) -> Result<()> {
     let client = get_mqtt_client(&mut self.client)?;
 
-    let disconnect_options = DisconnectOptionsBuilder::new().finalize();
+    let disconnect_options = DisconnectOptionsBuilder::new()
+      .timeout(self.client.broker_options.timeout)
+      .finalize();
     client.disconnect(disconnect_options)?;
     self.client.mqtt_client = None;
 

--- a/iota-client/src/node/mqtt.rs
+++ b/iota-client/src/node/mqtt.rs
@@ -1,0 +1,187 @@
+use crate::client::{Client, TopicEvent, TopicHandlerMap};
+use crate::Result;
+use regex::Regex;
+use rumqttc::{
+  Client as MqttClient, Connection as MqttConnection, Event, Incoming, MqttOptions, QoS,
+};
+
+use std::convert::TryFrom;
+use std::sync::{Arc, Mutex};
+
+macro_rules! lazy_static {
+  ($init:expr => $type:ty) => {{
+    static mut VALUE: Option<$type> = None;
+    static INIT: std::sync::Once = std::sync::Once::new();
+
+    INIT.call_once(|| unsafe { VALUE = Some($init) });
+    unsafe { VALUE.as_ref() }.expect("failed to get lazy static value")
+  }};
+}
+
+/// A topic.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct Topic(String);
+
+impl TryFrom<&str> for Topic {
+  type Error = crate::Error;
+
+  fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
+    Self::new(value)
+  }
+}
+
+impl Topic {
+  /// Creates a new topic and checks if it's valid.
+  pub fn new<S: Into<String>>(name: S) -> Result<Self> {
+    let valid_topics = lazy_static!(
+      ["milestones/latest", "milestones/solid", "messages", "messages/referenced"].to_vec() => Vec<&str>
+    );
+    let regexes = lazy_static!(
+      [
+        Regex::new(r"messages/([A-Fa-f0-9]{64})/metadata").unwrap(),
+        Regex::new(r"outputs/([A-Fa-f0-9]{64})(\d{4})").unwrap(),
+        Regex::new("addresses/([A-Fa-f0-9]{64})/outputs").unwrap(),
+        Regex::new(r"messages/indexation/(\.)").unwrap()
+      ].to_vec() => Vec<Regex>
+    );
+    let name = name.into();
+    if valid_topics.iter().any(|valid| valid == &name)
+      || regexes.iter().any(|re| re.is_match(&name))
+    {
+      let topic = Self(name);
+      Ok(topic)
+    } else {
+      Err(crate::Error::InvalidMqttTopic(name))
+    }
+  }
+}
+
+pub(crate) fn get_mqtt_client(client: &mut Client) -> Result<MqttClient> {
+  match client.mqtt_client.clone() {
+    Some(c) => Ok(c),
+    None => {
+      for node in client.pool.read().unwrap().iter() {
+        let host = node.host_str().unwrap();
+        let mqttoptions = MqttOptions::new(host, host, 1883);
+        let (mqtt_client, mut connection) = MqttClient::new(mqttoptions, 10);
+        // poll the event loop until we find a ConnAck event,
+        // which means that the mqtt client is ready to be used on this host
+        // if the event loop returns an error, we check the next node
+        for event in connection.iter() {
+          match event {
+            Ok(event) => {
+              if let Event::Incoming(incoming) = event {
+                if let Incoming::ConnAck(_) = incoming {
+                  client.mqtt_client = Some(mqtt_client);
+                  break;
+                }
+              }
+            }
+            Err(_) => break,
+          }
+        }
+
+        // if we found a valid mqtt connection, loop it on a separate thread
+        if client.mqtt_client.is_some() {
+          poll_mqtt(client.mqtt_topic_handlers.clone(), connection);
+        }
+      }
+      client
+        .mqtt_client
+        .clone()
+        .ok_or_else(|| crate::Error::NodePoolEmpty)
+    }
+  }
+}
+
+fn poll_mqtt(mqtt_topic_handlers: Arc<Mutex<TopicHandlerMap>>, connection: MqttConnection) {
+  let mut connection = connection;
+  std::thread::spawn(move || {
+    for event in connection.iter() {
+      if let Ok(Event::Incoming(Incoming::Publish(p))) = event {
+        let event_topic = p.topic;
+        let mqtt_topic_handlers_guard = mqtt_topic_handlers.lock().unwrap();
+        if let Some(handlers) = mqtt_topic_handlers_guard.get(&Topic(event_topic.clone())) {
+          let event_payload = String::from_utf8_lossy(&*p.payload).to_string();
+          let event = TopicEvent {
+            topic: event_topic,
+            payload: event_payload,
+          };
+          for handler in handlers {
+            handler(&event)
+          }
+        }
+      }
+    }
+  });
+}
+
+/// MQTT subscriber.
+pub struct MqttManager<'a> {
+  client: &'a mut Client,
+  topics: Vec<Topic>,
+}
+
+impl<'a> MqttManager<'a> {
+  /// Initializes a new instance of the mqtt subscriber.
+  pub fn new(client: &'a mut Client) -> Self {
+    Self {
+      client,
+      topics: vec![],
+    }
+  }
+
+  /// Add a new topic to the list.
+  pub fn topic(mut self, topic: Topic) -> Self {
+    self.topics.push(topic.into());
+    self
+  }
+
+  /// Add a collection of topics to the list.
+  pub fn topics(mut self, topics: Vec<Topic>) -> Self {
+    self.topics.extend(topics.into_iter());
+    self
+  }
+
+  /// Subscribe to the given topics with the callback.
+  pub fn subscribe<C: Fn(&crate::client::TopicEvent) + Send + Sync + 'static>(
+    mut self,
+    callback: C,
+  ) -> Result<()> {
+    let mut client = get_mqtt_client(&mut self.client)?;
+    let cb = Arc::new(
+      Box::new(callback) as Box<dyn Fn(&crate::client::TopicEvent) + Send + Sync + 'static>
+    );
+    let mqtt_topic_handlers = &self.client.mqtt_topic_handlers;
+    let mut mqtt_topic_handlers = mqtt_topic_handlers.lock().unwrap();
+    for topic in self.topics {
+      client.subscribe(&topic.0, QoS::AtLeastOnce)?;
+      match mqtt_topic_handlers.get_mut(&topic) {
+        Some(handlers) => handlers.push(cb.clone()),
+        None => {
+          mqtt_topic_handlers.insert(topic, vec![cb.clone()]);
+        }
+      }
+    }
+    Ok(())
+  }
+
+  /// Unsubscribe from the given topics.
+  /// If no topics were provided, the function will unsubscribe from every subscribed topic.
+  pub fn unsubscribe(mut self) -> Result<()> {
+    let mut client = get_mqtt_client(&mut self.client)?;
+    let mqtt_topic_handlers = &self.client.mqtt_topic_handlers;
+    let mut mqtt_topic_handlers = mqtt_topic_handlers.lock().unwrap();
+
+    let topics = if self.topics.is_empty() {
+      mqtt_topic_handlers.keys().cloned().collect()
+    } else {
+      self.topics
+    };
+    for topic in topics {
+      client.unsubscribe(&topic.0)?;
+      mqtt_topic_handlers.remove(&topic);
+    }
+    Ok(())
+  }
+}

--- a/iota-client/src/types.rs
+++ b/iota-client/src/types.rs
@@ -141,6 +141,18 @@ pub struct MessageMetadata {
     /// Solid status
     #[serde(rename = "isSolid")]
     pub is_solid: bool,
+    /// Is the message referenced by a milestone.
+    #[serde(rename = "referencedByMilestoneIndex")]
+    pub referenced_by_milestone_index: Option<u64>,
+    /// The ledger inclusion state.
+    #[serde(rename = "ledgerInclusionState")]
+    pub ledger_inclusion_state: Option<String>,
+    /// Should the message be promoted. Filled only when the message is solid.
+    #[serde(rename = "shouldPromote")]
+    pub should_promote: Option<bool>,
+    /// Should the message be reattached. Filled only when the message is solid.
+    #[serde(rename = "shouldReattach")]
+    pub should_reattach: Option<bool>,
 }
 
 impl ResponseType for MessageMetadata {}


### PR DESCRIPTION
This PR introduces the integration with Hornet's MQTT interface. Here's an example of the usage:

```rust
use iota::{Client, Topic};

fn main() {
    let mut iota = Client::new() // Crate a client instance builder
        .node("http://0.0.0.0:14265") // Insert the node here
        .unwrap()
        .build()
        .unwrap();
    iota.subscriber()
        .topic(Topic::new("milestones/latest").unwrap())
        .topic(Topic::new("addresses/5d2684dfdbd52a2241e135c15f9c5ede2bca5599f810ddbc14c75948540345bf/outputs").unwrap())
        .subscribe(|event| println!("{:?}", event))
        .unwrap();
    loop {}
}

```