### PR TITLE
chore: add requirements to neon binding readme

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -2,6 +2,10 @@
 
 Node.js binding to the IOTA client library.
 
+## Requirements
+
+`Rust` and `Cargo` are required. Install them [here](https://doc.rust-lang.org/cargo/getting-started/installation.html).
+
 ## Installation
 
 Currently the package isn't published so you'd need to link it to your project using `npm` or `yarn`.

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -6,6 +6,8 @@ Node.js binding to the IOTA client library.
 
 `Rust` and `Cargo` are required. Install them [here](https://doc.rust-lang.org/cargo/getting-started/installation.html).
 
+Ensure you have installed the required dependencies for the library [here](https://github.com/iotaledger/iota.rs/blob/dev/README.md).
+
 ## Installation
 
 Currently the package isn't published so you'd need to link it to your project using `npm` or `yarn`.


### PR DESCRIPTION
# Description of change

Adds Rust and Cargo requirements to Neon binding readme.

## Type of change

- Documentation Fix