### PR TITLE
refactor(client): remove BIP32Path argument on high APIs, use indexes

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -99,6 +99,16 @@ Sets the node syncing interval.
 
 **Returns** the client builder instance for chained calls.
 
+#### localPow(local): ClientBuilder
+
+Sets the PoW type.
+
+| Param | Type                 | Description                                                |
+| ----- | -------------------- | ---------------------------------------------------------- |
+| local | <code>boolean</code> | Flag determining if PoW should be done locally or remotely |
+
+**Returns** the client builder instance for chained calls.
+
 #### build(): Client
 
 Builds the client instance.
@@ -156,7 +166,7 @@ Finds all messages associated with the given indexation keys and message ids.
 
 #### getBalance(seed: string): BalanceGetter
 
-Get balance on a given seed and its wallet chain BIP32 path.
+Get balance on a given seed and its wallet account index.
 
 | Param | Type                | Description                    |
 | ----- | ------------------- | ------------------------------ |
@@ -327,13 +337,13 @@ Unsubscribes from the provided topics.
 
 Submits a value transaction message.
 
-#### path(path): ValueTransactionSender
+#### accountIndex(index): ValueTransactionSender
 
-Sets the account BIP32 path. This field is required.
+Sets the account index. This field is required.
 
-| Param | Type                | Description            |
-| ----- | ------------------- | ---------------------- |
-| path  | <code>string</code> | The account BIP32 path |
+| Param | Type                | Description       |
+| ----- | ------------------- | ----------------- |
+| index | <code>number</code> | The account index |
 
 **Returns** the message submit instance for chained calls.
 
@@ -348,7 +358,7 @@ Adds an output to the transaction.
 
 **Returns** the message submit instance for chained calls.
 
-#### index(index): ValueTransactionSender
+#### initialAddressIndex(index): ValueTransactionSender
 
 Sets the initial address index to search for balance. Defaults to 0 if the function isn't called.
 
@@ -368,17 +378,17 @@ Submits the message.
 
 Gets a valid unspent address associated with the seed.
 
-#### path(path): UnspentAddressGetter
+#### accountIndex(index): UnspentAddressGetter
 
-Sets the account BIP32 path. This field is required.
+Sets the account index. This field is required.
 
-| Param | Type                | Description            |
-| ----- | ------------------- | ---------------------- |
-| path  | <code>string</code> | The account BIP32 path |
+| Param | Type                | Description       |
+| ----- | ------------------- | ----------------- |
+| index | <code>number</code> | The account index |
 
 **Returns** the address getter instance for chained calls.
 
-#### index(index): UnspentAddressGetter
+#### initialAddressIndex(index): UnspentAddressGetter
 
 Sets the initial address index. Defaults to 0 if the function isn't called.
 
@@ -398,13 +408,13 @@ Performs the operation.
 
 Finds addresses on a given seed.
 
-#### path(path): AddressFinder
+#### accountIndex(index): AddressFinder
 
-Sets the account BIP32 path. This field is required.
+Sets the account index. This field is required.
 
-| Param | Type                | Description            |
-| ----- | ------------------- | ---------------------- |
-| path  | <code>string</code> | The account BIP32 path |
+| Param | Type                | Description       |
+| ----- | ------------------- | ----------------- |
+| index | <code>number</code> | The account index |
 
 **Returns** the address finder instance for chained calls.
 
@@ -429,17 +439,17 @@ Performs the operation.
 
 Gets balance on a given seed.
 
-#### path(path): BalanceGetter
+#### accountIndex(index): BalanceGetter
 
-Sets the account BIP32 path. This field is required.
+Sets the account index. This field is required.
 
-| Param | Type                | Description            |
-| ----- | ------------------- | ---------------------- |
-| path  | <code>string</code> | The account BIP32 path |
+| Param | Type                | Description       |
+| ----- | ------------------- | ----------------- |
+| index | <code>number</code> | The account index |
 
 **Returns** the balance getter instance for chained calls.
 
-#### index(index): BalanceGetter
+#### initialAddressIndex(index): BalanceGetter
 
 Sets the initial address index. Defaults to 0 if the function isn't called.
 
@@ -459,7 +469,7 @@ Performs the operation.
 
 Gets a message by indexation key or identifier.
 
-#### index(index): Promise<string[]>
+#### initialAddressIndex(index): Promise<string[]>
 
 | Param | Type                | Description        |
 | ----- | ------------------- | ------------------ |
@@ -535,9 +545,9 @@ Gets the metadata of the given message.
 
 #### Payload
 
