### PR TITLE
Fix macOS OpenSSL instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ $ set OPENSSL_ROOT_DIR="C:\Program Files\OpenSSL-Win64"
 
 ```
 $ brew install cmake
-$ brew install openssl
+$ brew install openssl@1.1
 # you may want to add this to your .zshrc or .bashrc since you'll need it to compile the crate
-$ OPENSSL_ROOT_DIR=$(brew --prefix openssl)
+$ OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
 ```
 
 ### Linux


### PR DESCRIPTION
Fixes command which specifies the version of OpenSSL to install. Depending on a user's environment, `brew --prefix openssl` may point to the wrong version of OpenSSL:

![image](https://user-images.githubusercontent.com/19519564/100706623-554a7580-3377-11eb-8842-3c383d25f519.png)

(it seems there is more than one version of OpenSSL installed on GitHub Actions macOS runners)