### PR TITLE
Support WASM and http client selection

### DIFF
--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -19,7 +19,7 @@ surf-wasm = ["surf", "surf/wasm-client"]
 
 [dependencies]
 bee-transaction = { git = "https://github.com/Alex6323/bee-p.git", branch = "master"}#, rev = "02965e78a5cd43d0fb773771470ab3d891066562" }#
-bee-ternary = { version = "0.3.4-alpha", git = "https://github.com/iotaledger/bee.git", features = ["serde1"], branch = "dev"}#, rev = "612fa2b9547c10f0c03a947d491db228af0fdabf" }#
+bee-ternary = { version = "0.4.0-alpha", git = "https://github.com/iotaledger/bee.git", features = ["serde1"], branch = "dev"}#, rev = "612fa2b9547c10f0c03a947d491db228af0fdabf" }#
 bee-signing = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 bee-crypto = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 #reqwest = { version = "0.10.6", features = ["json", "rustls-tls", "native-tls-vendored", "blocking"], default-features = false }

--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -19,7 +19,7 @@ surf-wasm = ["surf", "surf/wasm-client"]
 
 [dependencies]
 bee-transaction = { git = "https://github.com/Alex6323/bee-p.git", branch = "master"}#, rev = "02965e78a5cd43d0fb773771470ab3d891066562" }#
-bee-ternary = { version = "0.4.0-alpha", git = "https://github.com/iotaledger/bee.git", features = ["serde1"], branch = "dev"}#, rev = "612fa2b9547c10f0c03a947d491db228af0fdabf" }#
+bee-ternary = { version = "0.4.1-alpha", git = "https://github.com/iotaledger/bee.git", features = ["serde1"], branch = "dev"}#, rev = "612fa2b9547c10f0c03a947d491db228af0fdabf" }#
 bee-signing = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 bee-crypto = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 #reqwest = { version = "0.10.6", features = ["json", "rustls-tls", "native-tls-vendored", "blocking"], default-features = false }

--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -12,16 +12,22 @@ license = "Apache-2.0"
 [lib]
 name = "iota_client"
 
+[features]
+default = ["ureq"]
+surf-curl = ["surf", "surf/curl-client"]
+surf-wasm = ["surf", "surf/wasm-client"]
+
 [dependencies]
-bee-transaction = { git = "https://github.com/Alex6323/bee-p.git", branch = "master", rev = "02965e78a5cd43d0fb773771470ab3d891066562" }
-bee-ternary = { version = "0.3.4-alpha", git = "https://github.com/iotaledger/bee.git", branch = "dev", features = ["serde1"], rev = "612fa2b9547c10f0c03a947d491db228af0fdabf" }
+bee-transaction = { git = "https://github.com/Alex6323/bee-p.git", branch = "master"}#, rev = "02965e78a5cd43d0fb773771470ab3d891066562" }#
+bee-ternary = { version = "0.3.4-alpha", git = "https://github.com/iotaledger/bee.git", features = ["serde1"], branch = "dev"}#, rev = "612fa2b9547c10f0c03a947d491db228af0fdabf" }#
 bee-signing = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 bee-crypto = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 #reqwest = { version = "0.10.6", features = ["json", "rustls-tls", "native-tls-vendored", "blocking"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4.12"
-ureq = { version = "1.5.1", features = ["json"] }
+ureq = { version = "1.5.1", features = ["json"], optional = true }
+surf = { version = "2.1.0", default-features = false, features = [], optional = true }#"default-client"
 
 [dev-dependencies]
 anyhow = "1.0.31"

--- a/iota-client/src/builder.rs
+++ b/iota-client/src/builder.rs
@@ -3,8 +3,6 @@
 use crate::client::Client;
 use crate::error::*;
 
-use std::collections::HashSet;
-use std::iter::FromIterator;
 use std::sync::{Arc, RwLock};
 
 /// Network of the Iota nodes belong to
