### PR TITLE
Modify the transaction example with the updated send() API

### DIFF
--- a/bindings/node/native/src/classes/client/api.rs
+++ b/bindings/node/native/src/classes/client/api.rs
@@ -90,7 +90,7 @@ impl Task for ClientTask {
                         sender = sender.initial_address_index(*initial_address_index);
                     }
                     for output in outputs {
-                        sender = sender.output(output.0.clone(), output.1);
+                        sender = sender.output(&output.0.clone().to_bech32(), output.1).unwrap();
                     }
                     let message_id = sender.post().await?;
                     serde_json::to_string(&message_id).unwrap()

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,3 +28,7 @@ path = "transaction.rs"
 [[example]]
 name = "mqtt"
 path = "mqtt.rs"
+
+[[example]]
+name = "multiple_outputs"
+path = "multiple_outputs.rs"

--- a/examples/address.rs
+++ b/examples/address.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! cargo run --example address --release
 use iota::{Client, Seed};
 
 #[tokio::main]
@@ -12,7 +13,7 @@ async fn main() {
         .unwrap();
 
     let seed = Seed::from_ed25519_bytes(
-        &hex::decode("3ff69866a124d8cf168e5b928eb603bacc2d241f1a9d70af5c10f2dd34137896").unwrap(),
+        &hex::decode("256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b2").unwrap(),
     )
     .unwrap(); // Insert your seed
 

--- a/examples/balance.rs
+++ b/examples/balance.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! cargo run --example balance --release
 use iota::{Client, Ed25519Address};
 
 #[tokio::main]

--- a/examples/indexation.rs
+++ b/examples/indexation.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! cargo run --example indexation --release
 use iota::{Client, Payload};
 
 #[tokio::main]

--- a/examples/multiple_outputs.rs
+++ b/examples/multiple_outputs.rs
@@ -1,0 +1,80 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! cargo run --example multiple_outputs --release
+use iota::{Client, MessageId, Seed, Transfers};
+use std::{num::NonZeroU64, time::Duration};
+use tokio::time::delay_for;
+/// In this example, we send 900 tokens to the following 3 locations, respectively
+///
+/// Address Index 0
+///   output 0: 300 tokens iot1q86rlrygq5wcgdwt7fpajaxxppc49tg0jk0xadnp66fsfjtwt8vgc48sse6
+///   output 1: 300 tokens iot1qyg7l34etk4sdfrdt46vwt7a964avk9sfrxh8ecq2sgpezaktd55cyc76lc
+///   output 2: 300 tokens iot1q9r5hvlppf44gvcxnuue4dwjtjcredrw6yesphqeq7fqm2fyjy6kul4tv5r
+///
+///
+/// These two addresses belong to seed "256a818b2aac458941f7274985a410e57fb750f3a3a67369ece5bd9ae7eef5b0"
+
+#[tokio::main]
+async fn main() {
+    let iota = Client::builder() // Crate a client instance builder
+        .node("https://api.lb-0.testnet.chrysalis2.com") // Insert the node here
+        .unwrap()
+        .build()
+        .unwrap();
+
+    // Insert your seed. Since the output amount cannot be zero. The seed must contain non-zero balance.
+    // First address from the seed below is iot1qxt0nhsf38nh6rs4p6zs5knqp6psgha9wsv74uajqgjmwc75ugupxgecea4
+    let seed = Seed::from_ed25519_bytes(
+        &hex::decode("256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b2").unwrap(),
+    )
+    .unwrap();
+
+    let mut transfers = Transfers::new(
+        "iot1q86rlrygq5wcgdwt7fpajaxxppc49tg0jk0xadnp66fsfjtwt8vgc48sse6",
+        NonZeroU64::new(300).unwrap(),
+    )
+    .unwrap();
+    transfers
+        .add(
+            "iot1qyg7l34etk4sdfrdt46vwt7a964avk9sfrxh8ecq2sgpezaktd55cyc76lc",
+            NonZeroU64::new(300).unwrap(),
+        )
+        .unwrap();
+    transfers
+        .add(
+            "iot1q9r5hvlppf44gvcxnuue4dwjtjcredrw6yesphqeq7fqm2fyjy6kul4tv5r",
+            NonZeroU64::new(300).unwrap(),
+        )
+        .unwrap();
+
+    let message_id = iota
+        .send()
+        .transaction(&seed)
+        .account_index(0)
+        .outputs(transfers)
+        .post()
+        .await
+        .unwrap();
+
+    println!(
+        "Transaction sent: https://explorer.iota.org/chrysalis/message/{}",
+        message_id
+    );
+    reattach_promote_until_confirmed(message_id, &iota).await;
+}
+
+async fn reattach_promote_until_confirmed(message_id: MessageId, iota: &Client) {
+    while let Ok(metadata) = iota.get_message().metadata(&message_id).await {
+        if let Some(state) = metadata.ledger_inclusion_state {
+            println!("Leder inclusion state: {}", state);
+            break;
+        } else {
+            match iota.reattach(&message_id).await {
+                Ok(msg_id) => println!("Reattached or promoted {}", msg_id.0),
+                _ => {}
+            }
+        }
+        delay_for(Duration::from_secs(5)).await;
+    }
+}

--- a/examples/multiple_outputs.rs
+++ b/examples/multiple_outputs.rs
@@ -66,9 +66,8 @@ async fn reattach_promote_until_confirmed(message_id: MessageId, iota: &Client) 
             println!("Leder inclusion state: {}", state);
             break;
         } else {
-            match iota.reattach(&message_id).await {
-                Ok(msg_id) => println!("Reattached or promoted {}", msg_id.0),
-                _ => {}
+            if let Ok(msg_id) = iota.reattach(&message_id).await {
+                println!("Reattached or promoted {}", msg_id.0);
             }
         }
         delay_for(Duration::from_secs(5)).await;

--- a/examples/multiple_outputs.rs
+++ b/examples/multiple_outputs.rs
@@ -65,10 +65,8 @@ async fn reattach_promote_until_confirmed(message_id: MessageId, iota: &Client) 
         if let Some(state) = metadata.ledger_inclusion_state {
             println!("Leder inclusion state: {}", state);
             break;
-        } else {
-            if let Ok(msg_id) = iota.reattach(&message_id).await {
-                println!("Reattached or promoted {}", msg_id.0);
-            }
+        } else if let Ok(msg_id) = iota.reattach(&message_id).await {
+            println!("Reattached or promoted {}", msg_id.0);
         }
         delay_for(Duration::from_secs(5)).await;
     }

