### PR TITLE
Reworked get_network_info api

### DIFF
--- a/bindings/nodejs/native/src/classes/client/api.rs
+++ b/bindings/nodejs/native/src/classes/client/api.rs
@@ -39,6 +39,7 @@ pub(crate) enum Api {
     GetAddressBalances(Vec<Bech32Address>),
     // Node APIs
     GetInfo,
+    GetNetworkInfo,
     GetPeers,
     GetTips,
     PostMessage(MessageDto),
@@ -177,6 +178,7 @@ impl Task for ClientTask {
                 }
                 // Node APIs
                 Api::GetInfo => serde_json::to_string(&client.get_info().await?).unwrap(),
+                Api::GetNetworkInfo => serde_json::to_string(&client.get_synced_network_info().await?).unwrap(),
                 Api::GetPeers => serde_json::to_string(&client.get_peers().await?).unwrap(),
                 Api::GetTips => {
                     let tips = client.get_tips().await?;

--- a/bindings/nodejs/native/src/classes/client/mod.rs
+++ b/bindings/nodejs/native/src/classes/client/mod.rs
@@ -200,7 +200,8 @@ declare_types! {
         }
 
         method networkInfo(mut cx) {
-            let network_info = {
+            let cb = cx.argument::<JsFunction>(0)?;
+            {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
@@ -210,7 +211,7 @@ declare_types! {
                 };
                 client_task.schedule(cb);
             };
-            Ok(cx.string(network_info).upcast())
+            Ok(cx.undefined().upcast())
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/bindings/nodejs/native/src/classes/client/mod.rs
+++ b/bindings/nodejs/native/src/classes/client/mod.rs
@@ -204,10 +204,11 @@ declare_types! {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
-                let client = crate::get_client(&id);
-                let client = client.read().unwrap();
-                let info = client.get_network_info();
-                serde_json::to_string(&info).unwrap()
+                let client_task = ClientTask {
+                    client_id: id.clone(),
+                    api: Api::GetNetworkInfo,
+                };
+                client_task.schedule(cb);
             };
             Ok(cx.string(network_info).upcast())
         }

--- a/iota-client/src/api/message_builder.rs
+++ b/iota-client/src/api/message_builder.rs
@@ -491,12 +491,14 @@ impl<'a> ClientMessageBuilder<'a> {
             Some(mut parents) => {
                 parents.sort_unstable();
                 parents.dedup();
+                let min_pow_score = self.client.get_min_pow_score().await?;
+                let network_id = self.client.get_network_id().await?;
                 do_pow(
                     crate::client::ClientMinerBuilder::new()
                         .with_local_pow(self.client.get_local_pow())
                         .finish(),
-                    self.client.get_min_pow_score(),
-                    self.client.get_network_id().await?,
+                    min_pow_score,
+                    network_id,
                     payload,
                     parents,
                     Arc::new(AtomicBool::new(false)),
@@ -580,7 +582,7 @@ async fn is_dust_allowed(client: &Client, address: Bech32Address, outputs: Vec<(
 pub async fn finish_pow(client: &Client, payload: Option<Payload>) -> Result<Message> {
     let done = Arc::new(AtomicBool::new(false));
     let local_pow = client.get_local_pow();
-    let min_pow_score = client.get_min_pow_score();
+    let min_pow_score = client.get_min_pow_score().await?;
     let tips_interval = client.get_tips_interval();
     let network_id = client.get_network_id().await?;
     loop {

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -393,7 +393,7 @@ impl Client {
     /// Gets the miner to use based on the PoW setting
     pub fn get_pow_provider(&self) -> ClientMiner {
         ClientMinerBuilder::new()
-            .with_local_pow(self.network_info.read().unwrap().local_pow)
+            .with_local_pow(self.get_local_pow())
             .finish()
     }
 
@@ -564,7 +564,7 @@ impl Client {
         let mut url = self.get_node()?;
         url.set_path("api/v1/messages");
 
-        let timeout = if self.network_info.read().unwrap().local_pow {
+        let timeout = if self.get_local_pow() {
             self.get_timeout(Api::PostMessage)
         } else {
             self.get_timeout(Api::PostMessageWithRemotePow)

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -380,14 +380,8 @@ impl Client {
 
     /// Gets the network id of the node we're connecting to.
     pub async fn get_network_id(&self) -> Result<u64> {
-        let network_id = match self.get_network_info().network_id {
-            Some(id) => id,
-            None => {
-                let network_info = self.get_synced_network_info().await?;
-                network_info.network_id.unwrap()
-            }
-        };
-        Ok(network_id)
+        let network_info = self.get_synced_network_info().await?;
+        Ok(network_info.network_id.unwrap())
     }
 
     /// Gets the miner to use based on the PoW setting

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -392,9 +392,7 @@ impl Client {
 
     /// Gets the miner to use based on the PoW setting
     pub fn get_pow_provider(&self) -> ClientMiner {
-        ClientMinerBuilder::new()
-            .with_local_pow(self.get_local_pow())
-            .finish()
+        ClientMinerBuilder::new().with_local_pow(self.get_local_pow()).finish()
     }
 
     /// Gets the network related information and if it's the default one, sync it first.
@@ -405,7 +403,7 @@ impl Client {
             let mut client_network_info = self.network_info.write().unwrap();
             client_network_info.network_id = Some(network_id);
             client_network_info.min_pow_score = info.min_pow_score;
-            client_network_info.bech32_hrp = info.bech32_hrp.clone()
+            client_network_info.bech32_hrp = info.bech32_hrp.clone();
         }
 
         Ok(self.get_network_info())
@@ -417,7 +415,7 @@ impl Client {
     }
 
     /// returns the local pow
-       pub fn get_local_pow(&self) -> bool {
+    pub fn get_local_pow(&self) -> bool {
         self.network_info.read().unwrap().local_pow
     }
 


### PR DESCRIPTION
* This is related to issue #310 
* Added get_synced_network_info function which makes sure that the
  network_info object is synced.
* Removed unnecessary use of get_network_info where clone wasn't needed,
  now uses direct getters to the specific fields.
* Changed get_network_id to use  get_synced_network_info
