### PR TITLE
Bundle miner integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,6 @@
 members = [
     "iota-core",
     "iota-client",
+    "iota-bundle-miner",
     "examples",
-
-    #"bindings/c",
-    #"bindings/wasm",
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -49,3 +49,7 @@ path = "transfer_all.rs"
 [[example]]
 name = "migration"
 path = "migration.rs"
+
+[[example]]
+name = "bundle_miner"
+path = "bundle_miner.rs"

--- a/examples/bundle_miner.rs
+++ b/examples/bundle_miner.rs
@@ -1,0 +1,57 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! cargo run --example bundle_miner --release
+use iota::bundle_miner::MinerBuilder;
+use iota::ternary::{T1B1Buf, TritBuf, TryteBuf};
+
+fn main() {
+    let kown_bundle_hashes =
+        vec!["SEYZLVFTIKFROANWJDVJVOU9HZCHSHOZEIKS9CGHNHGCRUJBUEAQPBYWREUEXEAIRDXEWO9H9HXRIWVKB"];
+    let essences = vec![
+        "GPB9PBNCJTPGFZ9CCAOPCZBFMBSMMFMARZAKBMJFMTSECEBRWMGLPTYZRAFKUFOGJQVWVUPPABLTTLCIA",
+        "A99999999999999999999999999999999999999999999999999999999999999999999999B99999999",
+        "GMLRCFYRCWPZTORXSFCEGKXTVQGPFI9W9EJLERYJMEJGIPLNCLIKCCAOKQEFYUYCEUGIZKCSSJL9JD9SC",
+        "Z99999999999999999999999999999999999999999999999999999999999999A99999999B99999999",
+        "GMLRCFYRCWPZTORXSFCEGKXTVQGPFI9W9EJLERYJMEJGIPLNCLIKCCAOKQEFYUYCEUGIZKCSSJL9JD9SC",
+        "999999999999999999999999999999999999999999999999999999999999999B99999999B99999999",
+    ];
+    let security_level: usize = 3;
+    let mut miner = MinerBuilder::new()
+        .with_offset(0)
+        .with_essences_from_unsigned_bundle(
+            essences
+                .clone()
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&(*t).to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .with_security_level(security_level)
+        .with_kown_bundle_hashes(
+            kown_bundle_hashes
+                .clone()
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&(*t).to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .with_worker_count(1)
+        .with_core_thread_count(1)
+        .with_mining_timeout(40)
+        .finish()
+        .unwrap();
+    let target_crack_probability = None;
+    let threshold = None;
+    // We can set extra parameters when running the bundle miner to ease of more customized usage.
+    let miner_result = miner.run(target_crack_probability, threshold).unwrap();
+    println!("{:?}", miner_result);
+}

--- a/iota-bundle-miner/Cargo.toml
+++ b/iota-bundle-miner/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "iota-bundle-miner"
+version = "0.1.0-alpha.0"
+authors = ["bingyanglin <bingyang.lin@iota.org>"]
+edition = "2018"
+
+[lib]
+name = "iota_bundle_miner"
+
+[dependencies]
+bee-ternary = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
+bee-crypto = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
+bee-transaction = { git = "https://github.com/Alex6323/bee-p.git" }
+bee-signing = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
+tokio = { version = "0.2", features = ["rt-core", "rt-threaded", "sync", "time", "macros"] }
+futures = { version = "0.3"}
+criterion = "0.3"
+thiserror = "1.0"
+
+[[bench]]
+name = "miner_benchmark"
+harness = false

--- a/iota-bundle-miner/benches/miner_benchmark.rs
+++ b/iota-bundle-miner/benches/miner_benchmark.rs
@@ -1,0 +1,165 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use bee_ternary::TryteBuf;
+use bee_ternary::{T1B1Buf, TritBuf};
+use criterion::{criterion_group, criterion_main, Criterion};
+use iota_bundle_miner::miner::{
+    absorb_and_get_normalized_bundle_hash, create_obsolete_tag, increase_essense,
+    mining_worker_with_non_crack_probability_stop_criteria as worker, prepare_keccak_384,
+    update_essense_with_new_obsolete_tag, EqualTargetHash,
+};
+use tokio::runtime::Runtime;
+
+pub fn obsolete_tag_creation() {
+    // Create the runtime
+    let mut rt = Runtime::new().unwrap();
+
+    // Execute the future, blocking the current thread until completion
+    rt.block_on(async {
+        let increment: i64 = 3;
+        let worker_id: i32 = 0;
+        let essences = vec![
+            "EDIKZYSKVIWNNTMKWUSXKFMYQVIMBNECNYKBG9YVRKUMXNIXSVAKTIDCAHULLLXR9FSQSDDOFOJWKFACD",
+            "A99999999999999999999999999999999999999999999999999999999999999999999999C99999999",
+            "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+            "Z99999999999999999999999999999999999999999999999999999999999999A99999999C99999999",
+            "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+            "999999999999999999999999999999999999999999999999999999999999999B99999999C99999999",
+            "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+            "999999999999999999999999999999999999999999999999999999999999999C99999999C99999999",
+        ];
+        let kerl = prepare_keccak_384(
+            &essences[..essences.len() - 1]
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&t.to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .await;
+        let mut last_essence: TritBuf<T1B1Buf> =
+            TryteBuf::try_from_str(essences[essences.len() - 1])
+                .unwrap()
+                .as_trits()
+                .encode();
+
+        let obselete_tag = create_obsolete_tag(increment, worker_id).await;
+        last_essence = update_essense_with_new_obsolete_tag(last_essence, &obselete_tag).await;
+        let _hash = absorb_and_get_normalized_bundle_hash(kerl, &last_essence).await;
+    });
+}
+
+pub fn obsolete_tag_increment() {
+    // Create the runtime
+    let mut rt = Runtime::new().unwrap();
+
+    // Execute the future, blocking the current thread until completion
+    rt.block_on(async {
+        let increment: i64 = 0;
+        let worker_id: i32 = 0;
+        let essences = vec![
+            "EDIKZYSKVIWNNTMKWUSXKFMYQVIMBNECNYKBG9YVRKUMXNIXSVAKTIDCAHULLLXR9FSQSDDOFOJWKFACD",
+            "A99999999999999999999999999999999999999999999999999999999999999999999999C99999999",
+            "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+            "Z99999999999999999999999999999999999999999999999999999999999999A99999999C99999999",
+            "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+            "999999999999999999999999999999999999999999999999999999999999999B99999999C99999999",
+            "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+            "999999999999999999999999999999999999999999999999999999999999999C99999999C99999999",
+        ];
+        let kerl = prepare_keccak_384(
+            &essences[..essences.len() - 1]
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&t.to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .await;
+        let mut last_essence: TritBuf<T1B1Buf> =
+            TryteBuf::try_from_str(essences[essences.len() - 1])
+                .unwrap()
+                .as_trits()
+                .encode();
+
+        let obselete_tag = create_obsolete_tag(increment, worker_id).await;
+        last_essence = update_essense_with_new_obsolete_tag(last_essence, &obselete_tag).await;
+        let last_essence = increase_essense(last_essence).await.unwrap();
+        let last_essence = increase_essense(last_essence).await.unwrap();
+        let last_essence = increase_essense(last_essence).await.unwrap();
+        let _hash = absorb_and_get_normalized_bundle_hash(kerl, &last_essence).await;
+    });
+}
+
+pub fn mining_worker() {
+    // Create the runtime
+    let mut rt = Runtime::new().unwrap();
+
+    // Execute the future, blocking the current thread until completion
+    rt.block_on(async {
+        let increment: i64 = 0;
+        let worker_id: usize = 0;
+        let essences = vec![
+            "EDIKZYSKVIWNNTMKWUSXKFMYQVIMBNECNYKBG9YVRKUMXNIXSVAKTIDCAHULLLXR9FSQSDDOFOJWKFACD",
+            "A99999999999999999999999999999999999999999999999999999999999999999999999C99999999",
+            "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+            "Z99999999999999999999999999999999999999999999999999999999999999A99999999C99999999",
+            "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+            "999999999999999999999999999999999999999999999999999999999999999B99999999C99999999",
+            "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+            "999999999999999999999999999999999999999999999999999999999999999C99999999C99999999",
+        ];
+        let target_hash =
+            "NNNNNNFAHTZDAMSFMGDCKRWIMMVPVISUYXKTFADURMAEMTNFGBUMODCKQZPMWHUGISUOCWQQL99ZTGCJD";
+        worker(
+            increment,
+            worker_id,
+            essences
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&t.to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+            TryteBuf::try_from_str(&target_hash.to_string())
+                .unwrap()
+                .as_trits()
+                .encode(),
+            EqualTargetHash,
+        )
+        .await;
+    });
+}
+
+fn bench_tag_creation(c: &mut Criterion) {
+    c.bench_function("obsolete_tag_creation", |b| {
+        b.iter(|| obsolete_tag_creation())
+    });
+}
+
+fn bench_obsolete_tag_increment(c: &mut Criterion) {
+    c.bench_function("obsolete_tag_increment", |b| {
+        b.iter(|| obsolete_tag_increment())
+    });
+}
+
+fn bench_mining_worker(c: &mut Criterion) {
+    c.bench_function("mining_worker", |b| b.iter(|| mining_worker()));
+}
+
+criterion_group!(
+    benches,
+    bench_tag_creation,
+    bench_obsolete_tag_increment,
+    bench_mining_worker
+);
+criterion_main!(benches);

--- a/iota-bundle-miner/src/constant.rs
+++ b/iota-bundle-miner/src/constant.rs
@@ -1,0 +1,25 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use bee_crypto::ternary::bigint::{binary_representation::U32Repr, endianness::BigEndian, I384};
+
+// constants
+pub const HASH_CHUNK_LEN: usize = 27;
+pub const MAX_TRYTE_VALUE: i8 = 13;
+pub const MESSAGE_FRAGMENT_LENGTH: usize = 27;
+
+/// I384 big-endian `u32` 3^81
+pub const TRITS82_BE_U32: I384<BigEndian, U32Repr> = I384::<BigEndian, U32Repr>::from_array([
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    1,
+    1_301_861_838,
+    2_705_975_348,
+    3_065_973_865,
+    3_580_722_371,
+]);

--- a/iota-bundle-miner/src/error.rs
+++ b/iota-bundle-miner/src/error.rs
@@ -1,0 +1,50 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Error handling in iota-bundle-miner crate.
+
+/// Type alias of `Result` in iota-bundle-miner
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+/// Error type of the iota bundle miner crate.
+pub enum Error {
+    /// IO error.
+    #[error("{0}")]
+    IoError(#[from] std::io::Error),
+    /// Counters MutexGuard error.
+    #[error("Counters MutexGuard error")]
+    CounterPoisonError,
+    /// Crackability MutexGuard error.
+    #[error("Crackability MutexGuard error")]
+    CrackabilityPoisonError,
+    /// The kown bundle hashes are not set.
+    #[error("The kown bundle hashes should be set")]
+    KownBundleHashesNotSet,
+    /// The essences from unsigned bundle are not set.
+    #[error("The essences from unsigned bundle should be set")]
+    EssencesFromUnsignedBundleNotSet,
+    /// The ternary conversion error.
+    #[error("Ternary conversion error")]
+    InvalidConversion,
+    /// The essences to mine are empty.
+    #[error("The essences to mine are empty")]
+    EmptyEssenceToMine,
+    /// The normalized hashes are empty.
+    #[error("The normalized hashes are empty")]
+    EmptyNormalizedHashes,
+    /// The security level in recoverer needs to be set.
+    #[error(
+        "The recoverer security level should be set to calculate the target crack probability"
+    )]
+    RecovererSecurityLevelNotSet,
+    /// The miner should be set for recoverer.
+    #[error("The miner of the recoverer should be set")]
+    MinerInRecovererNotSet,
+}
+
+impl std::convert::From<()> for Error {
+    fn from(_: ()) -> Self {
+        Error::InvalidConversion
+    }
+}

--- a/iota-bundle-miner/src/helper.rs
+++ b/iota-bundle-miner/src/helper.rs
@@ -1,0 +1,48 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::constant::MESSAGE_FRAGMENT_LENGTH;
+use bee_signing::ternary::wots::normalize;
+use bee_ternary::{t3b1::T3B1Buf, T1B1Buf, TritBuf, Trits, T3B1};
+
+/// Get the maximum bundle hash by selecting the max trytes from all input bundle hashes
+pub fn get_max_normalized_bundle_hash(
+    bundle_hashes: &[TritBuf<T1B1Buf>],
+    security_level: usize,
+) -> TritBuf<T1B1Buf> {
+    // Normalize the bundle hashes
+    let mut normalized_hashes_i8_vecs = bundle_hashes
+        .iter()
+        .map(|t| {
+            TritBuf::<T3B1Buf>::from_i8s(normalize(&t).unwrap().as_i8_slice())
+                .unwrap()
+                .as_i8_slice()
+                .to_vec()
+        })
+        .collect::<Vec<Vec<i8>>>();
+
+    // Get the max normalized bundle hash
+    let mut max_vec_i8 = normalized_hashes_i8_vecs.pop().unwrap();
+    while let Some(current_vec_i8) = normalized_hashes_i8_vecs.pop() {
+        max_vec_i8 = get_the_max_tryte_values(max_vec_i8, current_vec_i8);
+    }
+
+    // Return the max normalized bundle hash in TritBuf::<T1B1Buf>
+    unsafe {
+        Trits::<T3B1>::from_raw_unchecked(
+            &max_vec_i8[..MESSAGE_FRAGMENT_LENGTH * security_level],
+            MESSAGE_FRAGMENT_LENGTH * security_level * 3,
+        )
+        .to_buf::<T3B1Buf>()
+        .encode::<T1B1Buf>()
+    }
+}
+
+/// Get max trytes values from two i8 vectors
+pub fn get_the_max_tryte_values(vec_i8_first: Vec<i8>, vec_i8_second: Vec<i8>) -> Vec<i8> {
+    vec_i8_first
+        .iter()
+        .zip(&vec_i8_second)
+        .map(|(&x, &y)| x.max(y))
+        .collect()
+}

--- a/iota-bundle-miner/src/lib.rs
+++ b/iota-bundle-miner/src/lib.rs
@@ -8,6 +8,6 @@ pub mod miner;
 pub mod recoverer;
 pub mod success;
 
-pub use miner::MinerBuilder;
+pub use miner::{MinerBuilder, EQUAL_TRAGET_HASH, LESS_THAN_MAX_HASH};
 pub use recoverer::RecovererBuilder;
 pub use success::success;

--- a/iota-bundle-miner/src/lib.rs
+++ b/iota-bundle-miner/src/lib.rs
@@ -3,9 +3,11 @@
 
 pub mod constant;
 pub mod error;
+pub mod helper;
 pub mod miner;
 pub mod recoverer;
 pub mod success;
 
 pub use miner::MinerBuilder;
+pub use recoverer::RecovererBuilder;
 pub use success::success;

--- a/iota-bundle-miner/src/lib.rs
+++ b/iota-bundle-miner/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod constant;
+pub mod error;
+pub mod miner;
+pub mod recoverer;
+pub mod success;
+
+pub use miner::MinerBuilder;
+pub use success::success;

--- a/iota-bundle-miner/src/miner.rs
+++ b/iota-bundle-miner/src/miner.rs
@@ -1,0 +1,801 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::constant::{HASH_CHUNK_LEN, MAX_TRYTE_VALUE, MESSAGE_FRAGMENT_LENGTH, TRITS82_BE_U32};
+use crate::error::{Error, Result};
+use crate::success;
+use bee_crypto::ternary::{
+    bigint::{binary_representation::U32Repr, endianness::BigEndian, I384, T242, T243},
+    sponge::{Kerl, Sponge},
+};
+use bee_signing::ternary::wots::normalize;
+use bee_ternary::{t3b1::T3B1Buf, Btrit, T1B1Buf, TritBuf, Trits, T3B1};
+use bee_transaction::bundled::TAG_TRIT_LEN;
+use futures::future::abortable;
+use std::{
+    convert::TryFrom,
+    sync::{Arc, Mutex},
+};
+use tokio::{runtime::Builder, sync::mpsc, task, time};
+
+/// TODO: Remove this when they are explosed to public in bee_transaction
+#[derive(Copy, Clone)]
+pub struct Offset {
+    pub start: usize,
+    pub length: usize,
+}
+
+/// TODO: Remove this when they are explosed to public in bee_transaction
+#[derive(Copy, Clone)]
+pub struct Field {
+    pub trit_offset: Offset,
+    pub tryte_offset: Offset,
+}
+
+/// TODO: Remove this when they are explosed to public in bee_transaction
+impl Field {
+    pub fn byte_start(&self) -> usize {
+        self.trit_offset.start / 5
+    }
+
+    pub fn byte_length(&self) -> usize {
+        if self.trit_offset.length % 5 == 0 {
+            self.trit_offset.length / 5
+        } else {
+            self.trit_offset.length / 5 + 1
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum MinerEvent {
+    MinedEssence(TritBuf<T1B1Buf>),
+    Timeout,
+}
+
+#[derive(Debug)]
+pub struct MinedCrackability {
+    pub crackability: f64,
+    pub mined_essence: Option<TritBuf<T1B1Buf>>,
+    pub mined_iteration: usize,
+}
+
+#[derive(Debug)]
+pub enum CrackabilityMinerEvent {
+    MinedCrackability(MinedCrackability),
+    Timeout(MinedCrackability),
+}
+
+/// TODO: Remove this when they are explosed to public in bee_transaction
+const HASH_TRYTES_COUNT: usize = 81;
+const RESERVED_NONCE_TRYTES_COUNT: usize = 42;
+
+/// Builder for a miner.
+pub struct MinerBuilder {
+    /// Bundle hashes from previous spends.
+    kown_bundle_hashes: Option<Vec<TritBuf<T1B1Buf>>>,
+
+    /// Obsolete tag offset from which to start mining. The miner will begin from this offset.
+    /// Existing obsolete tags in the unsignedBundle should be discarded.
+    offset: i64,
+
+    /// The essences from transactions of the unsigned bundle for mining.
+    essences_from_unsigned_bundle: Option<Vec<TritBuf<T1B1Buf>>>,
+
+    /// Bundle security level (usually 2).
+    security_level: usize,
+
+    /// The number of bundle fragments that should not contain a 13 (starting from bundle fragment at index 0).
+    num_13_free_fragments: Option<usize>,
+
+    /// The number of  concurrent mining workers.
+    worker_count: usize,
+
+    /// The number of used core threads in the user’s device.
+    core_thread_count: usize,
+
+    /// The seconds for mining.
+    mining_timeout: u64,
+}
+
+impl Default for MinerBuilder {
+    fn default() -> Self {
+        Self {
+            kown_bundle_hashes: None,
+            offset: 0,
+            essences_from_unsigned_bundle: None,
+            security_level: 2,
+            num_13_free_fragments: None,
+            worker_count: 1,
+            core_thread_count: 1,
+            mining_timeout: 600,
+        }
+    }
+}
+
+pub struct Miner {
+    /// Bundle hashes from previous spends.
+    kown_bundle_hashes: Vec<TritBuf<T1B1Buf>>,
+
+    /// Obsolete tag offset from which to start mining. The miner will begin from this offset.
+    /// Existing obsolete tags in the unsignedBundle should be discarded.
+    offset: i64,
+
+    /// The essences from transactions of the unsigned bundle for mining.
+    essences_from_unsigned_bundle: Vec<TritBuf<T1B1Buf>>,
+
+    /// Bundle security level (usually 2).
+    security_level: usize,
+
+    /// The number of bundle fragments that should not contain a 13 (starting from bundle fragment at index 0).
+    num_13_free_fragments: usize,
+
+    /// The number of  concurrent mining workers.
+    worker_count: usize,
+
+    /// The number of used core threads in the user’s device.
+    core_thread_count: usize,
+
+    /// The mining timeout.
+    mining_timeout: u64,
+}
+
+impl MinerBuilder {
+    /// Creates a new builder for a bundle miner.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the kown bundle hashes.
+    pub fn with_kown_bundle_hashes(mut self, kown_bundle_hashes: Vec<TritBuf<T1B1Buf>>) -> Self {
+        self.kown_bundle_hashes = Some(kown_bundle_hashes);
+        self
+    }
+
+    /// Set the offset.
+    pub fn with_offset(mut self, offset: i64) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    /// Set the essences from unsigned bundle.
+    pub fn with_essences_from_unsigned_bundle(
+        mut self,
+        essences_from_unsigned_bundle: Vec<TritBuf<T1B1Buf>>,
+    ) -> Self {
+        self.essences_from_unsigned_bundle = Some(essences_from_unsigned_bundle);
+        self
+    }
+
+    /// Set the security level.
+    pub fn with_security_level(mut self, security_level: usize) -> Self {
+        self.security_level = security_level;
+        self
+    }
+
+    /// Set the num-13-free_fragments.
+    pub fn with_num_13_free_fragments(mut self, num_13_free_fragments: usize) -> Self {
+        self.num_13_free_fragments = Some(num_13_free_fragments);
+        self
+    }
+
+    /// Set the worker count.
+    pub fn with_worker_count(mut self, worker_count: usize) -> Self {
+        self.worker_count = worker_count;
+        self
+    }
+
+    /// Set the core-thread count.
+    pub fn with_core_thread_count(mut self, core_thread_count: usize) -> Self {
+        self.core_thread_count = core_thread_count;
+        self
+    }
+
+    /// Set the mining timeout.
+    pub fn with_mining_timeout(mut self, mining_timeout: u64) -> Self {
+        self.mining_timeout = mining_timeout;
+        self
+    }
+
+    /// Builds a bundler miner.
+    pub fn finish(self) -> Result<Miner> {
+        let miner = Miner {
+            kown_bundle_hashes: match self.kown_bundle_hashes {
+                Some(hashes) => hashes,
+                None => return Err(Error::KownBundleHashesNotSet),
+            },
+            offset: self.offset,
+            essences_from_unsigned_bundle: match self.essences_from_unsigned_bundle {
+                Some(essences) => essences,
+                None => return Err(Error::EssencesFromUnsignedBundleNotSet),
+            },
+            security_level: self.security_level,
+            num_13_free_fragments: self
+                .num_13_free_fragments
+                .unwrap_or(self.security_level * HASH_CHUNK_LEN),
+            worker_count: self.worker_count,
+            core_thread_count: self.core_thread_count,
+            mining_timeout: self.mining_timeout,
+        };
+        Ok(miner)
+    }
+}
+
+/// Trait for defining the mining criteria.
+pub trait StopMiningCriteria {
+    /// Judgement function for the stop criterion.
+    fn judge(
+        &mut self,
+        mined_hash: &TritBuf<T1B1Buf>,
+        target_hash: &TritBuf<T1B1Buf>,
+    ) -> Result<bool>;
+}
+
+/// Criteria of each tryte is less then the corresponding tryte in the max hash.
+#[derive(Copy, Clone)]
+pub struct LessThanMaxHash;
+
+/// Criteria of each tryte equals to then the corresponding tryte in the target hash.
+#[derive(Copy, Clone)]
+pub struct EqualTargetHash;
+
+pub(crate) struct CrackProbabilityLessThanThresholdBuilder {
+    /// The target crack probability.
+    target_crack_probability: f64,
+    /// The mining will stop then the crack probability <= threshold.
+    threshold: f64,
+    /// The number of bundle fragments that should not contain a 13 (starting from bundle fragment at index 0).
+    num_13_free_fragments: usize,
+}
+
+impl Default for CrackProbabilityLessThanThresholdBuilder {
+    fn default() -> Self {
+        Self {
+            target_crack_probability: 1.0,
+            threshold: 0.0,
+            num_13_free_fragments: 0,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct CrackProbabilityLessThanThreshold {
+    /// The mined crack probability
+    mined_crack_probability: f64,
+    /// The mining will stop then the crack probability <= threshold.
+    threshold: f64,
+    /// The number of bundle fragments that should not contain a 13 (starting from bundle fragment at index 0).
+    num_13_free_fragments: usize,
+}
+
+impl CrackProbabilityLessThanThresholdBuilder {
+    /// Creates a new builder for a bundle miner.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+    /// Sets the target crack probability.
+    pub(crate) fn with_target_crack_probability(mut self, target_crack_probability: f64) -> Self {
+        self.target_crack_probability = target_crack_probability;
+        self
+    }
+    /// Sets the threshold of the cracker.
+    pub(crate) fn with_threshold(mut self, threshold: f64) -> Self {
+        self.threshold = threshold;
+        self
+    }
+    /// Sets the num-13-free_fragments of the cracker.
+    pub(crate) fn with_num_13_free_fragments(mut self, num_13_free_fragments: usize) -> Self {
+        self.num_13_free_fragments = num_13_free_fragments;
+        self
+    }
+    /// Builds a CrackProbabilityLessThanThreshold structure.
+    pub(crate) fn finish(mut self) -> CrackProbabilityLessThanThreshold {
+        if self.target_crack_probability >= self.threshold {
+            self.threshold = 0.99_f64 * self.target_crack_probability;
+        }
+        CrackProbabilityLessThanThreshold {
+            mined_crack_probability: 1.0_f64, // The init crackability = 1.0
+            threshold: self.threshold,
+            num_13_free_fragments: self.num_13_free_fragments,
+        }
+    }
+}
+
+/// The constant of `LessThanMaxHash` criterion.
+pub const LESS_THAN_MAX_HASH: LessThanMaxHash = LessThanMaxHash;
+
+/// The constant of `EqualTargetHash` criterion.
+pub const EQUAL_TRAGET_HASH: EqualTargetHash = EqualTargetHash;
+
+/// For `LessThanMaxHash` criterion, each tryte in mined hash should be smaller than that in the max hash.
+impl StopMiningCriteria for LessThanMaxHash {
+    fn judge(
+        &mut self,
+        mined_hash: &TritBuf<T1B1Buf>,
+        target_hash: &TritBuf<T1B1Buf>,
+    ) -> Result<bool> {
+        // Get the i8 slices from the mined bundle hash
+        let mined_bundle_hash_i8 = TritBuf::<T3B1Buf>::from_i8s(mined_hash.as_i8_slice())?
+            .as_i8_slice()
+            .to_vec();
+
+        // Get the i8 slices from the max bundle hash
+        let max_bundle_hash_i8 = TritBuf::<T3B1Buf>::from_i8s(target_hash.as_i8_slice())?
+            .as_i8_slice()
+            .to_vec();
+
+        // Check whether each tryte of mined hash is smaller than the corresponding tryte in the max hash
+        let larger_than_max_count: i8 = max_bundle_hash_i8
+            .iter()
+            .zip(&mined_bundle_hash_i8[..max_bundle_hash_i8.len()])
+            .map(|(&x, &y)| if x < y { 1 } else { 0 })
+            .collect::<Vec<i8>>()
+            .into_iter()
+            .sum();
+
+        // Return true if all of the trytes in the mined hash are smaller than those in the max hash
+        Ok(larger_than_max_count == 0)
+    }
+}
+
+/// For `EqualTargetHash` criterion, each tryte in mined hash should equal to that in the max hash.
+impl StopMiningCriteria for EqualTargetHash {
+    fn judge(
+        &mut self,
+        mined_hash: &TritBuf<T1B1Buf>,
+        target_hash: &TritBuf<T1B1Buf>,
+    ) -> Result<bool> {
+        Ok(mined_hash == target_hash)
+    }
+}
+
+/// For `CrackProbabilityLessThanThreshold` criterion, mining stops when mined_probability <= threshold
+impl StopMiningCriteria for CrackProbabilityLessThanThreshold {
+    fn judge(
+        &mut self,
+        mined_hash: &TritBuf<T1B1Buf>,
+        target_hash: &TritBuf<T1B1Buf>,
+    ) -> Result<bool> {
+        let mined_hash_trit_t3b1 = TritBuf::<T3B1Buf>::from_i8s(mined_hash.as_i8_slice())?;
+        let mined_hash_trit_t3b1_i8 = mined_hash_trit_t3b1.as_i8_slice();
+
+        let target_hash_trit_t3b1 = TritBuf::<T3B1Buf>::from_i8s(target_hash.as_i8_slice())?;
+        let target_hash_trit_t3b1_i8 = target_hash_trit_t3b1.as_i8_slice();
+
+        // We are only interested in hashes not containing 'M'
+        if mined_hash_trit_t3b1_i8[..self.num_13_free_fragments]
+            .iter()
+            .any(|&i| i == MAX_TRYTE_VALUE)
+        {
+            return Ok(false);
+        }
+
+        // Calculate the max hash
+        let max_hash = get_the_max_tryte_values(
+            mined_hash_trit_t3b1_i8.to_vec(),
+            target_hash_trit_t3b1_i8.to_vec(),
+        );
+
+        // Terminate early if we found an optimal bundle
+        // Return true when each tryte of max hash <= the corresponding tryte of the target hash
+        if !max_hash[..self.num_13_free_fragments]
+            .iter()
+            .zip(&target_hash_trit_t3b1_i8[..self.num_13_free_fragments])
+            .map(|(&x, &y)| x > y)
+            .any(|x| x)
+        {
+            return Ok(true);
+        }
+        let mut p = 1.0_f64;
+        for i in 0..(self.num_13_free_fragments / HASH_CHUNK_LEN) {
+            p *=
+                success(&max_hash[i * HASH_CHUNK_LEN..i * HASH_CHUNK_LEN + HASH_CHUNK_LEN].to_vec())
+        }
+        if self.mined_crack_probability > p {
+            self.mined_crack_probability = p;
+        }
+        Ok(p <= self.threshold)
+    }
+}
+
+impl Miner {
+    /// The minier which returns the best crackability and mined iteration.
+    pub fn run(
+        &mut self,
+        target_crack_probability: Option<f64>,
+        threshold: Option<f64>,
+    ) -> Result<CrackabilityMinerEvent> {
+        let target_hash =
+            get_max_normalized_bundle_hash(&self.kown_bundle_hashes, self.security_level);
+        let criterion = CrackProbabilityLessThanThresholdBuilder::new()
+            .with_target_crack_probability(target_crack_probability.unwrap_or(0.0))
+            .with_threshold(threshold.unwrap_or(0.0))
+            .with_num_13_free_fragments(self.num_13_free_fragments)
+            .finish();
+
+        let (tx, mut rx) = mpsc::channel(self.worker_count);
+        let counters = Arc::new(Mutex::new(vec![0; self.worker_count]));
+        let crackability = Arc::new(Mutex::new(1.0));
+        // Use the dummy essence and update in the mining_worker function
+        let best_essence = Arc::new(Mutex::new(self.essences_from_unsigned_bundle[0].clone()));
+        let mut runtime = Builder::new()
+            .threaded_scheduler()
+            .core_threads(self.core_thread_count)
+            .thread_name("bundle-miner")
+            .thread_stack_size(3 * 1024 * 1024) // TODO: configurable by user
+            .enable_time()
+            .build()?;
+        let mut abort_handles = Vec::new();
+        Ok(runtime.block_on(async {
+            for i in 0..self.worker_count {
+                let mut tx_cloned = tx.clone();
+                let (abortable_worker, abort_handle) = abortable(mining_worker(
+                    self.offset,
+                    i,
+                    self.essences_from_unsigned_bundle[..].to_vec(),
+                    target_hash.clone(),
+                    Arc::clone(&counters),
+                    Arc::clone(&crackability),
+                    Arc::clone(&best_essence),
+                    criterion,
+                ));
+                tokio::spawn(async move {
+                    if let Ok(mined_essence) = abortable_worker.await {
+                        tx_cloned
+                            .send(MinerEvent::MinedEssence(
+                                mined_essence.expect("Cannot get the mined essence"),
+                            ))
+                            .await
+                            .expect("Cannot send the MinedEssence event");
+                    }
+                });
+                abort_handles.push(abort_handle);
+            }
+            let (abortable_worker, abort_handle) = abortable(timeout_worker(self.mining_timeout));
+            let mut tx_cloned = tx.clone();
+            tokio::spawn(async move {
+                if abortable_worker.await.is_ok() {
+                    tx_cloned
+                        .send(MinerEvent::Timeout)
+                        .await
+                        .expect("Cannot send Timeout event");
+                }
+            });
+            abort_handles.push(abort_handle);
+            if let Some(event) = rx.recv().await {
+                let best_crackability =
+                    *(crackability.lock().expect("Cannot get the crackability"));
+                let mined_iteration = *(counters.lock().expect("Cannot get the counters"))
+                    .iter()
+                    .max()
+                    .expect("Cannot get the maximum iteration from counters");
+                let mined_best_essence = best_essence
+                    .lock()
+                    .expect("Cannot get the best essence")
+                    .clone();
+                match event {
+                    MinerEvent::MinedEssence(essence) => {
+                        for i in abort_handles {
+                            i.abort();
+                        }
+                        CrackabilityMinerEvent::MinedCrackability(MinedCrackability {
+                            crackability: best_crackability,
+                            mined_essence: Some(essence),
+                            mined_iteration,
+                        })
+                    }
+                    MinerEvent::Timeout => {
+                        for i in abort_handles {
+                            i.abort();
+                        }
+                        CrackabilityMinerEvent::Timeout(MinedCrackability {
+                            crackability: best_crackability,
+                            mined_essence: Some(mined_best_essence),
+                            mined_iteration,
+                        })
+                    }
+                }
+            } else {
+                unreachable!();
+            }
+        }))
+    }
+
+    /// Run the bundle miner with non-crack-probability stop criteria
+    pub fn run_with_with_non_crack_probability_stop_criteria(
+        &mut self,
+        target_hash: TritBuf<T1B1Buf>,
+        criterion: impl StopMiningCriteria + std::marker::Send + 'static + Copy,
+    ) -> MinerEvent {
+        let (tx, mut rx) = mpsc::channel(self.worker_count);
+        let mut runtime = Builder::new()
+            .threaded_scheduler()
+            .core_threads(self.core_thread_count)
+            .thread_name("miner")
+            .thread_stack_size(3 * 1024 * 1024) // TODO: configurable by user
+            .enable_time()
+            .build()
+            .unwrap();
+        let mut abort_handles = Vec::new();
+        runtime.block_on(async {
+            for i in 0..self.worker_count {
+                let mut tx_cloned = tx.clone();
+                let (abortable_worker, abort_handle) =
+                    abortable(mining_worker_with_non_crack_probability_stop_criteria(
+                        0,
+                        i,
+                        self.essences_from_unsigned_bundle[..].to_vec(),
+                        target_hash.clone(),
+                        criterion,
+                    ));
+                tokio::spawn(async move {
+                    if let Ok(mined_essence) = abortable_worker.await {
+                        tx_cloned
+                            .send(MinerEvent::MinedEssence(mined_essence))
+                            .await
+                            .unwrap();
+                    }
+                });
+                abort_handles.push(abort_handle);
+            }
+            let (abortable_worker, abort_handle) = abortable(timeout_worker(self.mining_timeout));
+            let mut tx_cloned = tx.clone();
+            tokio::spawn(async move {
+                if abortable_worker.await.is_ok() {
+                    tx_cloned.send(MinerEvent::Timeout).await.unwrap();
+                }
+            });
+            abort_handles.push(abort_handle);
+            if let Some(event) = rx.recv().await {
+                match event {
+                    MinerEvent::MinedEssence(essence) => {
+                        for i in abort_handles {
+                            i.abort();
+                        }
+                        MinerEvent::MinedEssence(essence)
+                    }
+                    MinerEvent::Timeout => {
+                        for i in abort_handles {
+                            i.abort();
+                        }
+                        MinerEvent::Timeout
+                    }
+                }
+            } else {
+                unreachable!();
+            }
+        })
+    }
+}
+
+/// The timeout worker to terminate the runtime in seconds
+pub async fn timeout_worker(seconds: u64) {
+    time::delay_for(time::Duration::from_secs(seconds)).await;
+}
+
+/// The mining worker, stop when timeout or the criterion is met
+/// Return the mined essence for the last transaction
+pub async fn mining_worker(
+    increment: i64,
+    worker_id: usize,
+    mut essences: Vec<TritBuf<T1B1Buf>>,
+    target_hash: TritBuf<T1B1Buf>,
+    counters: Arc<Mutex<Vec<usize>>>,
+    crackability: Arc<Mutex<f64>>,
+    best_essence: Arc<Mutex<TritBuf<T1B1Buf>>>,
+    mut criterion: CrackProbabilityLessThanThreshold,
+) -> Result<TritBuf<T1B1Buf>> {
+    let mut last_essence: TritBuf<T1B1Buf> = match essences.pop() {
+        Some(essence) => essence,
+        None => return Err(Error::EmptyEssenceToMine),
+    };
+    let kerl = prepare_keccak_384(&essences).await;
+    let obselete_tag = create_obsolete_tag(increment, worker_id as i32).await;
+    last_essence = update_essense_with_new_obsolete_tag(last_essence, &obselete_tag).await;
+
+    // Note that we check the last essence with `zero` incresement first
+    // While in the go-lang version the first checked essence hash `one` incresement
+    let mut mined_hash = last_essence.clone();
+    // Update the counter
+    {
+        let mut num = match counters.lock() {
+            Ok(num) => num,
+            Err(_) => return Err(Error::CounterPoisonError),
+        };
+        (*num)[worker_id] += 1;
+    }
+    while !criterion.judge(&mined_hash, &target_hash)? {
+        last_essence = increase_essense(last_essence).await?;
+        mined_hash = absorb_and_get_normalized_bundle_hash(kerl.clone(), &last_essence).await;
+        task::yield_now().await;
+        // Update the counter
+        {
+            let mut num = match counters.lock() {
+                Ok(num) => num,
+                Err(_) => return Err(Error::CounterPoisonError),
+            };
+            (*num)[worker_id] += 1;
+        }
+        // Update current best crackability
+        {
+            let mut current_best_crackability = match crackability.lock() {
+                Ok(crackability) => crackability,
+                Err(_) => return Err(Error::CrackabilityPoisonError),
+            };
+            if criterion.mined_crack_probability < *current_best_crackability {
+                *current_best_crackability = criterion.mined_crack_probability;
+                let mut current_best_essence = best_essence.lock().unwrap();
+                *current_best_essence = last_essence.clone();
+            }
+        }
+    }
+    // Finalize the best crackability
+    {
+        let mut current_best_crackability = crackability.lock().unwrap();
+        if criterion.mined_crack_probability < *current_best_crackability {
+            *current_best_crackability = criterion.mined_crack_probability;
+            let mut current_best_essence = best_essence.lock().unwrap();
+            *current_best_essence = last_essence.clone();
+        }
+    }
+    Ok(last_essence)
+}
+
+/// The mining worker, stop when timeout or the criterion is met
+/// Return the mined essence for the last transaction
+pub async fn mining_worker_with_non_crack_probability_stop_criteria(
+    increment: i64,
+    worker_id: usize,
+    mut essences: Vec<TritBuf<T1B1Buf>>,
+    target_hash: TritBuf<T1B1Buf>,
+    mut criterion: impl StopMiningCriteria,
+) -> TritBuf<T1B1Buf> {
+    let mut last_essence: TritBuf<T1B1Buf> = essences.pop().unwrap();
+    let kerl = prepare_keccak_384(&essences).await;
+    let obselete_tag = create_obsolete_tag(increment, worker_id as i32).await;
+    last_essence = update_essense_with_new_obsolete_tag(last_essence, &obselete_tag).await;
+
+    // Note that we check the last essence with `zero` incresement first
+    // While in the go-lang version the first checked essence hash `one` incresement
+    let mut mined_hash = last_essence.clone();
+    while !criterion.judge(&mined_hash, &target_hash).unwrap() {
+        last_essence = increase_essense(last_essence).await.unwrap();
+        task::yield_now().await;
+        mined_hash = absorb_and_get_normalized_bundle_hash(kerl.clone(), &last_essence).await;
+        task::yield_now().await;
+    }
+    last_essence
+}
+
+/// Absorb the input essences and return the Kerl
+pub async fn prepare_keccak_384(essences: &[TritBuf<T1B1Buf>]) -> Kerl {
+    let mut kerl = Kerl::new();
+    for essence in essences.iter() {
+        async { kerl.absorb(essence.as_slice()).unwrap() }.await;
+        task::yield_now().await;
+    }
+    kerl
+}
+
+/// Use Kerl to absorbe the last essence, sqeeze, and output the normalized hash
+pub async fn absorb_and_get_normalized_bundle_hash(
+    mut kerl: Kerl,
+    last_essence: &TritBuf<T1B1Buf>,
+) -> TritBuf<T1B1Buf> {
+    async { kerl.absorb(last_essence.as_slice()).unwrap() }.await;
+    task::yield_now().await;
+    // Return hash
+    async { normalize(&kerl.squeeze().unwrap()).unwrap() }.await
+}
+
+/// Increase the essence by 3^81, so the obselete is increased by 1
+pub async fn increase_essense(essence: TritBuf<T1B1Buf>) -> Result<TritBuf<T1B1Buf>> {
+    let mut essence_i384 = async {
+        I384::<BigEndian, U32Repr>::try_from(T243::<Btrit>::new(essence).into_t242()).unwrap()
+    }
+    .await;
+    async { essence_i384.add_inplace(TRITS82_BE_U32) }.await;
+    // Return essence
+    Ok(async {
+        T242::<Btrit>::try_from(essence_i384)
+            .unwrap()
+            .into_t243()
+            .into_inner()
+    }
+    .await)
+}
+
+/// Cast TritBuf to String for verification usage and ease of observation
+pub async fn trit_buf_to_string(trit_buf: &TritBuf<T1B1Buf>) -> Result<String> {
+    async {
+        Ok(TritBuf::<T3B1Buf>::from_i8s(trit_buf.as_i8_slice())?
+            .as_trytes()
+            .iter()
+            .map(|t| char::from(*t))
+            .collect::<String>())
+    }
+    .await
+}
+
+/// Replace the obselete tag in the essence with a new one
+pub async fn update_essense_with_new_obsolete_tag(
+    mut essence: TritBuf<T1B1Buf>,
+    obselete_tag: &TritBuf<T1B1Buf>,
+) -> TritBuf<T1B1Buf> {
+    let obselete_tag_i8s = obselete_tag.as_i8_slice();
+    let essence_i8s = unsafe { essence.as_i8_slice_mut() };
+    essence_i8s[TAG_TRIT_LEN..TAG_TRIT_LEN * 2].copy_from_slice(obselete_tag_i8s);
+    async { TritBuf::<T1B1Buf>::from_i8s(essence_i8s).unwrap() }.await
+}
+
+/// Create the obsolete tag by the increment (the 43th-81th trits) and worker_id (first 42 trits)
+pub async fn create_obsolete_tag(increment: i64, worker_id: i32) -> TritBuf<T1B1Buf> {
+    let mut zero_tritbuf = TritBuf::<T1B1Buf>::zeros(TAG_TRIT_LEN);
+    let reserved_nonce_tritbuf = async { TritBuf::<T1B1Buf>::from(increment) }.await;
+    let reserved_nonce_trits = async { reserved_nonce_tritbuf.as_i8_slice() }.await;
+    let other_essence_tritbuf = async { TritBuf::<T1B1Buf>::from(worker_id) }.await;
+    let other_essence_trits = async { other_essence_tritbuf.as_i8_slice() }.await;
+    let output = async { unsafe { zero_tritbuf.as_i8_slice_mut() } }.await;
+    let mut reserved_nonce_trits_len = async { reserved_nonce_trits.len() }.await;
+    if reserved_nonce_trits_len > RESERVED_NONCE_TRYTES_COUNT {
+        reserved_nonce_trits_len = RESERVED_NONCE_TRYTES_COUNT;
+    }
+    async { output[..reserved_nonce_trits_len].clone_from_slice(reserved_nonce_trits) }.await;
+    let mut other_trits_len = RESERVED_NONCE_TRYTES_COUNT + other_essence_trits.len();
+    if other_trits_len > HASH_TRYTES_COUNT {
+        other_trits_len = HASH_TRYTES_COUNT;
+    }
+    async {
+        output[RESERVED_NONCE_TRYTES_COUNT..other_trits_len].clone_from_slice(other_essence_trits)
+    }
+    .await;
+    async { TritBuf::<T1B1Buf>::from_i8s(output).unwrap() }.await
+}
+
+/// Get max trytes values from two i8 vectors
+pub fn get_the_max_tryte_values(vec_i8_first: Vec<i8>, vec_i8_second: Vec<i8>) -> Vec<i8> {
+    vec_i8_first
+        .iter()
+        .zip(&vec_i8_second)
+        .map(|(&x, &y)| x.max(y))
+        .collect()
+}
+
+/// Get the maximum bundle hash by selecting the max trytes from all input bundle hashes
+pub fn get_max_normalized_bundle_hash(
+    bundle_hashes: &[TritBuf<T1B1Buf>],
+    security_level: usize,
+) -> TritBuf<T1B1Buf> {
+    // Normalize the bundle hashes
+    let mut normalized_hashes_i8_vecs = bundle_hashes
+        .iter()
+        .map(|t| {
+            TritBuf::<T3B1Buf>::from_i8s(
+                normalize(&t)
+                    .expect("Hash normalization error")
+                    .as_i8_slice(),
+            )
+            .expect("Cannot convert hash from i8s")
+            .as_i8_slice()
+            .to_vec()
+        })
+        .collect::<Vec<Vec<i8>>>();
+
+    // Get the max normalized bundle hash
+    let mut max_vec_i8 = normalized_hashes_i8_vecs
+        .pop()
+        .expect("Normalized hashes are empty");
+    while let Some(current_vec_i8) = normalized_hashes_i8_vecs.pop() {
+        max_vec_i8 = get_the_max_tryte_values(max_vec_i8, current_vec_i8);
+    }
+
+    // Return the max normalized bundle hash in TritBuf::<T1B1Buf>
+    unsafe {
+        Trits::<T3B1>::from_raw_unchecked(
+            &max_vec_i8[..MESSAGE_FRAGMENT_LENGTH * security_level],
+            MESSAGE_FRAGMENT_LENGTH * security_level * 3,
+        )
+        .to_buf::<T3B1Buf>()
+        .encode::<T1B1Buf>()
+    }
+}

--- a/iota-bundle-miner/src/recoverer.rs
+++ b/iota-bundle-miner/src/recoverer.rs
@@ -1,0 +1,148 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::constant::MESSAGE_FRAGMENT_LENGTH;
+use crate::error::{Error, Result};
+use crate::{
+    miner::{CrackabilityMinerEvent, Miner},
+    success,
+};
+use bee_signing::ternary::wots::normalize;
+use bee_ternary::{t3b1::T3B1Buf, T1B1Buf, TritBuf, Trits, T3B1};
+
+/// CrackProbability estimates the probability that an attacker can successfully crack the given hashes.
+pub fn get_crack_probability(security_level: usize, bundle_hashes: &[TritBuf<T1B1Buf>]) -> f64 {
+    let max_hash = TritBuf::<T3B1Buf>::from_i8s(
+        get_max_normalized_bundle_hash(bundle_hashes, security_level).as_i8_slice(),
+    )
+    .unwrap()
+    .as_i8_slice()
+    .to_vec();
+    let mut p = 1.0_f64;
+    for i in 0..security_level {
+        p *= success(&max_hash[i * 27..i * 27 + 27].to_vec());
+    }
+    p
+}
+
+/// Builder for a recoverer.
+#[derive(Default)]
+pub struct RecovererBuilder {
+    /// The security level of the input hashes.
+    security_level: Option<usize>,
+    /// The input bundle hashes for cracking.
+    kown_bundle_hashes: Option<Vec<TritBuf<T1B1Buf>>>,
+    /// The threshold of the recoverer.
+    threshold: Option<f64>,
+    /// The bundle miner used in recoverer.
+    miner: Option<Miner>,
+}
+
+pub struct Recoverer {
+    /// The security level of the input hashes.
+    security_level: usize,
+    /// The input bundle hashes for recovering.
+    kown_bundle_hashes: Vec<TritBuf<T1B1Buf>>,
+    /// The threshold of the recoverer.
+    threshold: f64,
+    /// The bundle miner used in recoverer.
+    miner: Miner,
+}
+
+impl RecovererBuilder {
+    /// Creates a new builder for a recoverer.
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// Sets the security level of the recoverer.
+    pub fn with_security_level(mut self, security_level: usize) -> Self {
+        self.security_level.replace(security_level);
+        self
+    }
+    /// Sets the kown bundle hashes of the recoverer.
+    pub fn with_kown_bundle_hashes(mut self, kown_bundle_hashes: Vec<TritBuf<T1B1Buf>>) -> Self {
+        self.kown_bundle_hashes.replace(kown_bundle_hashes);
+        self
+    }
+    /// Sets the threshold of the recoverer.
+    pub fn with_threshold(mut self, threshold: f64) -> Self {
+        self.threshold.replace(threshold);
+        self
+    }
+    /// Sets the bundle miner of the recoverer.
+    pub fn miner(mut self, miner: Miner) -> Self {
+        self.miner.replace(miner);
+        self
+    }
+    /// Builds a recoverer.
+    pub fn finish(self) -> Result<Recoverer> {
+        Ok(Recoverer {
+            security_level: match self.security_level {
+                Some(level) => level,
+                None => return Err(Error::RecovererSecurityLevelNotSet),
+            },
+            kown_bundle_hashes: match self.kown_bundle_hashes {
+                Some(hashes) => hashes,
+                None => return Err(Error::KownBundleHashesNotSet),
+            },
+            threshold: self.threshold.unwrap_or(0.0),
+            miner: match self.miner {
+                Some(miner) => miner,
+                None => return Err(Error::MinerInRecovererNotSet),
+            },
+        })
+    }
+}
+
+impl Recoverer {
+    /// Start running mining workers
+    pub fn recover(&mut self) -> CrackabilityMinerEvent {
+        let target_crackability =
+            get_crack_probability(self.security_level, &self.kown_bundle_hashes);
+        self.miner
+            .run(Some(target_crackability), Some(self.threshold))
+            .unwrap()
+    }
+}
+
+/// Get the maximum bundle hash by selecting the max trytes from all input bundle hashes
+pub fn get_max_normalized_bundle_hash(
+    bundle_hashes: &[TritBuf<T1B1Buf>],
+    security_level: usize,
+) -> TritBuf<T1B1Buf> {
+    // Normalize the bundle hashes
+    let mut normalized_hashes_i8_vecs = bundle_hashes
+        .iter()
+        .map(|t| {
+            TritBuf::<T3B1Buf>::from_i8s(normalize(&t).unwrap().as_i8_slice())
+                .unwrap()
+                .as_i8_slice()
+                .to_vec()
+        })
+        .collect::<Vec<Vec<i8>>>();
+
+    // Get the max normalized bundle hash
+    let mut max_vec_i8 = normalized_hashes_i8_vecs.pop().unwrap();
+    while let Some(current_vec_i8) = normalized_hashes_i8_vecs.pop() {
+        max_vec_i8 = get_the_max_tryte_values(max_vec_i8, current_vec_i8);
+    }
+
+    // Return the max normalized bundle hash in TritBuf::<T1B1Buf>
+    unsafe {
+        Trits::<T3B1>::from_raw_unchecked(
+            &max_vec_i8[..MESSAGE_FRAGMENT_LENGTH * security_level],
+            MESSAGE_FRAGMENT_LENGTH * security_level * 3,
+        )
+        .to_buf::<T3B1Buf>()
+        .encode::<T1B1Buf>()
+    }
+}
+
+/// Get max trytes values from two i8 vectors
+pub fn get_the_max_tryte_values(vec_i8_first: Vec<i8>, vec_i8_second: Vec<i8>) -> Vec<i8> {
+    vec_i8_first
+        .iter()
+        .zip(&vec_i8_second)
+        .map(|(&x, &y)| x.max(y))
+        .collect()
+}

--- a/iota-bundle-miner/src/recoverer.rs
+++ b/iota-bundle-miner/src/recoverer.rs
@@ -1,14 +1,13 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::constant::MESSAGE_FRAGMENT_LENGTH;
 use crate::error::{Error, Result};
+use crate::helper::get_max_normalized_bundle_hash;
 use crate::{
     miner::{CrackabilityMinerEvent, Miner},
     success,
 };
-use bee_signing::ternary::wots::normalize;
-use bee_ternary::{t3b1::T3B1Buf, T1B1Buf, TritBuf, Trits, T3B1};
+use bee_ternary::{t3b1::T3B1Buf, T1B1Buf, TritBuf};
 
 /// CrackProbability estimates the probability that an attacker can successfully crack the given hashes.
 pub fn get_crack_probability(security_level: usize, bundle_hashes: &[TritBuf<T1B1Buf>]) -> f64 {
@@ -103,46 +102,4 @@ impl Recoverer {
             .run(Some(target_crackability), Some(self.threshold))
             .unwrap()
     }
-}
-
-/// Get the maximum bundle hash by selecting the max trytes from all input bundle hashes
-pub fn get_max_normalized_bundle_hash(
-    bundle_hashes: &[TritBuf<T1B1Buf>],
-    security_level: usize,
-) -> TritBuf<T1B1Buf> {
-    // Normalize the bundle hashes
-    let mut normalized_hashes_i8_vecs = bundle_hashes
-        .iter()
-        .map(|t| {
-            TritBuf::<T3B1Buf>::from_i8s(normalize(&t).unwrap().as_i8_slice())
-                .unwrap()
-                .as_i8_slice()
-                .to_vec()
-        })
-        .collect::<Vec<Vec<i8>>>();
-
-    // Get the max normalized bundle hash
-    let mut max_vec_i8 = normalized_hashes_i8_vecs.pop().unwrap();
-    while let Some(current_vec_i8) = normalized_hashes_i8_vecs.pop() {
-        max_vec_i8 = get_the_max_tryte_values(max_vec_i8, current_vec_i8);
-    }
-
-    // Return the max normalized bundle hash in TritBuf::<T1B1Buf>
-    unsafe {
-        Trits::<T3B1>::from_raw_unchecked(
-            &max_vec_i8[..MESSAGE_FRAGMENT_LENGTH * security_level],
-            MESSAGE_FRAGMENT_LENGTH * security_level * 3,
-        )
-        .to_buf::<T3B1Buf>()
-        .encode::<T1B1Buf>()
-    }
-}
-
-/// Get max trytes values from two i8 vectors
-pub fn get_the_max_tryte_values(vec_i8_first: Vec<i8>, vec_i8_second: Vec<i8>) -> Vec<i8> {
-    vec_i8_first
-        .iter()
-        .zip(&vec_i8_second)
-        .map(|(&x, &y)| x.max(y))
-        .collect()
 }

--- a/iota-bundle-miner/src/success.rs
+++ b/iota-bundle-miner/src/success.rs
@@ -1,0 +1,79 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub fn success(chunk: &[i8]) -> f64 {
+    let p = prod(chunk);
+    let sum_1 = sum_half(chunk);
+    let sum_2 = sum_square(chunk);
+    term_28(chunk, &sum_1, &sum_2, &p)
+        + term_29(&sum_1, &sum_2, &p)
+        + term_30(&chunk, &sum_1, &sum_2, &p)
+}
+
+pub fn prod(chunk: &[i8]) -> Vec<f64> {
+    let mut p: f64 = 1.0;
+    let mut result: Vec<f64> = chunk
+        .iter()
+        .rev()
+        .map(|&x| {
+            p *= (14.0_f64 + f64::from(x)) / 27.0_f64;
+            p
+        })
+        .collect();
+    result.reverse();
+    result
+}
+
+pub fn sum_half(chunk: &[i8]) -> Vec<f64> {
+    let mut s: f64 = 0.0;
+    let mut result: Vec<f64> = chunk
+        .iter()
+        .rev()
+        .map(|&x| {
+            s += (13.0_f64 - f64::from(x)) / 2.0_f64;
+            s
+        })
+        .collect();
+    result.reverse();
+    result
+}
+
+pub fn sum_square(chunk: &[i8]) -> Vec<f64> {
+    let mut s: f64 = 0.0;
+    let mut result: Vec<f64> = chunk
+        .iter()
+        .rev()
+        .map(|&x| {
+            s += (f64::from(x) + 13.0_f64).powf(2.0);
+            s
+        })
+        .collect();
+    result.reverse();
+    result
+}
+
+pub fn term_28(chunk: &[i8], sum_1: &[f64], sum_2: &[f64], p: &[f64]) -> f64 {
+    (-2.0_f64 * (f64::from(-chunk[0]) + sum_1[1]).powf(2.0) / sum_2[1]).exp() * p[0]
+}
+
+pub fn term_29(sum_1: &[f64], sum_2: &[f64], p: &[f64]) -> f64 {
+    let mut s = 0.0_f64;
+    for i in 2..14 {
+        s += (-2.0f64 * (13.0_f64 * ((i - 1) as f64) + sum_1[i - 1]).powf(2.0) / sum_2[i - 1])
+            .exp()
+            * p[i - 1];
+    }
+    s
+}
+
+pub fn term_30(chunk: &[i8], sum_1: &[f64], sum_2: &[f64], p: &[f64]) -> f64 {
+    let mut s = 0.0_f64;
+    for i in 1..14 {
+        let c = f64::from(chunk[i - 1]);
+        s += (-2.0f64 * (13.0_f64 * ((i - 1) as f64) - c + sum_1[i]).powf(2.0) / sum_2[i]).exp()
+            * (13.0_f64 - c)
+            / 27.0_f64
+            * p[i];
+    }
+    s
+}

--- a/iota-bundle-miner/tests/helper.rs
+++ b/iota-bundle-miner/tests/helper.rs
@@ -1,0 +1,65 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use bee_ternary::{T1B1Buf, T3B1Buf, TritBuf, Trits, TryteBuf, T3B1};
+use iota_bundle_miner::miner::trit_buf_to_string;
+use iota_bundle_miner::recoverer::{get_max_normalized_bundle_hash, get_the_max_tryte_values};
+
+#[tokio::test]
+pub async fn test_get_max_normalized_bundle_hash() {
+    let hashes_test = [
+        "MDBHGHUGQJCHGYHZENKOHOIZSFN9XYECIYWDVGAAAEBTOGOCVVHKQQBCBWZHYEBJDNWIBQJS9DBVLZGG9",
+        "IQRMJSRFJXAAKJQOBELVKKILRGNGGJVWBL9WIJTWYHUUUKNHVZAGEZYRNW9TEPTFZNGZEIILESTGPH9KC",
+        "UJAIQGLESRZUEOL9DUZLACRQAFKGXUDGSXCLPICDADVCCAXJSASL9LNFKWVGPLGHERGDIXVKFWULZEQ9C",
+    ];
+    let max_hash_expected = "NWAIJHLGJJCHKJL9EELLKKILAGK";
+    let security_level = 1;
+    let hashes_trit_buf_test = hashes_test
+        .clone()
+        .iter()
+        .map(|t| {
+            TryteBuf::try_from_str(&(*t).to_string())
+                .unwrap()
+                .as_trits()
+                .encode()
+        })
+        .collect::<Vec<TritBuf<T1B1Buf>>>();
+    let max_hash_computed = get_max_normalized_bundle_hash(&hashes_trit_buf_test, security_level);
+    assert_eq!(
+        String::from(max_hash_expected),
+        trit_buf_to_string(&max_hash_computed).await.unwrap()
+    );
+}
+
+#[tokio::test]
+pub async fn test_get_the_max_tryte_values() {
+    let hashes_test = [
+        "MDBHGHUGQJCHGYHZENKOHOIZSFN9XYECIYWDVGAAAEBTOGOCVVHKQQBCBWZHYEBJDNWIBQJS9DBVLZGG9",
+        "IQRMJSRFJXAAKJQOBELVKKILRGNGGJVWBL9WIJTWYHUUUKNHVZAGEZYRNW9TEPTFZNGZEIILESTGPH9KC",
+    ];
+    let max_hash_expected =
+        "MDBMJHUGJJCHKJHZEELVKKILSGNGGJECIL9DIJAAAHBUUKOHVZHKEZBCBW9HEEBJDNGIEIJLEDBGLHGKC";
+    let hashes_tryte_i8_test = hashes_test
+        .clone()
+        .iter()
+        .map(|t| {
+            TryteBuf::try_from_str(&(*t).to_string())
+                .unwrap()
+                .as_trits()
+                .encode()
+        })
+        .collect::<Vec<TritBuf<T3B1Buf>>>();
+    let max_hash = get_the_max_tryte_values(
+        hashes_tryte_i8_test[0].as_i8_slice().to_vec(),
+        hashes_tryte_i8_test[1].as_i8_slice().to_vec(),
+    );
+    let max_hash_computed = unsafe {
+        Trits::<T3B1>::from_raw_unchecked(&max_hash, max_hash.len() * 3)
+            .to_buf::<T3B1Buf>()
+            .encode::<T1B1Buf>()
+    };
+    assert_eq!(
+        String::from(max_hash_expected),
+        trit_buf_to_string(&max_hash_computed).await.unwrap()
+    );
+}

--- a/iota-bundle-miner/tests/helper.rs
+++ b/iota-bundle-miner/tests/helper.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bee_ternary::{T1B1Buf, T3B1Buf, TritBuf, Trits, TryteBuf, T3B1};
+use iota_bundle_miner::helper::{get_max_normalized_bundle_hash, get_the_max_tryte_values};
 use iota_bundle_miner::miner::trit_buf_to_string;
-use iota_bundle_miner::recoverer::{get_max_normalized_bundle_hash, get_the_max_tryte_values};
 
 #[tokio::test]
 pub async fn test_get_max_normalized_bundle_hash() {

--- a/iota-bundle-miner/tests/miner.rs
+++ b/iota-bundle-miner/tests/miner.rs
@@ -1,0 +1,338 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use bee_ternary::{T1B1Buf, TritBuf, TryteBuf};
+use iota_bundle_miner::miner::{
+    absorb_and_get_normalized_bundle_hash, create_obsolete_tag, increase_essense,
+    mining_worker_with_non_crack_probability_stop_criteria, prepare_keccak_384, trit_buf_to_string,
+    update_essense_with_new_obsolete_tag, MinerBuilder, MinerEvent, StopMiningCriteria,
+    EQUAL_TRAGET_HASH, LESS_THAN_MAX_HASH,
+};
+
+#[tokio::test]
+pub async fn test_obsolete_tag_creation() {
+    let increment: i64 = 3;
+    let worker_id: i32 = 0;
+    let essences = vec![
+        "EDIKZYSKVIWNNTMKWUSXKFMYQVIMBNECNYKBG9YVRKUMXNIXSVAKTIDCAHULLLXR9FSQSDDOFOJWKFACD",
+        "A99999999999999999999999999999999999999999999999999999999999999999999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "Z99999999999999999999999999999999999999999999999999999999999999A99999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "999999999999999999999999999999999999999999999999999999999999999B99999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "999999999999999999999999999999999999999999999999999999999999999C99999999C99999999",
+    ];
+    let target_hash =
+        "NNNNNNFAHTZDAMSFMGDCKRWIMMVPVISUYXKTFADURMAEMTNFGBUMODCKQZPMWHUGISUOCWQQL99ZTGCJD";
+    let kerl = prepare_keccak_384(
+        &essences[..essences.len() - 1]
+            .iter()
+            .map(|t| {
+                TryteBuf::try_from_str(&t.to_string())
+                    .unwrap()
+                    .as_trits()
+                    .encode()
+            })
+            .collect::<Vec<TritBuf<T1B1Buf>>>(),
+    )
+    .await;
+    let mut last_essence: TritBuf<T1B1Buf> = TryteBuf::try_from_str(essences[essences.len() - 1])
+        .unwrap()
+        .as_trits()
+        .encode();
+
+    let obselete_tag = create_obsolete_tag(increment, worker_id).await;
+    last_essence = update_essense_with_new_obsolete_tag(last_essence, &obselete_tag).await;
+    let hash = absorb_and_get_normalized_bundle_hash(kerl, &last_essence).await;
+
+    let hash_str = trit_buf_to_string(&hash).await.unwrap();
+    assert_eq!(String::from(target_hash), hash_str);
+}
+
+#[tokio::test]
+pub async fn test_obsolete_tag_increment() {
+    let increment: i64 = 0;
+    let worker_id: i32 = 0;
+    let essences = vec![
+        "EDIKZYSKVIWNNTMKWUSXKFMYQVIMBNECNYKBG9YVRKUMXNIXSVAKTIDCAHULLLXR9FSQSDDOFOJWKFACD",
+        "A99999999999999999999999999999999999999999999999999999999999999999999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "Z99999999999999999999999999999999999999999999999999999999999999A99999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "999999999999999999999999999999999999999999999999999999999999999B99999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "999999999999999999999999999999999999999999999999999999999999999C99999999C99999999",
+    ];
+    let target_hash =
+        "NNNNNNFAHTZDAMSFMGDCKRWIMMVPVISUYXKTFADURMAEMTNFGBUMODCKQZPMWHUGISUOCWQQL99ZTGCJD";
+    let kerl = prepare_keccak_384(
+        &essences[..essences.len() - 1]
+            .iter()
+            .map(|t| {
+                TryteBuf::try_from_str(&t.to_string())
+                    .unwrap()
+                    .as_trits()
+                    .encode()
+            })
+            .collect::<Vec<TritBuf<T1B1Buf>>>(),
+    )
+    .await;
+    let mut last_essence: TritBuf<T1B1Buf> = TryteBuf::try_from_str(essences[essences.len() - 1])
+        .unwrap()
+        .as_trits()
+        .encode();
+
+    let obselete_tag = create_obsolete_tag(increment, worker_id).await;
+    last_essence = update_essense_with_new_obsolete_tag(last_essence, &obselete_tag).await;
+    let last_essence = increase_essense(last_essence).await.unwrap();
+    let last_essence = increase_essense(last_essence).await.unwrap();
+    let last_essence = increase_essense(last_essence).await.unwrap();
+    let hash = absorb_and_get_normalized_bundle_hash(kerl, &last_essence).await;
+
+    let hash_str = trit_buf_to_string(&hash).await.unwrap();
+    assert_eq!(String::from(target_hash), hash_str);
+}
+
+#[tokio::test]
+pub async fn test_worker() {
+    let increment: i64 = 0;
+    let worker_id: usize = 0;
+    let essences = vec![
+        "EDIKZYSKVIWNNTMKWUSXKFMYQVIMBNECNYKBG9YVRKUMXNIXSVAKTIDCAHULLLXR9FSQSDDOFOJWKFACD",
+        "A99999999999999999999999999999999999999999999999999999999999999999999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "Z99999999999999999999999999999999999999999999999999999999999999A99999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "999999999999999999999999999999999999999999999999999999999999999B99999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "999999999999999999999999999999999999999999999999999999999999999C99999999C99999999",
+    ];
+    let target_hash =
+        "NNNNNNFAHTZDAMSFMGDCKRWIMMVPVISUYXKTFADURMAEMTNFGBUMODCKQZPMWHUGISUOCWQQL99ZTGCJD";
+
+    mining_worker_with_non_crack_probability_stop_criteria(
+        increment,
+        worker_id,
+        essences
+            .iter()
+            .map(|t| {
+                TryteBuf::try_from_str(&t.to_string())
+                    .unwrap()
+                    .as_trits()
+                    .encode()
+            })
+            .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        TryteBuf::try_from_str(&target_hash.to_string())
+            .unwrap()
+            .as_trits()
+            .encode(),
+        EQUAL_TRAGET_HASH,
+    )
+    .await;
+}
+
+#[test]
+pub fn test_equal_target_hash_criterion() {
+    let mined_hash = "NWAIJHLGJJCHKJL9EELLKKILAGK";
+    let target_hash_true = "NWAIJHLGJJCHKJL9EELLKKILAGK";
+    let target_hash_false = "NWAIJHLGJJCHK9L9EELLKKILAGK";
+    let target_hash_true_trit_buf = TryteBuf::try_from_str(&target_hash_true.to_string())
+        .unwrap()
+        .as_trits()
+        .encode();
+    let target_hash_false_trit_buf = TryteBuf::try_from_str(&target_hash_false.to_string())
+        .unwrap()
+        .as_trits()
+        .encode();
+    let mined_hash_trit_buf = TryteBuf::try_from_str(&mined_hash.to_string())
+        .unwrap()
+        .as_trits()
+        .encode();
+    assert_eq!(
+        true,
+        LESS_THAN_MAX_HASH
+            .judge(&mined_hash_trit_buf, &target_hash_true_trit_buf)
+            .unwrap()
+    );
+    assert_eq!(
+        false,
+        LESS_THAN_MAX_HASH
+            .judge(&mined_hash_trit_buf, &target_hash_false_trit_buf)
+            .unwrap()
+    );
+}
+
+#[test]
+pub fn test_less_than_max_hash_criterion() {
+    let max_hash_true = "NWAIJHLGJJCHKJL9EELLKKILAGK";
+    let max_hash_false = "NOPGBAGZHGZBJZHUC9TR9HFNTFE";
+    let mined_hash =
+        "NOPGBAGZHGZBJZHUC9TR9HFOTFEZXOCUJOUXVVMXMB9JJTYKGLOATSMMMJNU9IQHSWVEHBKOONQAZENGB";
+    let max_hash_true_trit_buf = TryteBuf::try_from_str(&max_hash_true.to_string())
+        .unwrap()
+        .as_trits()
+        .encode();
+    let max_hash_false_trit_buf = TryteBuf::try_from_str(&max_hash_false.to_string())
+        .unwrap()
+        .as_trits()
+        .encode();
+    let mined_hash_trit_buf = TryteBuf::try_from_str(&mined_hash.to_string())
+        .unwrap()
+        .as_trits()
+        .encode();
+    assert_eq!(
+        true,
+        LESS_THAN_MAX_HASH
+            .judge(&mined_hash_trit_buf, &max_hash_true_trit_buf)
+            .unwrap()
+    );
+    assert_eq!(
+        false,
+        LESS_THAN_MAX_HASH
+            .judge(&mined_hash_trit_buf, &max_hash_false_trit_buf)
+            .unwrap()
+    );
+}
+
+#[test]
+pub fn test_miner_builder() {
+    let essences = vec![
+        "EDIKZYSKVIWNNTMKWUSXKFMYQVIMBNECNYKBG9YVRKUMXNIXSVAKTIDCAHULLLXR9FSQSDDOFOJWKFACD",
+        "A99999999999999999999999999999999999999999999999999999999999999999999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "Z99999999999999999999999999999999999999999999999999999999999999A99999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "999999999999999999999999999999999999999999999999999999999999999B99999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "999999999999999999999999999999999999999999999999999999999999999C99999999C99999999",
+    ];
+
+    let _ = MinerBuilder::new()
+        .with_kown_bundle_hashes(vec![])
+        .with_core_thread_count(1)
+        .with_worker_count(5)
+        .with_essences_from_unsigned_bundle(
+            essences
+                .clone()
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&(*t).to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .with_mining_timeout(10)
+        .finish()
+        .unwrap();
+}
+
+#[test]
+pub fn test_miner_equal_target_hash_run() {
+    let essences = vec![
+        "EDIKZYSKVIWNNTMKWUSXKFMYQVIMBNECNYKBG9YVRKUMXNIXSVAKTIDCAHULLLXR9FSQSDDOFOJWKFACD",
+        "A99999999999999999999999999999999999999999999999999999999999999999999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "Z99999999999999999999999999999999999999999999999999999999999999A99999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "999999999999999999999999999999999999999999999999999999999999999B99999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "999999999999999999999999999999999999999999999999999999999999999C99999999C99999999",
+    ];
+    let target_hash =
+        "NNNNNNFAHTZDAMSFMGDCKRWIMMVPVISUYXKTFADURMAEMTNFGBUMODCKQZPMWHUGISUOCWQQL99ZTGCJD";
+    let expected_essence =
+        "999999999999999999999999999C99999999999999999999999999999999999C99999999C99999999";
+    let expected_essence: TritBuf<T1B1Buf> = TryteBuf::try_from_str(&expected_essence.to_string())
+        .unwrap()
+        .as_trits()
+        .encode();
+    let mut miner = MinerBuilder::new()
+        .with_kown_bundle_hashes(vec![])
+        .with_core_thread_count(1)
+        .with_worker_count(5)
+        .with_essences_from_unsigned_bundle(
+            essences
+                .clone()
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&(*t).to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .with_mining_timeout(10)
+        .finish()
+        .unwrap();
+    if let MinerEvent::MinedEssence(mined_essence) = miner
+        .run_with_with_non_crack_probability_stop_criteria(
+            TryteBuf::try_from_str(&target_hash.to_string())
+                .unwrap()
+                .as_trits()
+                .encode(),
+            EQUAL_TRAGET_HASH,
+        )
+    {
+        assert_eq!(mined_essence, expected_essence);
+    } else {
+        panic!();
+    }
+}
+
+#[test]
+pub fn test_miner_less_than_max_hash_run() {
+    let essences = vec![
+        "EDIKZYSKVIWNNTMKWUSXKFMYQVIMBNECNYKBG9YVRKUMXNIXSVAKTIDCAHULLLXR9FSQSDDOFOJWKFACD",
+        "A99999999999999999999999999999999999999999999999999999999999999999999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "Z99999999999999999999999999999999999999999999999999999999999999A99999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "999999999999999999999999999999999999999999999999999999999999999B99999999C99999999",
+        "BMLAF9QKVBYJTGHTGFFNOVDTGEMA9MSXGTJYSRRHEYTMMKRMQYETPJVAADGYLPYMGBJERKLJVUZUZYRQD",
+        "999999999999999999999999999999999999999999999999999999999999999C99999999C99999999",
+    ];
+    let target_hash =
+        "NNNNNNFAHTZDAMSFMGDCKRWIMMVPVISUYXKTFADURMAEMTNFGBUMODCKQZPMWHUGISUOCWQQL99ZTGCJD";
+    let expected_essence =
+        "999999999999999999999999999C99999999999999999999999999999999999C99999999C99999999";
+    let expected_essence: TritBuf<T1B1Buf> = TryteBuf::try_from_str(&expected_essence.to_string())
+        .unwrap()
+        .as_trits()
+        .encode();
+    let mut miner = MinerBuilder::new()
+        .with_kown_bundle_hashes(vec![])
+        .with_core_thread_count(1)
+        .with_worker_count(5)
+        .with_essences_from_unsigned_bundle(
+            essences
+                .clone()
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&(*t).to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .with_mining_timeout(10)
+        .finish()
+        .unwrap();
+    if let MinerEvent::MinedEssence(mined_essence) = miner
+        .run_with_with_non_crack_probability_stop_criteria(
+            TryteBuf::try_from_str(&target_hash.to_string())
+                .unwrap()
+                .as_trits()
+                .encode(),
+            LESS_THAN_MAX_HASH,
+        )
+    {
+        assert_eq!(mined_essence, expected_essence);
+    } else {
+        panic!();
+    }
+}

--- a/iota-bundle-miner/tests/recoverer.rs
+++ b/iota-bundle-miner/tests/recoverer.rs
@@ -1,0 +1,220 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use bee_ternary::{T1B1Buf, TritBuf, TryteBuf};
+use iota_bundle_miner::{
+    miner::{CrackabilityMinerEvent, MinerBuilder},
+    recoverer::{get_crack_probability, RecovererBuilder},
+};
+
+#[test]
+pub fn test_get_crack_probability_security_1() {
+    let hashes_test =
+        ["SEYZLVFTIKFROANWJDVJVOU9HZCHSHOZEIKS9CGHNHGCRUJBUEAQPBYWREUEXEAIRDXEWO9H9HXRIWVKB"];
+    let hashes_trit_i8_test = hashes_test
+        .clone()
+        .iter()
+        .map(|t| {
+            TryteBuf::try_from_str(&(*t).to_string())
+                .unwrap()
+                .as_trits()
+                .encode()
+        })
+        .collect::<Vec<TritBuf<T1B1Buf>>>();
+    let security_level = 1;
+    let p_actual = get_crack_probability(security_level, &hashes_trit_i8_test);
+    let p_expected = 9.77707241082429544488650258100839580e-15_f64;
+    assert_eq!(true, (p_expected - p_actual).abs() < p_expected * 1e-9);
+}
+
+#[test]
+pub fn test_get_crack_probability_security_2() {
+    let hashes_test =
+        ["SEYZLVFTIKFROANWJDVJVOU9HZCHSHOZEIKS9CGHNHGCRUJBUEAQPBYWREUEXEAIRDXEWO9H9HXRIWVKB"];
+    let hashes_trit_i8_test = hashes_test
+        .clone()
+        .iter()
+        .map(|t| {
+            TryteBuf::try_from_str(&(*t).to_string())
+                .unwrap()
+                .as_trits()
+                .encode()
+        })
+        .collect::<Vec<TritBuf<T1B1Buf>>>();
+    let security_level = 2;
+    let p_actual = get_crack_probability(security_level, &hashes_trit_i8_test);
+    let p_expected = 6.3270996534167465314983e-28_f64;
+    assert_eq!(true, (p_expected - p_actual).abs() < p_expected * 1e-9);
+}
+
+#[test]
+pub fn test_get_crack_probability_security_3() {
+    let hashes_test =
+        ["SEYZLVFTIKFROANWJDVJVOU9HZCHSHOZEIKS9CGHNHGCRUJBUEAQPBYWREUEXEAIRDXEWO9H9HXRIWVKB"];
+    let hashes_trit_i8_test = hashes_test
+        .clone()
+        .iter()
+        .map(|t| {
+            TryteBuf::try_from_str(&(*t).to_string())
+                .unwrap()
+                .as_trits()
+                .encode()
+        })
+        .collect::<Vec<TritBuf<T1B1Buf>>>();
+    let security_level = 3;
+    let p_actual = get_crack_probability(security_level, &hashes_trit_i8_test);
+    let p_expected = 1.1704004458e-40_f64;
+    assert_eq!(true, (p_expected - p_actual).abs() < p_expected * 1e-9);
+}
+
+#[test]
+pub fn test_recoverer_run_security_1() {
+    let kown_bundle_hashes =
+        vec!["SEYZLVFTIKFROANWJDVJVOU9HZCHSHOZEIKS9CGHNHGCRUJBUEAQPBYWREUEXEAIRDXEWO9H9HXRIWVKB"];
+    let essences = vec![
+        "GPB9PBNCJTPGFZ9CCAOPCZBFMBSMMFMARZAKBMJFMTSECEBRWMGLPTYZRAFKUFOGJQVWVUPPABLTTLCIA",
+        "A99999999999999999999999999999999999999999999999999999999999999999999999A99999999",
+        "GMLRCFYRCWPZTORXSFCEGKXTVQGPFI9W9EJLERYJMEJGIPLNCLIKCCAOKQEFYUYCEUGIZKCSSJL9JD9SC",
+        "Z99999999999999999999999999999999999999999999999999999999999999A99999999A99999999",
+    ];
+    let security_level: usize = 1;
+    let mined_iteration_expected: usize = 185;
+    let mined_crackability_expected: f64 = 8.99389659655018e-9;
+    let miner = MinerBuilder::new()
+        .with_kown_bundle_hashes(
+            kown_bundle_hashes
+                .clone()
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&(*t).to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .with_security_level(security_level)
+        .with_core_thread_count(1)
+        .with_worker_count(1)
+        .with_essences_from_unsigned_bundle(
+            essences
+                .clone()
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&(*t).to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .with_mining_timeout(20)
+        .finish()
+        .unwrap();
+    let mut recoverer = RecovererBuilder::new()
+        .with_security_level(security_level)
+        .with_kown_bundle_hashes(
+            kown_bundle_hashes
+                .clone()
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&(*t).to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .with_threshold(1e-8_f64)
+        .miner(miner)
+        .finish()
+        .unwrap();
+
+    if let CrackabilityMinerEvent::MinedCrackability(mined_info) = recoverer.recover() {
+        assert_eq!(mined_iteration_expected, mined_info.mined_iteration);
+        assert_eq!(
+            true,
+            (mined_crackability_expected - mined_info.crackability).abs()
+                < mined_crackability_expected * 1e-9
+        );
+    } else {
+        panic!();
+    }
+}
+
+#[test]
+pub fn test_recoverer_run_security_2() {
+    let kown_bundle_hashes =
+        vec!["SEYZLVFTIKFROANWJDVJVOU9HZCHSHOZEIKS9CGHNHGCRUJBUEAQPBYWREUEXEAIRDXEWO9H9HXRIWVKB"];
+    let essences = vec![
+        "GPB9PBNCJTPGFZ9CCAOPCZBFMBSMMFMARZAKBMJFMTSECEBRWMGLPTYZRAFKUFOGJQVWVUPPABLTTLCIA",
+        "A99999999999999999999999999999999999999999999999999999999999999999999999B99999999",
+        "GMLRCFYRCWPZTORXSFCEGKXTVQGPFI9W9EJLERYJMEJGIPLNCLIKCCAOKQEFYUYCEUGIZKCSSJL9JD9SC",
+        "Z99999999999999999999999999999999999999999999999999999999999999A99999999B99999999",
+        "GMLRCFYRCWPZTORXSFCEGKXTVQGPFI9W9EJLERYJMEJGIPLNCLIKCCAOKQEFYUYCEUGIZKCSSJL9JD9SC",
+        "999999999999999999999999999999999999999999999999999999999999999B99999999B99999999",
+    ];
+    let security_level: usize = 2;
+    let mined_iteration_expected: usize = 28925;
+    let mined_crackability_expected: f64 = 9.2430303968744906557891424497679297e-16;
+    let miner = MinerBuilder::new()
+        .with_kown_bundle_hashes(
+            kown_bundle_hashes
+                .clone()
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&(*t).to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .with_security_level(security_level)
+        .with_core_thread_count(1)
+        .with_worker_count(1)
+        .with_essences_from_unsigned_bundle(
+            essences
+                .clone()
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&(*t).to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .with_mining_timeout(30)
+        .finish()
+        .unwrap();
+    let mut recoverer = RecovererBuilder::new()
+        .with_security_level(security_level)
+        .with_kown_bundle_hashes(
+            kown_bundle_hashes
+                .clone()
+                .iter()
+                .map(|t| {
+                    TryteBuf::try_from_str(&(*t).to_string())
+                        .unwrap()
+                        .as_trits()
+                        .encode()
+                })
+                .collect::<Vec<TritBuf<T1B1Buf>>>(),
+        )
+        .with_threshold(1e-15_f64)
+        .miner(miner)
+        .finish()
+        .unwrap();
+
+    if let CrackabilityMinerEvent::MinedCrackability(mined_info) = recoverer.recover() {
+        assert_eq!(mined_iteration_expected, mined_info.mined_iteration);
+        assert_eq!(
+            true,
+            (mined_crackability_expected - mined_info.crackability).abs()
+                < mined_crackability_expected * 1e-9
+        );
+    } else {
+        panic!();
+    }
+}

--- a/iota-bundle-miner/tests/success.rs
+++ b/iota-bundle-miner/tests/success.rs
@@ -1,0 +1,22 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_bundle_miner::success;
+
+#[test]
+pub fn test_success() {
+    let chunk: Vec<i8> = vec![
+        -13, -13, -13, -13, -13, -7, 0, 11, 9, -7, 9, 7, -3, -12, 11, 12, 6, 10, 6, 0, 1, -4, -6,
+        5, 2, 5, 10,
+    ];
+    let expected = 2.6947539605615567e-9_f64;
+    let actual = success(&chunk);
+    assert_eq!(true, (expected - actual).abs() < expected * 1e-9);
+
+    let chunk: Vec<i8> = vec![
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
+    let expected = 1.2658620550621852e-13_f64;
+    let actual = success(&chunk);
+    assert_eq!(true, (expected - actual).abs() < expected * 1e-9);
+}

--- a/iota-core/Cargo.toml
+++ b/iota-core/Cargo.toml
@@ -15,6 +15,7 @@ bee-ternary = { version = "0.4.0-alpha", git = "https://github.com/iotaledger/be
 bee-signing = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 bee-crypto = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 iota-client = { version = "0.5.0-alpha", path = "../iota-client" }
+iota-bundle-miner = { version = "0.1.0-alpha.0", path = "../iota-bundle-miner"}
 
 #[features]
 #quorum = ["iota-client/quorum"]

--- a/iota-core/src/lib.rs
+++ b/iota-core/src/lib.rs
@@ -12,6 +12,7 @@ pub use bee_crypto as crypto;
 pub use bee_signing as signing;
 pub use bee_ternary as ternary;
 pub use bee_transaction as transaction;
+pub use iota_bundle_miner as bundle_miner;
 pub use iota_client as client;
 
 pub use client::{iota_core::AddressBuilder, Client, ClientBuilder};


### PR DESCRIPTION
# Description of change

Bundle miner integration with testing (test patterns are generated from Go-version directly), benchmarks, and an example. Things need to be addresses follow.
- In order to ease of integration in different scenarios and facilitate/speed up testing, the user just needs to provide the `essences_from_unsigned_bundle`, instead of `unsigned_bundle` directly, where the essences can be easily extracted from the bundle object. In this way, the bundle miner will return the `crackability`, `mined_essence` (instead of the bundle object), and the `mined_iteration`.
- The user can set different criteria to stop the miner, including `LessThanMaxHash`, `EQUAL_TRAGET_HASH`, or set the `mining_timeout`, `target_crack_probability`, and `threshold`.

Examples to use the bundle miner.
```rust
// Copyright 2021 IOTA Stiftung
// SPDX-License-Identifier: Apache-2.0

//! cargo run --example bundle_miner --release
use iota::bundle_miner::MinerBuilder;
use iota::ternary::{T1B1Buf, TritBuf, TryteBuf};

fn main() {
    let kown_bundle_hashes =
        vec!["SEYZLVFTIKFROANWJDVJVOU9HZCHSHOZEIKS9CGHNHGCRUJBUEAQPBYWREUEXEAIRDXEWO9H9HXRIWVKB"];
    let essences = vec![
        "GPB9PBNCJTPGFZ9CCAOPCZBFMBSMMFMARZAKBMJFMTSECEBRWMGLPTYZRAFKUFOGJQVWVUPPABLTTLCIA",
        "A99999999999999999999999999999999999999999999999999999999999999999999999B99999999",
        "GMLRCFYRCWPZTORXSFCEGKXTVQGPFI9W9EJLERYJMEJGIPLNCLIKCCAOKQEFYUYCEUGIZKCSSJL9JD9SC",
        "Z99999999999999999999999999999999999999999999999999999999999999A99999999B99999999",
        "GMLRCFYRCWPZTORXSFCEGKXTVQGPFI9W9EJLERYJMEJGIPLNCLIKCCAOKQEFYUYCEUGIZKCSSJL9JD9SC",
        "999999999999999999999999999999999999999999999999999999999999999B99999999B99999999",
    ];
    let security_level: usize = 3;
    let mut miner = MinerBuilder::new()
        .with_offset(0)
        .with_essences_from_unsigned_bundle(
            essences
                .clone()
                .iter()
                .map(|t| {
                    TryteBuf::try_from_str(&(*t).to_string())
                        .unwrap()
                        .as_trits()
                        .encode()
                })
                .collect::<Vec<TritBuf<T1B1Buf>>>(),
        )
        .with_security_level(security_level)
        .with_kown_bundle_hashes(
            kown_bundle_hashes
                .clone()
                .iter()
                .map(|t| {
                    TryteBuf::try_from_str(&(*t).to_string())
                        .unwrap()
                        .as_trits()
                        .encode()
                })
                .collect::<Vec<TritBuf<T1B1Buf>>>(),
        )
        .with_worker_count(1)
        .with_core_thread_count(1)
        .with_mining_timeout(40)
        .finish()
        .unwrap();
    let target_crack_probability = None;
    let threshold = None;
    // We can set extra parameters when running the bundle miner to ease of more customized usage.
    let miner_result = miner.run(target_crack_probability, threshold).unwrap();
    println!("{:?}", miner_result);
}
```

## Links to any relevant issues

N/A

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- Tested w/ the patterns generated from the `Go` version. Also the benchmarks are provided.
 
## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