--- a/examples/multiple_outputs.rs
+++ b/examples/multiple_outputs.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! cargo run --example multiple_outputs --release
-use iota::{Client, MessageId, Seed, Transfers};
+use iota::{Client, MessageId, Seed};
 use std::{num::NonZeroU64, time::Duration};
 use tokio::time::delay_for;
 /// In this example, we send 900 tokens to the following 3 locations, respectively
@@ -30,29 +30,25 @@ async fn main() {
     )
     .unwrap();
 
-    let mut transfers = Transfers::new(
-        "iot1q86rlrygq5wcgdwt7fpajaxxppc49tg0jk0xadnp66fsfjtwt8vgc48sse6",
-        NonZeroU64::new(300).unwrap(),
-    )
-    .unwrap();
-    transfers
-        .add(
-            "iot1qyg7l34etk4sdfrdt46vwt7a964avk9sfrxh8ecq2sgpezaktd55cyc76lc",
-            NonZeroU64::new(300).unwrap(),
-        )
-        .unwrap();
-    transfers
-        .add(
-            "iot1q9r5hvlppf44gvcxnuue4dwjtjcredrw6yesphqeq7fqm2fyjy6kul4tv5r",
-            NonZeroU64::new(300).unwrap(),
-        )
-        .unwrap();
-
     let message_id = iota
         .send()
         .transaction(&seed)
         .account_index(0)
-        .outputs(transfers)
+        .output(
+            "iot1q86rlrygq5wcgdwt7fpajaxxppc49tg0jk0xadnp66fsfjtwt8vgc48sse6",
+            NonZeroU64::new(300).unwrap(),
+        )
+        .unwrap()
+        .output(
+            "iot1qyg7l34etk4sdfrdt46vwt7a964avk9sfrxh8ecq2sgpezaktd55cyc76lc",
+            NonZeroU64::new(280).unwrap(),
+        )
+        .unwrap()
+        .output(
+            "iot1q9r5hvlppf44gvcxnuue4dwjtjcredrw6yesphqeq7fqm2fyjy6kul4tv5r",
+            NonZeroU64::new(300).unwrap(),
+        )
+        .unwrap()
         .post()
         .await
         .unwrap();

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -9,8 +9,8 @@ use tokio::time::delay_for;
 ///
 /// Address Index 0. Note that we can use the `address` example codes to know the addresses belong to the seed.
 ///   output 0: 300 tokens iot1q86rlrygq5wcgdwt7fpajaxxppc49tg0jk0xadnp66fsfjtwt8vgc48sse6
