### PR TITLE
Add back the network_id to prevent message build error

### DIFF
--- a/examples/indexation.rs
+++ b/examples/indexation.rs
@@ -15,7 +15,7 @@ async fn main() {
     let tips = client.get_tips().await.unwrap();
 
     let message = Message::builder()
-        // TODO temporarily removed .with_network_id(0)
+        .with_network_id(0)
         .with_parent1(tips.0)
         .with_parent2(tips.1)
         .with_payload(Payload::Indexation(Box::new(index)))

--- a/iota-client/src/api/send.rs
+++ b/iota-client/src/api/send.rs
@@ -208,7 +208,7 @@ impl<'a> SendBuilder<'a> {
         let payload = Payload::Transaction(Box::new(payload));
         let message = Message::builder()
             // TODO: make the newtwork id configurable
-            // TODO temporarily removed .with_network_id(0)
+            .with_network_id(0)
             .with_parent1(tips.0)
             .with_parent2(tips.1)
             .with_payload(payload)

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -239,7 +239,7 @@ impl Client {
         let tips = self.get_tips().await?;
         let reattach_message = Message::builder()
             // TODO: make the newtwork id configurable
-            // TODO: temporarily remove .with_network_id(0)
+            .with_network_id(0)
             .with_parent1(tips.0)
             .with_parent2(tips.1)
             .with_payload(message.payload().to_owned().unwrap())
@@ -258,7 +258,7 @@ impl Client {
         let tips = self.get_tips().await?;
         let promote_message = Message::builder()
             // TODO: make the newtwork id configurable
-            // TODO: temporarily remove .with_network_id(0)
+            .with_network_id(0)
             .with_parent1(tips.0)
             .with_parent2(*message_id)
             .finish()

--- a/iota-client/src/types.rs
+++ b/iota-client/src/types.rs
@@ -300,7 +300,7 @@ impl TryFrom<MessageJson> for Message {
         let nonce = value.nonce;
         Ok(Message::builder()
             // TODO: make the newtwork id configurable
-            // TODO temporarily removed .with_network_id(0)
+            .with_network_id(0)
             .with_parent1(MessageId::new(parent1))
             .with_parent2(MessageId::new(parent2))
             .with_payload(value.payload.try_into()?)

--- a/iota-client/tests/node_api.rs
+++ b/iota-client/tests/node_api.rs
@@ -56,7 +56,7 @@ async fn test_post_message_with_indexation() {
     let tips = client.get_tips().await.unwrap();
 
     let message = Message::builder()
-        // TODO temporarily removed .with_network_id(0)
+        .with_network_id(0)
         .with_parent1(tips.0)
         .with_parent2(tips.1)
         .with_payload(Payload::Indexation(Box::new(index)))
@@ -136,7 +136,7 @@ async fn test_post_message_with_transaction() {
     //println!("{:#?}", transaction);
     let tips = client.get_tips().await.unwrap();
     let message = Message::builder()
-        // TODO temporarily removed .with_network_id(0)
+        .with_network_id(0)
         .with_parent1(tips.0)
         .with_parent2(tips.1)
         .with_payload(Payload::Transaction(Box::new(transaction)))


### PR DESCRIPTION
Fix the message build error in the latest bee crate.