### PR TITLE
Enhance test cases, examples, and align metadata type with current hornet node

### DIFF
--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -151,7 +151,7 @@ async fn main() {
     delay_for(Duration::from_millis(15000)).await;
     let message_metadata = iota.get_message().metadata(&message_id.unwrap()).await;
     println!(
-        "The ledgerInclusionState: {}",
+        "The ledgerInclusionState: {:?}",
         message_metadata.unwrap().ledger_inclusion_state
     );
 }

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -1,6 +1,25 @@
 use iota::{hex_to_address, BIP32Path, Client, Seed};
-
 use std::num::NonZeroU64;
+use std::time::Duration;
+use tokio::time::delay_for;
+
+/// In this example, we send 600 tokens to the following 6 locations, respectively
+///
+/// Address m/0 (5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8)
+///   output 0: 100 tokens
+///   output 1: 100 tokens
+///   output 2: 100 tokens
+///
+/// Address m/1 (bcbe5e2ccd4ce942407a0fd8ccad1df33c68c9cb1078c043e95e486d8c6e0230)
+///   output 0: 100 tokens
+///   output 1: 100 tokens
+///   output 2: 100 tokens
+///
+///
+/// These two addresses belong to seed "256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b1"
+/// Then we send 550 tokens from seed "256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b1"
+/// to address "6920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1fff", and check the ledger
+/// inclusion state, which should be "included".
 
 #[tokio::main]
 async fn main() {
@@ -9,23 +28,130 @@ async fn main() {
         .unwrap()
         .build()
         .unwrap();
+
+    // Insert your seed. Since the output amount cannot be zero. The seed must contain non-zero balance.
     let seed = Seed::from_ed25519_bytes(
         &hex::decode("256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b2").unwrap(),
     )
-    .unwrap(); // Insert your seed. Since the output amount cannot be zero. The seed must contain non-zero balance.
+    .unwrap();
 
-    let path = BIP32Path::from_str("m/").unwrap(); // Insert your account path. Note that index must be hardened(like 0', 123').
-    let balance = iota
+    // Insert your account path. Note that index must be hardened(like 0', 123').
+    let path = BIP32Path::from_str("m/").unwrap();
+    let message_id = iota
         .send(&seed)
         .path(&path)
         // Insert the output address and ampunt to spent. The amount cannot be zero.
         .output(
-            hex_to_address("6920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1f92")
+            hex_to_address("5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8")
                 .unwrap(),
             NonZeroU64::new(100).unwrap(),
         )
         .post()
         .await;
 
-    println!("{:#?}", balance);
+    println!("{:#?}", message_id);
+    delay_for(Duration::from_millis(15000)).await;
+    let message_id = iota
+        .send(&seed)
+        .path(&path)
+        // Insert the output address and ampunt to spent. The amount cannot be zero.
+        .output(
+            hex_to_address("bcbe5e2ccd4ce942407a0fd8ccad1df33c68c9cb1078c043e95e486d8c6e0230")
+                .unwrap(),
+            NonZeroU64::new(100).unwrap(),
+        )
+        .post()
+        .await;
+
+    println!("{:#?}", message_id);
+
+    delay_for(Duration::from_millis(15000)).await;
+    // Insert your account path. Note that index must be hardened(like 0', 123').
+    let path = BIP32Path::from_str("m/").unwrap();
+    let message_id = iota
+        .send(&seed)
+        .path(&path)
+        // Insert the output address and ampunt to spent. The amount cannot be zero.
+        .output(
+            hex_to_address("5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8")
+                .unwrap(),
+            NonZeroU64::new(100).unwrap(),
+        )
+        .post()
+        .await;
+
+    println!("{:#?}", message_id);
+    delay_for(Duration::from_millis(15000)).await;
+    let message_id = iota
+        .send(&seed)
+        .path(&path)
+        // Insert the output address and ampunt to spent. The amount cannot be zero.
+        .output(
+            hex_to_address("bcbe5e2ccd4ce942407a0fd8ccad1df33c68c9cb1078c043e95e486d8c6e0230")
+                .unwrap(),
+            NonZeroU64::new(100).unwrap(),
+        )
+        .post()
+        .await;
+
+    println!("{:#?}", message_id);
+
+    delay_for(Duration::from_millis(15000)).await;
+    // Insert your account path. Note that index must be hardened(like 0', 123').
+    let path = BIP32Path::from_str("m/").unwrap();
+    let message_id = iota
+        .send(&seed)
+        .path(&path)
+        // Insert the output address and ampunt to spent. The amount cannot be zero.
+        .output(
+            hex_to_address("5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8")
+                .unwrap(),
+            NonZeroU64::new(100).unwrap(),
+        )
+        .post()
+        .await;
+
+    println!("{:#?}", message_id);
+    delay_for(Duration::from_millis(15000)).await;
+    let message_id = iota
+        .send(&seed)
+        .path(&path)
+        // Insert the output address and ampunt to spent. The amount cannot be zero.
+        .output(
+            hex_to_address("bcbe5e2ccd4ce942407a0fd8ccad1df33c68c9cb1078c043e95e486d8c6e0230")
+                .unwrap(),
+            NonZeroU64::new(100).unwrap(),
+        )
+        .post()
+        .await;
+
+    println!("{:#?}", message_id);
+
+    let seed = Seed::from_ed25519_bytes(
+        &hex::decode("256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b1").unwrap(),
+    )
+    .unwrap(); // Insert your seed. Since the output amount cannot be zero. The seed must contain non-zero balance.
+
+    delay_for(Duration::from_millis(15000)).await;
+    // Insert your account path. Note that index must be hardened(like 0', 123').
+    let path = BIP32Path::from_str("m/").unwrap();
+    let message_id = iota
+        .send(&seed)
+        .path(&path)
+        // Insert the output address and ampunt to spent. The amount cannot be zero.
+        .output(
+            hex_to_address("6920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1fff")
+                .unwrap(),
+            NonZeroU64::new(550).unwrap(),
+        )
+        .post()
+        .await;
+
+    println!("{:#?}", message_id);
+    delay_for(Duration::from_millis(15000)).await;
+    let message_metadata = iota.get_message().metadata(&message_id.unwrap()).await;
+    println!(
+        "The ledgerInclusionState: {}",
+        message_metadata.unwrap().ledger_inclusion_state
+    );
 }

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -426,9 +426,9 @@ impl Client {
     pub async fn retry(&self, message_id: &MessageId) -> Result<(MessageId, Message)> {
         // Get the metadata to check if it needs to promote or reattach
         let message_metadata = self.get_message().metadata(message_id).await?;
-        if message_metadata.should_promote.unwrap_or(false) {
+        if message_metadata.should_promote {
             return self.promote(message_id).await;
-        } else if message_metadata.should_reattach.unwrap_or(false) {
+        } else if message_metadata.should_reattach {
             return self.reattach(message_id).await;
         } else {
             return Err(Error::NoNeedPromoteOrReattach(message_id.to_string()));

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -426,9 +426,9 @@ impl Client {
     pub async fn retry(&self, message_id: &MessageId) -> Result<(MessageId, Message)> {
         // Get the metadata to check if it needs to promote or reattach
         let message_metadata = self.get_message().metadata(message_id).await?;
-        if message_metadata.should_promote {
+        if message_metadata.should_promote.unwrap_or(false) {
             return self.promote(message_id).await;
-        } else if message_metadata.should_reattach {
+        } else if message_metadata.should_reattach.unwrap_or(false) {
             return self.reattach(message_id).await;
         } else {
             return Err(Error::NoNeedPromoteOrReattach(message_id.to_string()));

--- a/iota-client/src/node/message.rs
+++ b/iota-client/src/node/message.rs
@@ -64,11 +64,10 @@ impl<'a> GetMessageBuilder<'a> {
         let mut url = self.client.get_node()?;
         url.set_path(&format!("api/v1/messages/{}/metadata", message_id));
         let resp = reqwest::get(url).await?;
-
         match resp.status().as_u16() {
             200 => {
-                let meta = resp.json::<MessageMetadata>().await?;
-                Ok(meta)
+                let meta = resp.json::<Response<MessageMetadata>>().await?;
+                Ok(meta.data)
             }
             status => Err(Error::ResponseError(status)),
         }

--- a/iota-client/src/types.rs
+++ b/iota-client/src/types.rs
@@ -142,21 +142,17 @@ pub struct MessageMetadata {
     #[serde(rename = "isSolid")]
     pub is_solid: bool,
     /// Should promote
-    #[serde(default)]
     #[serde(rename = "shouldPromote")]
-    pub should_promote: bool,
+    pub should_promote: Option<bool>,
     /// Should reattach
-    #[serde(default)]
     #[serde(rename = "shouldReattach")]
-    pub should_reattach: bool,
+    pub should_reattach: Option<bool>,
     /// Referenced by milestone index
-    #[serde(default)]
     #[serde(rename = "referencedByMilestoneIndex")]
-    pub referenced_by_milestone_index: u64,
+    pub referenced_by_milestone_index: Option<u64>,
     /// Ledger inclusion state
-    #[serde(default)]
     #[serde(rename = "ledgerInclusionState")]
-    pub ledger_inclusion_state: String,
+    pub ledger_inclusion_state: Option<String>,
 }
 
 impl ResponseType for MessageMetadata {}

--- a/iota-client/src/types.rs
+++ b/iota-client/src/types.rs
@@ -141,18 +141,22 @@ pub struct MessageMetadata {
     /// Solid status
     #[serde(rename = "isSolid")]
     pub is_solid: bool,
-    /// Is the message referenced by a milestone.
-    #[serde(rename = "referencedByMilestoneIndex")]
-    pub referenced_by_milestone_index: Option<u64>,
-    /// The ledger inclusion state.
-    #[serde(rename = "ledgerInclusionState")]
-    pub ledger_inclusion_state: Option<String>,
-    /// Should the message be promoted. Filled only when the message is solid.
+    /// Should promote
+    #[serde(default)]
     #[serde(rename = "shouldPromote")]
-    pub should_promote: Option<bool>,
-    /// Should the message be reattached. Filled only when the message is solid.
+    pub should_promote: bool,
+    /// Should reattach
+    #[serde(default)]
     #[serde(rename = "shouldReattach")]
-    pub should_reattach: Option<bool>,
+    pub should_reattach: bool,
+    /// Referenced by milestone index
+    #[serde(default)]
+    #[serde(rename = "referencedByMilestoneIndex")]
+    pub referenced_by_milestone_index: u64,
+    /// Ledger inclusion state
+    #[serde(default)]
+    #[serde(rename = "ledgerInclusionState")]
+    pub ledger_inclusion_state: String,
 }
 
 impl ResponseType for MessageMetadata {}


### PR DESCRIPTION
# Description of change

- Enhanced the test_post_message_with_transaction testing, to test the token sending from genesis
- Modified the `get_message().metadata` API, because now the returned JSON has a higher level hierarchy with a key (`data`).
- Enhanced the `transaction` example, where we first send 100 tokens to 6 different output addresses, respectively, where the first three addresses belong to path `m/0'`, and the remaining three addresses belong to path `m/1`. Then, we send tokens to another address which belongs to another user, and check if the message is `included` in the node.

## Links to any relevant issues

N/A

## Type of change

Enhancement (a non-breaking change which adds functionality).

## How the change has been tested

- Tested w/ `cargo test -- --include-ignored -Z unstable-options` with a local hornet.
- Tested the examples with a local hornet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x]  have checked that new and existing unit tests pass locally with my changes