-///   output 1: 300 tokens iot1q9r5hvlppf44gvcxnuue4dwjtjcredrw6yesphqeq7fqm2fyjy6kul4tv5r
-///   output 2: 300 tokens iot1q84egwx5gu4nme5cn6q3fxwe2j7qex6h66d2g6m5grshaxq07fntxufm9td
+///   output 1: 300 tokens iot1qyg7l34etk4sdfrdt46vwt7a964avk9sfrxh8ecq2sgpezaktd55cyc76lc
+///   output 2: 300 tokens iot1q9r5hvlppf44gvcxnuue4dwjtjcredrw6yesphqeq7fqm2fyjy6kul4tv5r
 ///
 ///
 /// These two addresses belong to seed "256a818b2aac458941f7274985a410e57fb750f3a3a67369ece5bd9ae7eef5b0"
@@ -22,7 +22,7 @@ use tokio::time::delay_for;
 #[tokio::main]
 async fn main() {
     let iota = Client::builder() // Crate a client instance builder
-        .node("https://api.lb-0.testnet.chrysalis2.com") // Insert the node here
+        .node("http://0.0.0.0:14265") // Insert the node here
         .unwrap()
         .build()
         .unwrap();
@@ -49,7 +49,27 @@ async fn main() {
         .unwrap();
 
     println!(
-        "First transaction sent: https://explorer.iota.org/chrysalis/message/{}",
+        "First transaction sent: http://127.0.0.1:14265/api/v1/messages/{}",
+        message_id
+    );
+    reattach_promote_until_confirmed(message_id, &iota).await;
+
+    let message_id = iota
+        .send()
+        .transaction(&seed)
+        .account_index(0)
+        // Insert the output address and amount to spent. The amount cannot be zero.
+        .output(
+            "iot1qyg7l34etk4sdfrdt46vwt7a964avk9sfrxh8ecq2sgpezaktd55cyc76lc",
+            NonZeroU64::new(300).unwrap(),
+        )
+        .unwrap()
+        .post()
+        .await
+        .unwrap();
+
+    println!(
+        "Second transaction sent: http://127.0.0.1:14265/api/v1/messages/{}",
         message_id
     );
     reattach_promote_until_confirmed(message_id, &iota).await;
@@ -67,28 +87,8 @@ async fn main() {
         .post()
         .await
         .unwrap();
-
     println!(
-        "Second transaction sent: https://explorer.iota.org/chrysalis/message/{}",
-        message_id
-    );
-    reattach_promote_until_confirmed(message_id, &iota).await;
-
-    let message_id = iota
-        .send()
-        .transaction(&seed)
-        .account_index(0)
-        // Insert the output address and amount to spent. The amount cannot be zero.
-        .output(
-            "iot1q84egwx5gu4nme5cn6q3fxwe2j7qex6h66d2g6m5grshaxq07fntxufm9td",
-            NonZeroU64::new(300).unwrap(),
-        )
-        .unwrap()
-        .post()
-        .await
-        .unwrap();
-    println!(
-        "Third transaction sent: https://explorer.iota.org/chrysalis/message/{}",
+        "Third transaction sent: http://127.0.0.1:14265/api/v1/messages/{}",
         message_id
     );
     reattach_promote_until_confirmed(message_id, &iota).await;
@@ -119,7 +119,7 @@ async fn main() {
         .unwrap();
 
     println!(
-        "Last transaction sent: https://explorer.iota.org/chrysalis/message/{}",
+        "Last transaction sent: http://127.0.0.1:14265/api/v1/messages/{}",
         message_id
     );
     reattach_promote_until_confirmed(message_id, &iota).await;

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -136,9 +136,8 @@ async fn reattach_promote_until_confirmed(message_id: MessageId, iota: &Client) 
             println!("Leder inclusion state: {}", state);
             break;
         } else {
-            match iota.reattach(&message_id).await {
-                Ok(msg_id) => println!("Reattached or promoted {}", msg_id.0),
-                _ => {}
+            if let Ok(msg_id) = iota.reattach(&message_id).await {
+                println!("Reattached or promoted {}", msg_id.0);
             }
         }
         delay_for(Duration::from_secs(5)).await;

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -1,32 +1,33 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota::{Client, Ed25519Address, Seed};
+//! cargo run --example transaction --release
+use iota::{Client, MessageId, Seed};
 use std::{num::NonZeroU64, time::Duration};
 use tokio::time::delay_for;
-
 /// In this example, we send 900 tokens to the following 3 locations, respectively
 ///
 /// Address Index 0
-///   output 0: 300 tokens d25a0fb1d36b9760e6a893877a5bd0c316aba4d2504264dceb79287421b6448c
-///   output 1: 300 tokens b41dc1fec07761335d66dc5e810bb3191cfa940f6756bb69ec8451e3c061b449
-///   output 2: 300 tokens 3726ee414e23d398477bfdfa885815615e1a57b9a7e29a884335cb54a2bbb764
+///   output 0: 300 tokens iot1q86rlrygq5wcgdwt7fpajaxxppc49tg0jk0xadnp66fsfjtwt8vgc48sse6
+///   output 1: 300 tokens iot1qyg7l34etk4sdfrdt46vwt7a964avk9sfrxh8ecq2sgpezaktd55cyc76lc
+///   output 2: 300 tokens iot1q9r5hvlppf44gvcxnuue4dwjtjcredrw6yesphqeq7fqm2fyjy6kul4tv5r
 ///
 ///
-/// These two addresses belong to seed "256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b1"
-/// Then we send 550 tokens from seed "256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b1"
-/// to address "6920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1fff", and check the ledger
+/// These two addresses belong to seed "256a818b2aac458941f7274985a410e57fb750f3a3a67369ece5bd9ae7eef5b0"
+/// Then we send 550 tokens from seed "256a818b2aac458941f7274985a410e57fb750f3a3a67369ece5bd9ae7eef5b0"
+/// to address "iot1q95jpvtk7cf7c7l9ne50c684jl4n8ya0srm5clpak7qes9ratu0l76clafr", and check the ledger
 /// inclusion state, which should be "included".
 
 #[tokio::main]
 async fn main() {
     let iota = Client::builder() // Crate a client instance builder
-        .node("http://0.0.0.0:14265") // Insert the node here
+        .node("https://api.lb-0.testnet.chrysalis2.com") // Insert the node here
         .unwrap()
         .build()
         .unwrap();
 
     // Insert your seed. Since the output amount cannot be zero. The seed must contain non-zero balance.
+    // First address from the seed below is iot1qxt0nhsf38nh6rs4p6zs5knqp6psgha9wsv74uajqgjmwc75ugupxgecea4
     let seed = Seed::from_ed25519_bytes(
         &hex::decode("256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b2").unwrap(),
     )
@@ -38,35 +39,19 @@ async fn main() {
         .account_index(0)
         // Insert the output address and amount to spent. The amount cannot be zero.
         .output(
-            "d25a0fb1d36b9760e6a893877a5bd0c316aba4d2504264dceb79287421b6448c"
-                .parse::<Ed25519Address>()
-                .unwrap()
-                .into(), // Insert the address to search for
+            "iot1q86rlrygq5wcgdwt7fpajaxxppc49tg0jk0xadnp66fsfjtwt8vgc48sse6", // Insert the address to search for
             NonZeroU64::new(300).unwrap(),
         )
+        .unwrap()
         .post()
-        .await;
+        .await
+        .unwrap();
 
-    println!("{:#?}", message_id);
-    delay_for(Duration::from_millis(15000)).await;
-    let message_id = iota
-        .send()
-        .transaction(&seed)
-        .account_index(0)
-        // Insert the output address and amount to spent. The amount cannot be zero.
-        .output(
-            "b41dc1fec07761335d66dc5e810bb3191cfa940f6756bb69ec8451e3c061b449"
-                .parse::<Ed25519Address>()
-                .unwrap()
-                .into(),
-            NonZeroU64::new(300).unwrap(),
-        )
-        .post()
-        .await;
-
-    println!("{:#?}", message_id);
-
-    delay_for(Duration::from_millis(15000)).await;
+    println!(
+        "First transaction sent: https://explorer.iota.org/chrysalis/message/{}",
+        message_id
+    );
+    reattach_promote_until_confirmed(message_id, &iota).await;
 
     let message_id = iota
         .send()
@@ -74,45 +59,81 @@ async fn main() {
         .account_index(0)
         // Insert the output address and amount to spent. The amount cannot be zero.
         .output(
-            "3726ee414e23d398477bfdfa885815615e1a57b9a7e29a884335cb54a2bbb764"
-                .parse::<Ed25519Address>()
-                .unwrap()
-                .into(),
+            "iot1qyg7l34etk4sdfrdt46vwt7a964avk9sfrxh8ecq2sgpezaktd55cyc76lc",
             NonZeroU64::new(300).unwrap(),
         )
+        .unwrap()
         .post()
-        .await;
+        .await
+        .unwrap();
 
-    println!("{:#?}", message_id);
-    delay_for(Duration::from_millis(15000)).await;
+    println!(
+        "Second transaction sent: https://explorer.iota.org/chrysalis/message/{}",
+        message_id
+    );
+    reattach_promote_until_confirmed(message_id, &iota).await;
+
+    let message_id = iota
+        .send()
+        .transaction(&seed)
+        .account_index(0)
+        // Insert the output address and amount to spent. The amount cannot be zero.
+        .output(
+            "iot1q9r5hvlppf44gvcxnuue4dwjtjcredrw6yesphqeq7fqm2fyjy6kul4tv5r",
+            NonZeroU64::new(300).unwrap(),
+        )
+        .unwrap()
+        .post()
+        .await
+        .unwrap();
+    println!(
+        "Third transaction sent: https://explorer.iota.org/chrysalis/message/{}",
+        message_id
+    );
+    reattach_promote_until_confirmed(message_id, &iota).await;
 
     let seed = Seed::from_ed25519_bytes(
-        &hex::decode("256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b1").unwrap(),
+        &hex::decode("256a818b2aac458941f7274985a410e57fb750f3a3a67369ece5bd9ae7eef5b0").unwrap(),
     )
     .unwrap(); // Insert your seed. Since the output amount cannot be zero. The seed must contain non-zero balance.
 
-    delay_for(Duration::from_millis(15000)).await;
-
     let message_id = iota
         .send()
         .transaction(&seed)
         .account_index(0)
         // Insert the output address and amount to spent. The amount cannot be zero.
         .output(
-            "6920b176f613ec7be59e68fc68f597eb3393af80f74c7c3db78198147d5f1fff"
-                .parse::<Ed25519Address>()
-                .unwrap()
-                .into(),
+            "iot1q95jpvtk7cf7c7l9ne50c684jl4n8ya0srm5clpak7qes9ratu0l76clafr",
             NonZeroU64::new(550).unwrap(),
         )
+        .unwrap()
         .post()
-        .await;
+        .await
+        .unwrap();
 
-    println!("{:#?}", message_id);
-    delay_for(Duration::from_millis(15000)).await;
-    let message_metadata = iota.get_message().metadata(&message_id.unwrap()).await;
+    println!(
+        "Last transaction sent: https://explorer.iota.org/chrysalis/message/{}",
+        message_id
+    );
+    reattach_promote_until_confirmed(message_id, &iota).await;
+    let message_metadata = iota.get_message().metadata(&message_id).await;
     println!(
         "The ledgerInclusionState: {:?}",
         message_metadata.unwrap().ledger_inclusion_state
     );
+}
+
+async fn reattach_promote_until_confirmed(message_id: MessageId, iota: &Client) {
+    while let Ok(metadata) = iota.get_message().metadata(&message_id).await {
+        if let Some(state) = metadata.ledger_inclusion_state {
+            println!("Leder inclusion state: {}", state);
+            break;
+        } else {
+            match iota.reattach(&message_id).await {
+                Ok(msg_id) => println!("Reattached or promoted {}", msg_id.0),
+                _ => {}
+            }
+        }
+        delay_for(Duration::from_secs(5)).await;
+    }
 }

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -5,17 +5,12 @@ use iota::{Client, Ed25519Address, Seed};
 use std::{num::NonZeroU64, time::Duration};
 use tokio::time::delay_for;
 
-/// In this example, we send 600 tokens to the following 6 locations, respectively
+/// In this example, we send 900 tokens to the following 3 locations, respectively
 ///
-/// Address m/0 (5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8)
-///   output 0: 100 tokens
-///   output 1: 100 tokens
-///   output 2: 100 tokens
-///
-/// Address m/1 (bcbe5e2ccd4ce942407a0fd8ccad1df33c68c9cb1078c043e95e486d8c6e0230)
-///   output 0: 100 tokens
-///   output 1: 100 tokens
-///   output 2: 100 tokens
+/// Address Index 0
+///   output 0: 300 tokens d25a0fb1d36b9760e6a893877a5bd0c316aba4d2504264dceb79287421b6448c
+///   output 1: 300 tokens b41dc1fec07761335d66dc5e810bb3191cfa940f6756bb69ec8451e3c061b449
+///   output 2: 300 tokens 3726ee414e23d398477bfdfa885815615e1a57b9a7e29a884335cb54a2bbb764
 ///
 ///
 /// These two addresses belong to seed "256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b1"
@@ -43,11 +38,11 @@ async fn main() {
         .account_index(0)
         // Insert the output address and amount to spent. The amount cannot be zero.
         .output(
-            "5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8"
+            "d25a0fb1d36b9760e6a893877a5bd0c316aba4d2504264dceb79287421b6448c"
                 .parse::<Ed25519Address>()
                 .unwrap()
                 .into(), // Insert the address to search for
-            NonZeroU64::new(100).unwrap(),
+            NonZeroU64::new(300).unwrap(),
         )
         .post()
         .await;
@@ -60,47 +55,11 @@ async fn main() {
         .account_index(0)
         // Insert the output address and amount to spent. The amount cannot be zero.
         .output(
-            "bcbe5e2ccd4ce942407a0fd8ccad1df33c68c9cb1078c043e95e486d8c6e0230"
+            "b41dc1fec07761335d66dc5e810bb3191cfa940f6756bb69ec8451e3c061b449"
                 .parse::<Ed25519Address>()
                 .unwrap()
                 .into(),
-            NonZeroU64::new(100).unwrap(),
-        )
-        .post()
-        .await;
-
-    println!("{:#?}", message_id);
-
-    delay_for(Duration::from_millis(15000)).await;
-
-    let message_id = iota
-        .send()
-        .transaction(&seed)
-        .account_index(0)
-        // Insert the output address and amount to spent. The amount cannot be zero.
-        .output(
-            "5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8"
-                .parse::<Ed25519Address>()
-                .unwrap()
-                .into(),
-            NonZeroU64::new(100).unwrap(),
-        )
-        .post()
-        .await;
-
-    println!("{:#?}", message_id);
-    delay_for(Duration::from_millis(15000)).await;
-    let message_id = iota
-        .send()
-        .transaction(&seed)
-        .account_index(0)
-        // Insert the output address and amount to spent. The amount cannot be zero.
-        .output(
-            "bcbe5e2ccd4ce942407a0fd8ccad1df33c68c9cb1078c043e95e486d8c6e0230"
-                .parse::<Ed25519Address>()
-                .unwrap()
-                .into(),
-            NonZeroU64::new(100).unwrap(),
+            NonZeroU64::new(300).unwrap(),
         )
         .post()
         .await;
@@ -115,34 +74,17 @@ async fn main() {
         .account_index(0)
         // Insert the output address and amount to spent. The amount cannot be zero.
         .output(
-            "5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8"
+            "3726ee414e23d398477bfdfa885815615e1a57b9a7e29a884335cb54a2bbb764"
                 .parse::<Ed25519Address>()
                 .unwrap()
                 .into(),
-            NonZeroU64::new(100).unwrap(),
+            NonZeroU64::new(300).unwrap(),
         )
         .post()
         .await;
 
     println!("{:#?}", message_id);
     delay_for(Duration::from_millis(15000)).await;
-
-    let message_id = iota
-        .send()
-        .transaction(&seed)
-        .account_index(0)
-        // Insert the output address and amount to spent. The amount cannot be zero.
-        .output(
-            "bcbe5e2ccd4ce942407a0fd8ccad1df33c68c9cb1078c043e95e486d8c6e0230"
-                .parse::<Ed25519Address>()
-                .unwrap()
-                .into(),
-            NonZeroU64::new(100).unwrap(),
-        )
-        .post()
-        .await;
-
-    println!("{:#?}", message_id);
 
     let seed = Seed::from_ed25519_bytes(
         &hex::decode("256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b1").unwrap(),

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -7,15 +7,16 @@ use std::{num::NonZeroU64, time::Duration};
 use tokio::time::delay_for;
 /// In this example, we send 900 tokens to the following 3 locations, respectively
 ///
-/// Address Index 0
+/// Address Index 0. Note that we can use the `address` example codes to know the addresses belong to the seed.
 ///   output 0: 300 tokens iot1q86rlrygq5wcgdwt7fpajaxxppc49tg0jk0xadnp66fsfjtwt8vgc48sse6
-///   output 1: 300 tokens iot1qyg7l34etk4sdfrdt46vwt7a964avk9sfrxh8ecq2sgpezaktd55cyc76lc
-///   output 2: 300 tokens iot1q9r5hvlppf44gvcxnuue4dwjtjcredrw6yesphqeq7fqm2fyjy6kul4tv5r
+///   output 1: 300 tokens iot1q9r5hvlppf44gvcxnuue4dwjtjcredrw6yesphqeq7fqm2fyjy6kul4tv5r
+///   output 2: 300 tokens iot1q84egwx5gu4nme5cn6q3fxwe2j7qex6h66d2g6m5grshaxq07fntxufm9td
 ///
 ///
 /// These two addresses belong to seed "256a818b2aac458941f7274985a410e57fb750f3a3a67369ece5bd9ae7eef5b0"
 /// Then we send 550 tokens from seed "256a818b2aac458941f7274985a410e57fb750f3a3a67369ece5bd9ae7eef5b0"
-/// to address "iot1q95jpvtk7cf7c7l9ne50c684jl4n8ya0srm5clpak7qes9ratu0l76clafr", and check the ledger
+/// to addresses "iot1q95jpvtk7cf7c7l9ne50c684jl4n8ya0srm5clpak7qes9ratu0l76clafr" and
+/// "iot1q9gtmpa58j9vp23hrsztckt5rquy26lrrv25nz4g0v9pr8nsnqetcjskw9m", and check the ledger
 /// inclusion state, which should be "included".
 
 #[tokio::main]
@@ -59,7 +60,7 @@ async fn main() {
         .account_index(0)
         // Insert the output address and amount to spent. The amount cannot be zero.
         .output(
-            "iot1qyg7l34etk4sdfrdt46vwt7a964avk9sfrxh8ecq2sgpezaktd55cyc76lc",
+            "iot1q9r5hvlppf44gvcxnuue4dwjtjcredrw6yesphqeq7fqm2fyjy6kul4tv5r",
             NonZeroU64::new(300).unwrap(),
         )
         .unwrap()
@@ -79,7 +80,7 @@ async fn main() {
         .account_index(0)
         // Insert the output address and amount to spent. The amount cannot be zero.
         .output(
-            "iot1q9r5hvlppf44gvcxnuue4dwjtjcredrw6yesphqeq7fqm2fyjy6kul4tv5r",
+            "iot1q84egwx5gu4nme5cn6q3fxwe2j7qex6h66d2g6m5grshaxq07fntxufm9td",
             NonZeroU64::new(300).unwrap(),
         )
         .unwrap()
@@ -102,9 +103,15 @@ async fn main() {
         .transaction(&seed)
         .account_index(0)
         // Insert the output address and amount to spent. The amount cannot be zero.
+        // Note that we can transfer to multiple outputs by using the `SendTransactionBuilder`
         .output(
             "iot1q95jpvtk7cf7c7l9ne50c684jl4n8ya0srm5clpak7qes9ratu0l76clafr",
-            NonZeroU64::new(550).unwrap(),
+            NonZeroU64::new(270).unwrap(),
+        )
+        .unwrap()
+        .output(
+            "iot1q9gtmpa58j9vp23hrsztckt5rquy26lrrv25nz4g0v9pr8nsnqetcjskw9m",
+            NonZeroU64::new(280).unwrap(),
         )
         .unwrap()
         .post()

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -135,10 +135,8 @@ async fn reattach_promote_until_confirmed(message_id: MessageId, iota: &Client) 
         if let Some(state) = metadata.ledger_inclusion_state {
             println!("Leder inclusion state: {}", state);
             break;
-        } else {
-            if let Ok(msg_id) = iota.reattach(&message_id).await {
-                println!("Reattached or promoted {}", msg_id.0);
-            }
+        } else if let Ok(msg_id) = iota.reattach(&message_id).await {
+            println!("Reattached or promoted {}", msg_id.0);
         }
         delay_for(Duration::from_secs(5)).await;
     }

--- a/iota-client/src/api/send.rs
+++ b/iota-client/src/api/send.rs
@@ -50,6 +50,7 @@ struct AddressIndexRecorder {
     input: Input,
     address_index: usize,
     address_path: BIP32Path,
+    internal: bool,
 }
 
 impl<'a> SendTransactionBuilder<'a> {
@@ -183,6 +184,7 @@ impl<'a> SendTransactionBuilder<'a> {
                                     input,
                                     address_index,
                                     address_path,
+                                    internal: *internal,
                                 });
                                 // Output the remaining tokens back to the original address
                                 if total_already_spent > total_to_spend {
@@ -238,13 +240,16 @@ impl<'a> SendTransactionBuilder<'a> {
 
         let mut unlock_blocks = Vec::new();
         let mut current_block_index: usize = 0;
-        let mut signature_indexes = HashMap::<usize, usize>::new();
+        let mut signature_indexes = HashMap::<String, usize>::new();
         address_index_recorders.sort_by(|a, b| a.input.cmp(&b.input));
 
         for recorder in address_index_recorders.iter() {
             // Check if current path is same as previous path
             // If so, add a reference unlock block
-            if let Some(block_index) = signature_indexes.get(&recorder.address_index) {
+
+            // Format to differentiate between public and private addresses
+            let index = format!("{}{}", recorder.address_index, recorder.internal);
+            if let Some(block_index) = signature_indexes.get(&index) {
                 unlock_blocks.push(UnlockBlock::Reference(ReferenceUnlock::new(*block_index as u16)?));
             } else {
                 // If not, we should create a signature unlock block
@@ -261,7 +266,7 @@ impl<'a> SendTransactionBuilder<'a> {
                     }
                     Seed::Wots(_) => panic!("Wots signing scheme isn't supported."),
                 }
-                signature_indexes.insert(recorder.address_index, current_block_index);
+                signature_indexes.insert(index, current_block_index);
 
                 // Update current block index
                 current_block_index += 1;

--- a/iota-client/src/api/send.rs
+++ b/iota-client/src/api/send.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Client, ClientMiner, Error, Result, Transfers};
+use crate::{Client, ClientMiner, Error, Result};
 
 use bee_common::packable::Packable;
 use bee_message::prelude::*;
@@ -90,15 +90,6 @@ impl<'a> SendTransactionBuilder<'a> {
         let output = SignatureLockedSingleOutput::new(address.parse::<Ed25519Address>()?.into(), amount).into();
         self.outputs.push(output);
         Ok(self)
-    }
-
-    /// Set transfers to the builder, addresses need to be Bech32 encoded
-    pub fn outputs(mut self, transfers: Transfers) -> Self {
-        for transfer in transfers.0 {
-            let output = SignatureLockedSingleOutput::new(transfer.0, transfer.1).into();
-            self.outputs.push(output);
-        }
-        self
     }
 
     /// Set indexation payload to the builder

--- a/iota-client/src/types.rs
+++ b/iota-client/src/types.rs
@@ -14,6 +14,7 @@ use serde::ser::Serializer;
 use std::{
     convert::{From, TryFrom, TryInto},
     io::{BufReader, Read},
+    num::NonZeroU64,
 };
 
 /// Marker trait for response
@@ -236,17 +237,20 @@ pub struct AddressBalancePair {
 ///
 /// Users could use this to construct output address with amount of iota they want to get.
 #[derive(Debug)]
-pub struct Transfers(pub Vec<(Address, u64)>);
+pub struct Transfers(pub Vec<(Address, NonZeroU64)>);
 
 impl Transfers {
     /// Create Transfers starting with one address
-    pub fn new(address: Address, amount: u64) -> Self {
-        Self(vec![(address, amount)])
+    pub fn new(address: &str, amount: NonZeroU64) -> Result<Self> {
+        let address = Address::try_from_bech32(address)?;
+        Ok(Self(vec![(address, amount)]))
     }
 
     /// Add more address to the Transfers
-    pub fn add(&mut self, address: Address, amount: u64) {
+    pub fn add(&mut self, address: &str, amount: NonZeroU64) -> Result<()> {
+        let address = Address::try_from_bech32(address)?;
         self.0.push((address, amount));
+        Ok(())
     }
 }
 

--- a/iota-client/src/types.rs
+++ b/iota-client/src/types.rs
@@ -14,7 +14,6 @@ use serde::ser::Serializer;
 use std::{
     convert::{From, TryFrom, TryInto},
     io::{BufReader, Read},
-    num::NonZeroU64,
 };
 
 /// Marker trait for response
@@ -231,27 +230,6 @@ pub struct AddressBalancePair {
     pub address: Address,
     /// Balance in the address
     pub balance: u64,
-}
-
-/// Transfers structure
-///
-/// Users could use this to construct output address with amount of iota they want to get.
-#[derive(Debug)]
-pub struct Transfers(pub Vec<(Address, NonZeroU64)>);
-
-impl Transfers {
-    /// Create Transfers starting with one address
-    pub fn new(address: &str, amount: NonZeroU64) -> Result<Self> {
-        let address = Address::try_from_bech32(address)?;
-        Ok(Self(vec![(address, amount)]))
-    }
-
-    /// Add more address to the Transfers
-    pub fn add(&mut self, address: &str, amount: NonZeroU64) -> Result<()> {
-        let address = Address::try_from_bech32(address)?;
-        self.0.push((address, amount));
-        Ok(())
-    }
 }
 
 /// JSON struct for Message

--- a/iota-client/tests/node_api.rs
+++ b/iota-client/tests/node_api.rs
@@ -102,13 +102,11 @@ async fn test_post_message_with_transaction() {
         .transaction(&seed)
         .account_index(0)
         // Insert the output address and ampunt to spent. The amount cannot be zero.
-        .output(
-            "5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8"
-                .parse::<Ed25519Address>()
-                .unwrap()
-                .into(), // Insert the address to search for
+        .output_hex(
+            "5eec99d6ee4ba21aa536c3364bbf2b587cb98a7f2565b75d948b10083e2143f8", // Insert the address to search for
             NonZeroU64::new(100).unwrap(),
         )
+        .unwrap()
         .post()
         .await
         .unwrap();

--- a/iota-client/tests/node_api.rs
+++ b/iota-client/tests/node_api.rs
@@ -262,7 +262,7 @@ async fn test_get_milestone() {
         .unwrap()
         .build()
         .unwrap()
-        .get_milestone(50265)
+        .get_milestone(3)
         .await
         .unwrap();
 


### PR DESCRIPTION
Now the send() API has the `account_index` field, which needs to be indicated whenever tokens are transferred. In the previous example, we send tokens from two different account_index at one time, which is not valid anymore.

- In the `transaction` example, we transfer 300, 300, 300 tokens to three different addresses of a user account, and then send 550 tokens from the user to another address. This example passed local tests.
- The transfers array API is removed due to redundancy.
- The Bech32 addresses are used directly in the testing and examples.