### PR TITLE
fix(client) `nonce` response type as String instead of u64

### DIFF
--- a/examples/indexation.rs
+++ b/examples/indexation.rs
@@ -4,11 +4,7 @@ use iota::{hex_to_message_id, Client, Message, Payload};
 
 #[tokio::main]
 async fn main() {
-    let index = Indexation::new(
-        String::from("Hello"),
-        String::from("Tangle")
-            .as_bytes(),
-    ).unwrap();
+    let index = Indexation::new(String::from("Hello"), String::from("Tangle").as_bytes()).unwrap();
 
     let client = Client::new()
         .nodes(&vec!["http://localhost:14265"])
@@ -19,7 +15,7 @@ async fn main() {
     let tips = client.get_tips().await.unwrap();
 
     let message = Message::builder()
-        .with_network_id(0)
+        // TODO temporarily removed .with_network_id(0)
         .with_parent1(tips.0)
         .with_parent2(tips.1)
         .with_payload(Payload::Indexation(Box::new(index)))

--- a/iota-client/src/api/send.rs
+++ b/iota-client/src/api/send.rs
@@ -208,7 +208,7 @@ impl<'a> SendBuilder<'a> {
         let payload = Payload::Transaction(Box::new(payload));
         let message = Message::builder()
             // TODO: make the newtwork id configurable
-            .with_network_id(0)
+            // TODO temporarily removed .with_network_id(0)
             .with_parent1(tips.0)
             .with_parent2(tips.1)
             .with_payload(payload)

--- a/iota-client/tests/node_api.rs
+++ b/iota-client/tests/node_api.rs
@@ -56,7 +56,7 @@ async fn test_post_message_with_indexation() {
     let tips = client.get_tips().await.unwrap();
 
     let message = Message::builder()
-        .with_network_id(0)
+        // TODO temporarily removed .with_network_id(0)
         .with_parent1(tips.0)
         .with_parent2(tips.1)
         .with_payload(Payload::Indexation(Box::new(index)))
@@ -136,7 +136,7 @@ async fn test_post_message_with_transaction() {
     //println!("{:#?}", transaction);
     let tips = client.get_tips().await.unwrap();
     let message = Message::builder()
-        .with_network_id(0)
+        // TODO temporarily removed .with_network_id(0)
         .with_parent1(tips.0)
         .with_parent2(tips.1)
         .with_payload(Payload::Transaction(Box::new(transaction)))


### PR DESCRIPTION
The Hornet API changed the `nonce` type to String because JSON doesn't support uint64.