@@ -75,7 +73,7 @@ impl ClientBuilder {
 
     /// Build the Client instance.
     pub fn build(self) -> Result<Client> {
-        if self.nodes.len() == 0 {
+        if self.nodes.is_empty() {
             return Err(Error::MissingNode);
         }
 
@@ -96,7 +94,7 @@ impl ClientBuilder {
         };
 
         let client = Client {
-            pool: Arc::new(RwLock::new(HashSet::from_iter(self.nodes.into_iter()))),
+            pool: Arc::new(RwLock::new(self.nodes.into_iter().collect())),
             mwm,
             quorum_size,
             quorum_threshold,

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -5,7 +5,7 @@ use crate::extended::*;
 use crate::response::*;
 use crate::util::tx_trytes;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
 
 use bee_crypto::ternary::Hash;
@@ -40,15 +40,19 @@ macro_rules! response {
         surf::post(&$self.get_node()?)
             .content_type(surf::http::mime::JSON)
             .header("X-IOTA-API-Version", "1")
-            .body($body).await?
-            .body_json().await?
+            .body($body)
+            .await?
+            .body_json()
+            .await?
     };
     ($self:ident, $body:ident, $node:ident) => {
         surf::post($node)
             .content_type(surf::http::mime::JSON)
             .header("X-IOTA-API-Version", "1")
-            .body($body).await?
-            .body_json().await?
+            .body($body)
+            .await?
+            .body_json()
+            .await?
     };
 }
 
@@ -497,7 +501,7 @@ impl Client {
                 tail = false;
             }
 
-            hash = res.trunk().clone();
+            hash = *res.trunk();
             if res.index() == res.last_index() {
                 bundle.push(res);
                 break Ok(bundle);

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -16,6 +16,7 @@ use bee_transaction::bundled::{
 };
 use bee_transaction::Vertex;
 
+#[cfg(feature = "ureq")]
 macro_rules! response {
     ($self:ident, $body:ident) => {
         ureq::post(&$self.get_node()?)
@@ -30,6 +31,24 @@ macro_rules! response {
             .set("X-IOTA-API-Version", "1")
             .send_json($body)
             .into_json_deserialize()?
+    };
+}
+
+#[cfg(feature = "surf")]
+macro_rules! response {
+    ($self:ident, $body:ident) => {
+        surf::post(&$self.get_node()?)
+            .content_type(surf::http::mime::JSON)
+            .header("X-IOTA-API-Version", "1")
+            .body($body).await?
+            .body_json().await?
+    };
+    ($self:ident, $body:ident, $node:ident) => {
+        surf::post($node)
+            .content_type(surf::http::mime::JSON)
+            .header("X-IOTA-API-Version", "1")
+            .body($body).await?
+            .body_json().await?
     };
 }
 

--- a/iota-client/src/error.rs
+++ b/iota-client/src/error.rs
@@ -57,3 +57,10 @@ impl From<std::io::Error> for Error {
         Error::IoError(error)
     }
 }
+
+#[cfg(feature = "surf")]
+impl From<surf::Error> for Error {
+    fn from(error: surf::Error) -> Self {
+        error.downcast().unwrap()
+    }
+}

--- a/iota-client/src/extended/send.rs
+++ b/iota-client/src/extended/send.rs
@@ -94,7 +94,7 @@ impl<'a> SendBuilder<'a> {
             transfer = transfer.remainder(remainder);
         }
 
-        let mut trytes: Vec<Transaction> = transfer.build().await?.into_iter().map(|x| x).collect();
+        let mut trytes: Vec<Transaction> = transfer.build().await?.into_iter().collect();
         trytes.reverse();
         let mut send_trytes = self
             .client

--- a/iota-client/src/response.rs
+++ b/iota-client/src/response.rs
@@ -101,7 +101,7 @@ impl ConsistencyResponseBuilder {
         }
 
         Ok(ConsistencyResponse {
-            state: state,
+            state,
             info: self.info,
         })
     }

--- a/iota-core/Cargo.toml
+++ b/iota-core/Cargo.toml
@@ -6,15 +6,21 @@ edition = "2018"
 description = "Core library of IOTA"
 license = "Apache-2.0"
 
+[features]
+default = ["ureq"]
+ureq = ["iota-client/ureq"]
+surf-curl = ["iota-client/surf-curl"]
+surf-wasm = ["iota-client/surf-wasm"]
+
 [lib]
 name = "iota"
 
 [dependencies]
-bee-transaction = { git = "https://github.com/Alex6323/bee-p.git", branch = "master", rev = "02965e78a5cd43d0fb773771470ab3d891066562" }
-bee-ternary = { version = "0.3.4-alpha", git = "https://github.com/iotaledger/bee.git", branch = "dev", features = ["serde1"], rev = "612fa2b9547c10f0c03a947d491db228af0fdabf" }
+bee-transaction = { git = "https://github.com/Alex6323/bee-p.git", branch = "master"}#, rev = "02965e78a5cd43d0fb773771470ab3d891066562" }#
+bee-ternary = { version = "0.3.4-alpha", git = "https://github.com/iotaledger/bee.git", features = ["serde1"], branch = "dev"}#, rev = "612fa2b9547c10f0c03a947d491db228af0fdabf" }#
 bee-signing = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 bee-crypto = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
-iota-client = { version = "0.5.0-alpha", path = "../iota-client" }
+iota-client = { path = "../iota-client", default-features = false }
 
 #[features]
 #quorum = ["iota-client/quorum"]

--- a/iota-core/Cargo.toml
+++ b/iota-core/Cargo.toml
@@ -17,7 +17,7 @@ name = "iota"
 
 [dependencies]
 bee-transaction = { git = "https://github.com/Alex6323/bee-p.git", branch = "master"}#, rev = "02965e78a5cd43d0fb773771470ab3d891066562" }#
-bee-ternary = { version = "0.3.4-alpha", git = "https://github.com/iotaledger/bee.git", features = ["serde1"], branch = "dev"}#, rev = "612fa2b9547c10f0c03a947d491db228af0fdabf" }#
+bee-ternary = { version = "0.4.0-alpha", git = "https://github.com/iotaledger/bee.git", features = ["serde1"], branch = "dev"}#, rev = "612fa2b9547c10f0c03a947d491db228af0fdabf" }#
 bee-signing = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 bee-crypto = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 iota-client = { path = "../iota-client", default-features = false }

--- a/iota-core/Cargo.toml
+++ b/iota-core/Cargo.toml
@@ -17,7 +17,7 @@ name = "iota"
 
 [dependencies]
 bee-transaction = { git = "https://github.com/Alex6323/bee-p.git", branch = "master"}#, rev = "02965e78a5cd43d0fb773771470ab3d891066562" }#
-bee-ternary = { version = "0.4.0-alpha", git = "https://github.com/iotaledger/bee.git", features = ["serde1"], branch = "dev"}#, rev = "612fa2b9547c10f0c03a947d491db228af0fdabf" }#
+bee-ternary = { version = "0.4.1-alpha", git = "https://github.com/iotaledger/bee.git", features = ["serde1"], branch = "dev"}#, rev = "612fa2b9547c10f0c03a947d491db228af0fdabf" }#
 bee-signing = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 bee-crypto = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 iota-client = { path = "../iota-client", default-features = false }


### PR DESCRIPTION
The issue is lack of WASM support due to `ureq` not supporting WASM. There's `surf` http client that does support WASM. This PR adds ability to choose http client via cargo features.

By `default` `ureq` http client is used. 
`surf-curl` feature enables `surf` crate with `curl` http client. 
`surf-wasm` feature enables `surf` crate with `wasm` http client.