### PR TITLE
feat(client): add option to disable node sync, closes #203

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -99,6 +99,12 @@ Sets the node syncing interval.
 
 **Returns** the client builder instance for chained calls.
 
+#### disableNodeSync(): ClientBuilder
+
+Disables the node syncing process. Every node will be considered healthy and ready to use.
+
+**Returns** the client builder instance for chained calls.
+
 #### defaultTimeout(timeoutMs): ClientBuilder
 
 Sets the default HTTP request timeout.

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -19,6 +19,7 @@ export declare class ClientBuilder {
   quorumThreshold(threshold: number): ClientBuilder
   brokerOptions(options: BrokerOptions): ClientBuilder
   nodeSyncInterval(interval: number): ClientBuilder
+  disableNodeSync(): ClientBuilder
   requestTimeout(timeoutMs: number): ClientBuilder
   apiTimeout(api: Api, timeoutMs: number): ClientBuilder
   localPow(local: boolean): ClientBuilder

--- a/bindings/node/native/src/classes/client/unspent_address_getter.rs
+++ b/bindings/node/native/src/classes/client/unspent_address_getter.rs
@@ -4,15 +4,13 @@
 use iota::Seed;
 use neon::prelude::*;
 
-use std::sync::{Arc, Mutex};
-
 use super::{Api, ClientTask};
 
 pub struct UnspentAddressGetter {
     client_id: String,
     seed: String,
-    account_index: Arc<Mutex<Option<usize>>>,
-    initial_address_index: Arc<Mutex<Option<usize>>>,
+    account_index: Option<usize>,
+    initial_address_index: Option<usize>,
 }
 
 declare_types! {
@@ -23,18 +21,17 @@ declare_types! {
             Ok(UnspentAddressGetter {
                 client_id,
                 seed,
-                account_index: Arc::new(Mutex::new(None)),
-                initial_address_index: Arc::new(Mutex::new(None)),
+                account_index: None,
+                initial_address_index: None,
             })
         }
 
         method accountIndex(mut cx) {
             let account_index = cx.argument::<JsNumber>(0)?.value() as usize;
             {
-                let this = cx.this();
+                let mut this = cx.this();
                 let guard = cx.lock();
-                let ref_ = &(*this.borrow(&guard)).account_index;
-                let mut get_account_index = ref_.lock().unwrap();
+                let get_account_index = &mut this.borrow_mut(&guard).account_index;
                 get_account_index.replace(account_index);
             }
 
@@ -44,10 +41,9 @@ declare_types! {
         method initialAddressIndex(mut cx) {
             let index = cx.argument::<JsNumber>(0)?.value() as usize;
             {
-                let this = cx.this();
+                let mut this = cx.this();
                 let guard = cx.lock();
-                let ref_ = &(*this.borrow(&guard)).initial_address_index;
-                let mut get_address_index = ref_.lock().unwrap();
+                let get_address_index = &mut this.borrow_mut(&guard).initial_address_index;
                 get_address_index.replace(index);
             }
 
@@ -64,8 +60,8 @@ declare_types! {
                     client_id: ref_.client_id.clone(),
                     api: Api::GetUnspentAddress {
                         seed: Seed::from_ed25519_bytes(&hex::decode(&ref_.seed).expect("invalid seed hex")).expect("invalid seed"),
-                        account_index: *ref_.account_index.lock().unwrap(),
-                        initial_address_index: *ref_.initial_address_index.lock().unwrap(),
+                        account_index: ref_.account_index,
+                        initial_address_index: ref_.initial_address_index,
                     },
                 };
                 client_task.schedule(cb);

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -25,7 +25,6 @@ use std::{
     collections::{HashMap, HashSet},
     convert::TryInto,
     hash::Hash,
-    num::NonZeroU64,
     str::FromStr,
     sync::{Arc, RwLock},
     time::Duration,
@@ -181,7 +180,7 @@ pub struct Client {
     /// Node pool of synced IOTA nodes
     pub(crate) sync: Arc<RwLock<HashSet<Url>>>,
     /// Flag to stop the node syncing
-    pub(crate) sync_kill_sender: Arc<Sender<()>>,
+    pub(crate) sync_kill_sender: Option<Arc<Sender<()>>>,
     /// A reqwest Client to make Requests with
     pub(crate) client: reqwest::Client,
     /// A MQTT client to subscribe/unsubscribe to topics.
@@ -209,13 +208,14 @@ impl std::fmt::Debug for Client {
 impl Drop for Client {
     /// Gracefully shutdown the `Client`
     fn drop(&mut self) {
-        self.sync_kill_sender
-            .clone()
-            .send(())
-            .expect("failed to stop syncing process");
+        if let Some(sender) = self.sync_kill_sender.take() {
+            sender.send(()).expect("failed to stop syncing process");
+        }
+
         if let Some(runtime) = self.runtime.take() {
             runtime.shutdown_background();
         }
+
         if self.mqtt_client.is_some() {
             self.subscriber()
                 .disconnect()
@@ -234,11 +234,11 @@ impl Client {
     pub(crate) fn start_sync_process(
         runtime: &Runtime,
         sync: Arc<RwLock<HashSet<Url>>>,
-        nodes: Vec<Url>,
-        node_sync_interval: NonZeroU64,
+        nodes: HashSet<Url>,
+        node_sync_interval: Duration,
         mut kill: Receiver<()>,
     ) {
-        let node_sync_interval = TokioDuration::from_millis(node_sync_interval.into());
+        let node_sync_interval = TokioDuration::from_nanos(node_sync_interval.as_nanos().try_into().unwrap());
 
         runtime.enter(|| {
             tokio::spawn(async move {
@@ -257,7 +257,7 @@ impl Client {
         });
     }
 
-    pub(crate) async fn sync_nodes(sync: &Arc<RwLock<HashSet<Url>>>, nodes: &[Url]) {
+    pub(crate) async fn sync_nodes(sync: &Arc<RwLock<HashSet<Url>>>, nodes: &HashSet<Url>) {
         let mut synced_nodes = HashSet::new();
 
         for node_url in nodes {


### PR DESCRIPTION
The client builder now has a `disable_node_sync` method that makes the client skip the syncing process so every listed node is considered healthy.