-| Field | Type                                                                                                                    | Description  |
-| ----- | ----------------------------------------------------------------------------------------------------------------------- | ------------ |
-| data  | <code>{ Transaction: TransactionPayload } \| { Indexation: IndexationPayload } \| { Milestone: MilestonePayload}</code> | Payload data |
+| Field | Type                                                                                                                                                              | Description  |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| data  | <code>{ type: 'Transaction', data: TransactionPayload } \| { type: 'Indexation', data: IndexationPayload } \| { type: 'Milestone', data: MilestonePayload}</code> | Payload data |
 
 ##### TransactionPayload
 

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -17,31 +17,32 @@ export declare class ClientBuilder {
   quorumThreshold(threshold: number): ClientBuilder
   brokerOptions(options: BrokerOptions): ClientBuilder
   nodeSyncInterval(interval: number): ClientBuilder
+  localPow(local: bool): ClientBuilder
   build(): Client
 }
 
 export declare class ValueTransactionSender {
-  path(bip32path: string): ValueTransactionSender
-  index(index: number): ValueTransactionSender
+  accountIndex(index: number): ValueTransactionSender
+  initialAddressIndex(index: number): ValueTransactionSender
   output(address: string, value: number): ValueTransactionSender
   submit(): Promise<string>
 }
 
 export declare class UnspentAddressGetter {
-  path(bip32path: string): UnspentAddressGetter
-  index(index: number): UnspentAddressGetter
+  accountIndex(index: number): UnspentAddressGetter
+  initialAddressIndex(index: number): UnspentAddressGetter
   get(): Promise<[Address, number]>
 }
 
 export declare class AddressFinder {
-  path(bip32path: string): AddressFinder
+  accountIndex(index: number): AddressFinder
   range(start: number, end: number): AddressFinder
-  get(): Address[]
+  get(): [Address, boolean][]
 }
 
 export declare class BalanceGetter {
-  path(bip32path: string): BalanceGetter
-  index(index: number): BalanceGetter
+  accountIndex(index: number): BalanceGetter
+  initialAddressIndex(index: number): BalanceGetter
   get(): Promise<number>
 }
 

--- a/bindings/node/lib/types/message.d.ts
+++ b/bindings/node/lib/types/message.d.ts
@@ -66,9 +66,9 @@ export declare interface MilestonePayload {
   signatures: number[][]
 }
 
-export declare type Payload = { Indexation: IndexationPayload } |
-{ Milestone: MilestonePayload } |
-{ Transaction: TransactionPayload }
+export declare type Payload = { type: 'Indexation', data: IndexationPayload } |
+{ type: 'Milestone', data: MilestonePayload } |
+{ type: 'Transaction', data: TransactionPayload }
 
 export declare interface Message {
   network_id: number

--- a/bindings/node/native/src/classes/client/balance_getter.rs
+++ b/bindings/node/native/src/classes/client/balance_getter.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota::{BIP32Path, Seed};
+use iota::Seed;
 use neon::prelude::*;
 
 use std::sync::{Arc, Mutex};
@@ -11,8 +11,8 @@ use super::{Api, ClientTask};
 pub struct BalanceGetter {
     client_id: String,
     seed: String,
-    path: Arc<Mutex<Option<BIP32Path>>>,
-    index: Arc<Mutex<Option<usize>>>,
+    account_index: Arc<Mutex<Option<usize>>>,
+    initial_address_index: Arc<Mutex<Option<usize>>>,
 }
 
 declare_types! {
@@ -23,33 +23,32 @@ declare_types! {
             Ok(BalanceGetter {
                 client_id,
                 seed,
-                path: Arc::new(Mutex::new(None)),
-                index: Arc::new(Mutex::new(None)),
+                account_index: Arc::new(Mutex::new(None)),
+                initial_address_index: Arc::new(Mutex::new(None)),
             })
         }
 
-        method path(mut cx) {
-            let path = cx.argument::<JsString>(0)?.value();
-            let path = BIP32Path::from_str(path.as_str()).expect("invalid bip32 path");
+        method accountIndex(mut cx) {
+            let account_index = cx.argument::<JsNumber>(0)?.value() as usize;
             {
                 let this = cx.this();
                 let guard = cx.lock();
-                let ref_ = &(*this.borrow(&guard)).path;
-                let mut get_path = ref_.lock().unwrap();
-                get_path.replace(path);
+                let ref_ = &(*this.borrow(&guard)).account_index;
+                let mut get_account_index = ref_.lock().unwrap();
+                get_account_index.replace(account_index);
             }
 
             Ok(cx.this().upcast())
         }
 
-        method index(mut cx) {
+        method initialAddressIndex(mut cx) {
             let index = cx.argument::<JsNumber>(0)?.value() as usize;
             {
                 let this = cx.this();
                 let guard = cx.lock();
-                let ref_ = &(*this.borrow(&guard)).index;
-                let mut get_index = ref_.lock().unwrap();
-                get_index.replace(index);
+                let ref_ = &(*this.borrow(&guard)).initial_address_index;
+                let mut get_address_index = ref_.lock().unwrap();
+                get_address_index.replace(index);
             }
 
             Ok(cx.this().upcast())
@@ -65,8 +64,8 @@ declare_types! {
                     client_id: ref_.client_id.clone(),
                     api: Api::GetBalance {
                         seed: Seed::from_ed25519_bytes(&hex::decode(&ref_.seed).expect("invalid seed hex")).expect("invalid seed"),
-                        path: (*ref_.path.lock().unwrap()).clone(),
-                        index: *ref_.index.lock().unwrap(),
+                        account_index: (*ref_.account_index.lock().unwrap()).clone(),
+                        initial_address_index: *ref_.initial_address_index.lock().unwrap(),
                     },
                 };
                 client_task.schedule(cb);

--- a/bindings/node/native/src/classes/client/balance_getter.rs
+++ b/bindings/node/native/src/classes/client/balance_getter.rs
@@ -64,7 +64,7 @@ declare_types! {
                     client_id: ref_.client_id.clone(),
                     api: Api::GetBalance {
                         seed: Seed::from_ed25519_bytes(&hex::decode(&ref_.seed).expect("invalid seed hex")).expect("invalid seed"),
-                        account_index: (*ref_.account_index.lock().unwrap()).clone(),
+                        account_index: *ref_.account_index.lock().unwrap(),
                         initial_address_index: *ref_.initial_address_index.lock().unwrap(),
                     },
                 };

--- a/bindings/node/native/src/classes/client/unspent_address_getter.rs
+++ b/bindings/node/native/src/classes/client/unspent_address_getter.rs
@@ -64,7 +64,7 @@ declare_types! {
                     client_id: ref_.client_id.clone(),
                     api: Api::GetUnspentAddress {
                         seed: Seed::from_ed25519_bytes(&hex::decode(&ref_.seed).expect("invalid seed hex")).expect("invalid seed"),
-                        account_index: (*ref_.account_index.lock().unwrap()).clone(),
+                        account_index: *ref_.account_index.lock().unwrap(),
                         initial_address_index: *ref_.initial_address_index.lock().unwrap(),
                     },
                 };

--- a/bindings/node/native/src/classes/client/value_transaction_sender.rs
+++ b/bindings/node/native/src/classes/client/value_transaction_sender.rs
@@ -84,7 +84,7 @@ declare_types! {
                     client_id: ref_.client_id.clone(),
                     api: Api::SendTransfer {
                         seed: Seed::from_ed25519_bytes(&hex::decode(&ref_.seed).expect("invalid seed hex")).expect("invalid seed"),
-                        account_index: (*ref_.account_index.lock().unwrap()).clone(),
+                        account_index: *ref_.account_index.lock().unwrap(),
                         initial_address_index: *ref_.initial_address_index.lock().unwrap(),
                         outputs: (*ref_.outputs.lock().unwrap()).clone(),
                     },

--- a/bindings/node/native/src/classes/client/value_transaction_sender.rs
+++ b/bindings/node/native/src/classes/client/value_transaction_sender.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota::{message::prelude::Address, BIP32Path, Seed};
+use iota::{message::prelude::Address, Seed};
 use neon::prelude::*;
 
 use std::{
@@ -14,8 +14,8 @@ use super::{parse_address, Api, ClientTask};
 pub struct ValueTransactionSender {
     client_id: String,
     seed: String,
-    path: Arc<Mutex<Option<BIP32Path>>>,
-    index: Arc<Mutex<Option<usize>>>,
+    account_index: Arc<Mutex<Option<usize>>>,
+    initial_address_index: Arc<Mutex<Option<usize>>>,
     outputs: Arc<Mutex<Vec<(Address, NonZeroU64)>>>,
 }
 
@@ -27,34 +27,33 @@ declare_types! {
             Ok(ValueTransactionSender {
                 client_id,
                 seed,
-                path: Arc::new(Mutex::new(None)),
-                index: Arc::new(Mutex::new(None)),
+                account_index: Arc::new(Mutex::new(None)),
+                initial_address_index: Arc::new(Mutex::new(None)),
                 outputs: Arc::new(Mutex::new(vec![]))
             })
         }
 
-        method path(mut cx) {
-            let path = cx.argument::<JsString>(0)?.value();
-            let path = BIP32Path::from_str(path.as_str()).expect("invalid bip32 path");
+        method accountIndex(mut cx) {
+            let account_index = cx.argument::<JsNumber>(0)?.value() as usize;
             {
                 let this = cx.this();
                 let guard = cx.lock();
-                let ref_ = &(*this.borrow(&guard)).path;
-                let mut send_path = ref_.lock().unwrap();
-                send_path.replace(path);
+                let ref_ = &(*this.borrow(&guard)).account_index;
+                let mut send_account_index = ref_.lock().unwrap();
+                send_account_index.replace(account_index);
             }
 
             Ok(cx.this().upcast())
         }
 
-        method index(mut cx) {
+        method initialAddressIndex(mut cx) {
             let index = cx.argument::<JsNumber>(0)?.value() as usize;
             {
                 let this = cx.this();
                 let guard = cx.lock();
-                let ref_ = &(*this.borrow(&guard)).index;
-                let mut send_index = ref_.lock().unwrap();
-                send_index.replace(index);
+                let ref_ = &(*this.borrow(&guard)).initial_address_index;
+                let mut send_address_index = ref_.lock().unwrap();
+                send_address_index.replace(index);
             }
 
             Ok(cx.this().upcast())
@@ -85,8 +84,8 @@ declare_types! {
                     client_id: ref_.client_id.clone(),
                     api: Api::SendTransfer {
                         seed: Seed::from_ed25519_bytes(&hex::decode(&ref_.seed).expect("invalid seed hex")).expect("invalid seed"),
-                        path: (*ref_.path.lock().unwrap()).clone(),
-                        index: *ref_.index.lock().unwrap(),
+                        account_index: (*ref_.account_index.lock().unwrap()).clone(),
+                        initial_address_index: *ref_.initial_address_index.lock().unwrap(),
                         outputs: (*ref_.outputs.lock().unwrap()).clone(),
                     },
                 };

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "install": "neon build",
-    "test": "mocha ./tests --exclude assertions.js"
+    "test": "mocha ./tests --exclude assertions.js --timeout 0"
   },
   "devDependencies": {
     "mocha": "^8.2.1"

--- a/bindings/node/tests/client.js
+++ b/bindings/node/tests/client.js
@@ -2,11 +2,12 @@ const { ClientBuilder } = require('../lib')
 const { assertAddress, assertMessageId, assertMessage } = require('./assertions')
 const assert = require('assert')
 
-const seed = '256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b2'
+const seed = 'b3a9bf35521157aa9c4508ab3a9266e210ae297ff5a4584234c4d9e7d01712e3'
 
 const client = new ClientBuilder()
   .node('http://localhost:14265')
   .brokerOptions({ timeout: 50 })
+  .localPow(false)
   .build()
 
 describe('Client', () => {
@@ -20,29 +21,39 @@ describe('Client', () => {
 
   it('finds addresses', () => {
     const addresses = client.findAddresses(seed)
-      .path("m/0'/0'")
+      .accountIndex(0)
       .range(0, 5)
       .get()
     assert.strictEqual(Array.isArray(addresses), true)
-    assert.strictEqual(addresses.length, 5)
-    addresses.forEach(assertAddress)
+    assert.strictEqual(addresses.length, 10)
+    addresses.forEach(([address, _internal]) => assertAddress(address))
   })
 
   it('sends a value transaction and checks output balance', async () => {
     const depositAddress = 'iot1q9jyad2efwyq7ldg9u6eqg5krxdqawgcdxvhjlmxrveylrt4fgaqj30s9qj'
     const messageId = await client
       .send(seed)
-      .path("m/0'/0'")
+      .accountIndex(0)
       .output(depositAddress, 2)
       .submit()
     assertMessageId(messageId)
+
+    while (true) {
+      const metadata = await client.getMessage().metadata(messageId)
+      if (metadata.ledgerInclusionState) {
+        assert.strictEqual(metadata.ledgerInclusionState, 'included')
+        break
+      } else {
+        await new Promise(resolve => setTimeout(resolve, 2000))
+      }
+    }
 
     const depositBalance = await client.getAddressBalance(depositAddress)
     assert.strictEqual(depositBalance >= 2, true)
   })
 
   it('gets an unspent address', async () => {
-    const res = await client.getUnspentAddress(seed).index(5).path("m/0'/0'").get()
+    const res = await client.getUnspentAddress(seed).initialAddressIndex(5).accountIndex(0).get()
     assert.strictEqual(Array.isArray(res), true)
     assert.strictEqual(res.length, 2)
     const [address, index] = res
@@ -51,7 +62,7 @@ describe('Client', () => {
   })
 
   it('gets seed balance', async () => {
-    const balance = await client.getBalance(seed).path("m/0'/0'").index(50000).get()
+    const balance = await client.getBalance(seed).accountIndex(0).initialAddressIndex(50000).get()
     assert.strictEqual(balance, 0)
   })
 
@@ -92,24 +103,21 @@ describe('Client', () => {
   })
 
   it('submits an indexation message and reads it', async () => {
-    const tips = await client.getTips()
     const indexation = {
       index: 'IOTA.RS BINDING - NODE.JS',
       data: 'INDEXATION DATA'
     }
     const messageId = await client.postMessage({
-      parent1: tips[0],
-      parent2: tips[1],
-      payload: indexation,
-      nonce: 0
+      payload: indexation
     })
     assertMessageId(messageId)
 
     const message = await client.getMessage().data(messageId)
     assertMessage(message)
-    assert.strictEqual(typeof message.payload.Indexation, 'object')
+    assert.strictEqual(message.payload.type, 'Indexation')
+    assert.strictEqual(typeof message.payload.data, 'object')
     const encoder = new TextEncoder()
-    assert.deepStrictEqual(message.payload.Indexation, {
+    assert.deepStrictEqual(message.payload.data, {
       index: indexation.index,
       data: Array.from(encoder.encode(indexation.data))
     })

--- a/examples/address.rs
+++ b/examples/address.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota::{BIP32Path, Client, Seed};
+use iota::{Client, Seed};
 
 #[tokio::main]
 async fn main() {
@@ -11,14 +11,15 @@ async fn main() {
         .build()
         .unwrap();
 
-    let seed = Seed::from_ed25519_bytes(&[0u8; 32]).unwrap(); // Insert your seed
-    let path = BIP32Path::from_str("m/0'/0'").unwrap(); // Insert your account path. Note that index must be hardened(like 0', 123').
+    let seed = Seed::from_ed25519_bytes(
+        &hex::decode("3ff69866a124d8cf168e5b928eb603bacc2d241f1a9d70af5c10f2dd34137896").unwrap(),
+    )
+    .unwrap(); // Insert your seed
 
-    let address = iota.get_unspent_address(&seed).path(&path).get().await.unwrap();
+    let addresses = iota.find_addresses(&seed).account_index(0).range(0..4).get().unwrap();
 
-    println!("Get an unspent address: {:#?}", address);
-
-    let addresses = iota.find_addresses(&seed).path(&path).range(0..3).get().unwrap();
-
-    println!("List of generated address: {:#?}", addresses);
+    println!(
+        "List of generated address: {:#?}",
+        addresses.iter().map(|(a, _)| a.to_bech32()).collect::<Vec<String>>()
+    );
 }

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota::{BIP32Path, Client, Ed25519Address, Seed};
+use iota::{Client, Ed25519Address, Seed};
 use std::{num::NonZeroU64, time::Duration};
 use tokio::time::delay_for;
 
@@ -37,12 +37,10 @@ async fn main() {
     )
     .unwrap();
 
-    // Insert your account path. Note that index must be hardened(like 0', 123').
-    let path = BIP32Path::from_str("m/").unwrap();
     let message_id = iota
         .send()
         .transaction(&seed)
-        .path(&path)
+        .account_index(0)
         // Insert the output address and ampunt to spent. The amount cannot be zero.
         .output(
             "5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8"
@@ -59,7 +57,7 @@ async fn main() {
     let message_id = iota
         .send()
         .transaction(&seed)
-        .path(&path)
+        .account_index(0)
         // Insert the output address and ampunt to spent. The amount cannot be zero.
         .output(
             "bcbe5e2ccd4ce942407a0fd8ccad1df33c68c9cb1078c043e95e486d8c6e0230"
@@ -74,12 +72,11 @@ async fn main() {
     println!("{:#?}", message_id);
 
     delay_for(Duration::from_millis(15000)).await;
-    // Insert your account path. Note that index must be hardened(like 0', 123').
-    let path = BIP32Path::from_str("m/").unwrap();
+
     let message_id = iota
         .send()
         .transaction(&seed)
-        .path(&path)
+        .account_index(0)
         // Insert the output address and ampunt to spent. The amount cannot be zero.
         .output(
             "5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8"
@@ -96,7 +93,7 @@ async fn main() {
     let message_id = iota
         .send()
         .transaction(&seed)
-        .path(&path)
+        .account_index(0)
         // Insert the output address and ampunt to spent. The amount cannot be zero.
         .output(
             "bcbe5e2ccd4ce942407a0fd8ccad1df33c68c9cb1078c043e95e486d8c6e0230"
@@ -111,12 +108,11 @@ async fn main() {
     println!("{:#?}", message_id);
 
     delay_for(Duration::from_millis(15000)).await;
-    // Insert your account path. Note that index must be hardened(like 0', 123').
-    let path = BIP32Path::from_str("m/").unwrap();
+
     let message_id = iota
         .send()
         .transaction(&seed)
-        .path(&path)
+        .account_index(0)
         // Insert the output address and ampunt to spent. The amount cannot be zero.
         .output(
             "5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8"
@@ -130,10 +126,11 @@ async fn main() {
 
     println!("{:#?}", message_id);
     delay_for(Duration::from_millis(15000)).await;
+
     let message_id = iota
         .send()
         .transaction(&seed)
-        .path(&path)
+        .account_index(0)
         // Insert the output address and ampunt to spent. The amount cannot be zero.
         .output(
             "bcbe5e2ccd4ce942407a0fd8ccad1df33c68c9cb1078c043e95e486d8c6e0230"
@@ -153,12 +150,11 @@ async fn main() {
     .unwrap(); // Insert your seed. Since the output amount cannot be zero. The seed must contain non-zero balance.
 
     delay_for(Duration::from_millis(15000)).await;
-    // Insert your account path. Note that index must be hardened(like 0', 123').
-    let path = BIP32Path::from_str("m/").unwrap();
+
     let message_id = iota
         .send()
         .transaction(&seed)
-        .path(&path)
+        .account_index(0)
         // Insert the output address and ampunt to spent. The amount cannot be zero.
         .output(
             "6920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1fff"

--- a/iota-client/src/api/balance.rs
+++ b/iota-client/src/api/balance.rs
@@ -3,14 +3,14 @@
 
 use crate::{Client, Error, Result};
 
-use bee_signing_ext::{binary::BIP32Path, Seed};
+use bee_signing_ext::Seed;
 
 /// Builder of get_balance API
 pub struct GetBalanceBuilder<'a> {
     client: &'a Client,
     seed: &'a Seed,
-    path: Option<&'a BIP32Path>,
-    index: Option<usize>,
+    account_index: Option<usize>,
+    initial_address_index: Option<usize>,
 }
 
 impl<'a> GetBalanceBuilder<'a> {
@@ -19,41 +19,30 @@ impl<'a> GetBalanceBuilder<'a> {
         Self {
             client,
             seed,
-            path: None,
-            index: None,
+            account_index: None,
+            initial_address_index: None,
         }
     }
 
-    /// Set path to the builder
-    pub fn path(mut self, path: &'a BIP32Path) -> Self {
-        self.path = Some(path);
+    /// Sets the account index.
+    pub fn account_index(mut self, account_index: usize) -> Self {
+        self.account_index = Some(account_index);
         self
     }
 
-    /// Set index to the builder
-    pub fn index(mut self, index: usize) -> Self {
-        self.index = Some(index);
+    /// Sets the index of the address to start looking for balance.
+    pub fn initial_address_index(mut self, initial_address_index: usize) -> Self {
+        self.initial_address_index = Some(initial_address_index);
         self
     }
 
     /// Consume the builder and get the API result
     pub async fn get(self) -> Result<u64> {
-        let path = match self.path {
-            Some(p) => {
-                if p.depth() != 2 {
-                    return Err(Error::InvalidParameter(String::from(
-                        "Must provide BIP32Path with depth of 2",
-                    )));
-                }
-                p
-            }
-            None => return Err(Error::MissingParameter(String::from("BIP32 path"))),
-        };
+        let account_index = self
+            .account_index
+            .ok_or_else(|| Error::MissingParameter(String::from("account index")))?;
 
-        let mut index = match self.index {
-            Some(r) => r,
-            None => 0,
-        };
+        let mut index = self.initial_address_index.unwrap_or(0);
 
         // get account balance and check with value
         let mut balance = 0;
@@ -61,24 +50,24 @@ impl<'a> GetBalanceBuilder<'a> {
             let addresses = self
                 .client
                 .find_addresses(self.seed)
-                .path(path)
+                .account_index(account_index)
                 .range(index..index + 20)
                 .get()?;
 
-            // TODO we assume all addressees are unspent and valid if balance > 0
-            let mut end = false;
-            for address in addresses {
+            // TODO we assume all addresses are unspent and valid if balance > 0
+            let mut found_zero_balance = false;
+            for (address, _) in addresses {
                 let address_balance = self.client.get_address().balance(&address).await?;
                 match address_balance {
                     0 => {
-                        end = true;
+                        found_zero_balance = true;
                         break;
                     }
                     _ => balance += address_balance,
                 }
             }
 
-            match end {
+            match found_zero_balance {
                 true => break,
                 false => index += 20,
             }

--- a/iota-client/src/api/send.rs
+++ b/iota-client/src/api/send.rs
@@ -38,8 +38,8 @@ const TRANSACTION_ID_LENGTH: usize = 32;
 pub struct SendTransactionBuilder<'a> {
     client: &'a Client,
     seed: &'a Seed,
-    path: Option<&'a BIP32Path>,
-    index: Option<usize>,
+    account_index: Option<usize>,
+    initial_address_index: Option<usize>,
     outputs: Vec<Output>,
     indexation: Option<Indexation>,
 }
@@ -58,22 +58,22 @@ impl<'a> SendTransactionBuilder<'a> {
         Self {
             client,
             seed,
-            path: None,
-            index: None,
+            account_index: None,
+            initial_address_index: None,
             outputs: Vec::new(),
             indexation: None,
         }
     }
 
-    /// Set path to the builder
-    pub fn path(mut self, path: &'a BIP32Path) -> Self {
-        self.path = Some(path);
+    /// Sets the account index.
+    pub fn account_index(mut self, account_index: usize) -> Self {
+        self.account_index = Some(account_index);
         self
     }
 
-    /// Set index to the builder
-    pub fn index(mut self, index: usize) -> Self {
-        self.index = Some(index);
+    /// Sets the index of the address to start looking for balance.
+    pub fn initial_address_index(mut self, initial_address_index: usize) -> Self {
+        self.initial_address_index = Some(initial_address_index);
         self
     }
 
@@ -92,15 +92,12 @@ impl<'a> SendTransactionBuilder<'a> {
 
     /// Consume the builder and get the API result
     pub async fn post(self) -> Result<MessageId> {
-        let path = match self.path {
-            Some(p) => p,
-            None => return Err(Error::MissingParameter(String::from("BIP32 path"))),
-        };
+        let account_index = self
+            .account_index
+            .ok_or_else(|| Error::MissingParameter(String::from("account index")))?;
+        let path = BIP32Path::from_str(&crate::account_path!(account_index)).expect("invalid account index");
 
-        let mut index = match self.index {
-            Some(r) => r,
-            None => 0,
-        };
+        let mut index = self.initial_address_index.unwrap_or(0);
 
         if self.outputs.is_empty() {
             return Err(Error::MissingParameter(String::from("Outputs")));
@@ -129,12 +126,12 @@ impl<'a> SendTransactionBuilder<'a> {
             let addresses = self
                 .client
                 .find_addresses(self.seed)
-                .path(path)
+                .account_index(account_index)
                 .range(index..index + 20)
                 .get()?;
 
             // For each address, get the address outputs
-            for (address_index, address) in addresses.iter().enumerate() {
+            for (address_index, (address, _)) in addresses.iter().enumerate() {
                 let address_outputs = self.client.get_address().outputs(&address).await?;
                 let mut outputs = vec![];
                 for output_id in address_outputs.iter() {

--- a/iota-client/src/api/unspent.rs
+++ b/iota-client/src/api/unspent.rs
@@ -4,14 +4,14 @@
 use crate::{Client, Error, Result};
 
 use bee_message::prelude::Address;
-use bee_signing_ext::{binary::BIP32Path, Seed};
+use bee_signing_ext::Seed;
 
 /// Builder of get_unspent_address API
 pub struct GetUnspentAddressBuilder<'a> {
     client: &'a Client,
     seed: &'a Seed,
-    path: Option<&'a BIP32Path>,
-    index: Option<usize>,
+    account_index: Option<usize>,
+    initial_address_index: Option<usize>,
 }
 
 impl<'a> GetUnspentAddressBuilder<'a> {
@@ -20,53 +20,51 @@ impl<'a> GetUnspentAddressBuilder<'a> {
         Self {
             client,
             seed,
-            path: None,
-            index: None,
+            account_index: None,
+            initial_address_index: None,
         }
     }
 
-    /// Set path to the builder
-    pub fn path(mut self, path: &'a BIP32Path) -> Self {
-        self.path = Some(path);
+    /// Sets the account index.
+    pub fn account_index(mut self, account_index: usize) -> Self {
+        self.account_index = Some(account_index);
         self
     }
 
-    /// Set index to the builder
-    pub fn index(mut self, index: usize) -> Self {
-        self.index = Some(index);
+    /// Sets the index of the address to start looking for balance.
+    pub fn initial_address_index(mut self, initial_address_index: usize) -> Self {
+        self.initial_address_index = Some(initial_address_index);
         self
     }
 
     /// Consume the builder and get the API result
     pub async fn get(self) -> Result<(Address, usize)> {
-        let path = match self.path {
-            Some(p) => p,
-            None => return Err(Error::MissingParameter(String::from("BIP32 path"))),
-        };
+        let account_index = self
+            .account_index
+            .ok_or_else(|| Error::MissingParameter(String::from("account index")))?;
 
-        let mut index = match self.index {
-            Some(r) => r,
-            None => 0,
-        };
+        let mut index = self.initial_address_index.unwrap_or(0);
 
         let result = loop {
             let addresses = self
                 .client
                 .find_addresses(self.seed)
-                .path(path)
+                .account_index(account_index)
                 .range(index..index + 20)
                 .get()?;
 
             // TODO we assume all addressees are unspent and valid if balance > 0
             let mut address = None;
-            for a in addresses {
-                let address_balance = self.client.get_address().balance(&a).await?;
-                match address_balance {
-                    0 => {
-                        address = Some(a);
-                        break;
+            for (a, internal) in addresses {
+                if !internal {
+                    let address_balance = self.client.get_address().balance(&a).await?;
+                    match address_balance {
+                        0 => {
+                            address = Some(a);
+                            break;
+                        }
+                        _ => index += 1,
                     }
-                    _ => index += 1,
                 }
             }
 

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -519,8 +519,7 @@ impl Client {
         Ok(messages)
     }
 
-    /// Return the balance for a provided seed and its wallet chain BIP32 path. BIP32 derivation path
-    /// of the address should be in form of `m/0'/0'/k'`. So the wallet chain is expected to be `m/0'/0'`.
+    /// Return the balance for a provided seed and its wallet chain account index.
     /// Addresses with balance must be consecutive, so this method will return once it encounters a zero
     /// balance address.
     pub fn get_balance<'a>(&'a self, seed: &'a Seed) -> GetBalanceBuilder<'a> {

--- a/iota-client/src/lib.rs
+++ b/iota-client/src/lib.rs
@@ -33,3 +33,11 @@ macro_rules! parse_response {
         }
     }};
 }
+
+/// gets the BIP32 account path from a given account_index/address_internal/address_index
+#[macro_export]
+macro_rules! account_path {
+    ($account_index:expr) => {
+        format!("m/44'/4218'/{}'", $account_index)
+    };
+}

--- a/iota-client/tests/node_api.rs
+++ b/iota-client/tests/node_api.rs
@@ -4,7 +4,7 @@
 // These are E2E test samples, so they are ignored by default.
 
 use bee_message::prelude::*;
-use bee_signing_ext::{binary::BIP32Path, Seed};
+use bee_signing_ext::Seed;
 
 use iota_client::MessageJson;
 use std::{convert::TryInto, num::NonZeroU64, str::FromStr};
@@ -98,12 +98,10 @@ async fn test_post_message_with_transaction() {
     )
     .unwrap();
 
-    // Insert your account path. Note that index must be hardened(like 0', 123').
-    let path = BIP32Path::from_str("m/").unwrap();
     let message_id = iota
         .send()
         .transaction(&seed)
-        .path(&path)
+        .account_index(0)
         // Insert the output address and ampunt to spent. The amount cannot be zero.
         .output(
             "5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8"


### PR DESCRIPTION
This PR changes the high level APIs to take account indexes instead of full BIP32 paths. It's easier to use and no one needs to import the BIP32Path struct and create a new one, knowing that it should be m'/44'/4218'/{index}.

Also, this introduces internal addresses usage.
