### PR TITLE
Addresses Builder improvements and refactoring

### DIFF
--- a/bindings/nodejs/native/src/classes/client/address_finder.rs
+++ b/bindings/nodejs/native/src/classes/client/address_finder.rs
@@ -6,6 +6,8 @@ use neon::prelude::*;
 
 use std::ops::Range;
 
+use super::{Api, ClientTask};
+
 pub struct AddressFinder {
     client_id: String,
     seed: String,
@@ -63,7 +65,7 @@ declare_types! {
                 let client_task = ClientTask {
                     client_id: ref_.client_id.clone(),
                     api: Api::FindAddresses {
-                        seed: Seed::fromcar_bytes(&hex::decode(&ref_.seed).expect("invalid seed hex")).expect("invalid seed"),
+                        seed: Seed::from_bytes(&hex::decode(&ref_.seed).expect("invalid seed hex")).expect("invalid seed"),
                         account_index: ref_.account_index,
                         range: ref_.range,
                     },

--- a/bindings/nodejs/native/src/classes/client/address_finder.rs
+++ b/bindings/nodejs/native/src/classes/client/address_finder.rs
@@ -67,7 +67,7 @@ declare_types! {
                     api: Api::FindAddresses {
                         seed: Seed::from_bytes(&hex::decode(&ref_.seed).expect("invalid seed hex")).expect("invalid seed"),
                         account_index: ref_.account_index,
-                        range: ref_.range,
+                        range: ref_.range.clone(),
                     },
                 };
                 client_task.schedule(cb);

--- a/bindings/nodejs/native/src/classes/client/address_finder.rs
+++ b/bindings/nodejs/native/src/classes/client/address_finder.rs
@@ -56,6 +56,18 @@ declare_types! {
             Ok(cx.this().upcast())
         }
 
+        method bech32_hrp(mut cx) {
+            let bech32_hrp = cx.argument::<JsString>(0)?.value();
+            {
+                let mut this = cx.this();
+                let guard = cx.lock();
+                let find_bech32_hrp = &mut this.borrow_mut(&guard).bech32_hrp;
+                find_bech32_hrp.replace(bech32_hrp);
+            }
+
+            Ok(cx.this().upcast())
+        }
+
         method get(mut cx) {
             let cb = cx.argument::<JsFunction>(0)?;
             {
@@ -68,6 +80,7 @@ declare_types! {
                         seed: Seed::from_bytes(&hex::decode(&ref_.seed).expect("invalid seed hex")).expect("invalid seed"),
                         account_index: ref_.account_index,
                         range: ref_.range.clone(),
+                        bech32_hrp: ref_.bech32_hrp.clone(),
                     },
                 };
                 client_task.schedule(cb);

--- a/bindings/nodejs/native/src/classes/client/api.rs
+++ b/bindings/nodejs/native/src/classes/client/api.rs
@@ -160,7 +160,7 @@ impl Task for ClientTask {
                         getter = getter.with_range(range.clone());
                     }
 
-                    let addresses = getter.finish();
+                    let addresses = getter.finish().await?;
                     serde_json::to_string(&addresses).unwrap()
                 }
                 Api::FindMessages {

--- a/bindings/nodejs/native/src/classes/client/api.rs
+++ b/bindings/nodejs/native/src/classes/client/api.rs
@@ -31,6 +31,7 @@ pub(crate) enum Api {
         seed: Seed,
         account_index: Option<usize>,
         range: Option<Range<usize>>,
+        bech32_hrp: Option<String>,
     },
     FindMessages {
         indexation_keys: Vec<String>,
@@ -151,6 +152,7 @@ impl Task for ClientTask {
                     seed,
                     account_index,
                     range,
+                    bech32_hrp,
                 } => {
                     let mut getter = client.find_addresses(&seed);
                     if let Some(account_index) = account_index {
@@ -158,6 +160,10 @@ impl Task for ClientTask {
                     }
                     if let Some(range) = range {
                         getter = getter.with_range(range.clone());
+                    }
+
+                    if let Some(bech32_hrp) = bech32_hrp {
+                        getter = getter.with_bech32_hrp(bech32_hrp.clone())
                     }
 
                     let addresses = getter.finish().await?;

--- a/bindings/nodejs/native/src/classes/client/api.rs
+++ b/bindings/nodejs/native/src/classes/client/api.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{convert::TryInto, str::FromStr};
+use std::{convert::TryInto, str::FromStr, ops::Range};
 
 use super::MessageDto;
 
@@ -159,7 +159,9 @@ impl Task for ClientTask {
                     if let Some(range) = range {
                         getter = getter.with_range(range.clone());
                     }
-                    getter.get_all().await?.map(|addresses| {
+                    let addresses = getter.get_all().await?;
+
+                    addresses.into_iter().map(|addresses| {
                         serde_json::to_string(&addresses).unwrap()
                     })
                 }
@@ -199,7 +201,7 @@ impl Task for ClientTask {
                 }
                 // Node APIs
                 Api::GetInfo => serde_json::to_string(&client.get_info().await?).unwrap(),
-                Api::GetNetworkInfo => serde_json::to_string(&client.get_synced_network_info().await?).unwrap(),
+                Api::GetNetworkInfo => serde_json::to_string(&client.get_network_info().await?).unwrap(),
                 Api::GetPeers => serde_json::to_string(&client.get_peers().await?).unwrap(),
                 Api::GetTips => {
                     let tips = client.get_tips().await?;

--- a/bindings/nodejs/native/src/classes/client/api.rs
+++ b/bindings/nodejs/native/src/classes/client/api.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{convert::TryInto, str::FromStr, ops::Range};
+use std::{convert::TryInto, ops::Range, str::FromStr};
 
 use super::MessageDto;
 
@@ -159,11 +159,9 @@ impl Task for ClientTask {
                     if let Some(range) = range {
                         getter = getter.with_range(range.clone());
                     }
-                    let addresses = getter.get_all().await?;
 
-                    addresses.into_iter().map(|addresses| {
-                        serde_json::to_string(&addresses).unwrap()
-                    })
+                    let addresses = getter.finish();
+                    serde_json::to_string(&addresses).unwrap()
                 }
                 Api::FindMessages {
                     indexation_keys,

--- a/bindings/nodejs/native/src/classes/client/builder.rs
+++ b/bindings/nodejs/native/src/classes/client/builder.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-
+#![allow(clippy::unnecessary_wraps)]
 use std::{collections::HashMap, num::NonZeroU64, str::FromStr, time::Duration};
 
 use iota::client::{Api, BrokerOptions, ClientBuilder};

--- a/bindings/python/native/src/client/high_level_api.rs
+++ b/bindings/python/native/src/client/high_level_api.rs
@@ -18,6 +18,7 @@ use std::{
 /// General high level APIs
 #[pymethods]
 impl Client {
+    #[allow(clippy::too_many_arguments)]
     fn message(
         &self,
         seed: Option<String>,

--- a/bindings/python/native/src/client/high_level_api.rs
+++ b/bindings/python/native/src/client/high_level_api.rs
@@ -240,23 +240,28 @@ impl Client {
             end = input_range_end.unwrap();
         }
         if get_all.unwrap_or(false) {
-            let addresses = self
-                .client
-                .find_addresses(&seed)
-                .with_account_index(account_index.unwrap_or(0))
-                .with_range(begin..end)
-                .get_all()?;
+            let rt = tokio::runtime::Runtime::new()?;
+            let addresses = rt.block_on(async {
+                self.client
+                    .find_addresses(&seed)
+                    .with_account_index(account_index.unwrap_or(0))
+                    .with_range(begin..end)
+                    .get_all()
+                    .await
+            })?;
             Ok(addresses
                 .iter()
                 .map(|address_changed| (address_changed.0.to_string(), Some(address_changed.1)))
                 .collect())
         } else {
-            let addresses = self
-                .client
-                .find_addresses(&seed)
-                .with_account_index(account_index.unwrap_or(0))
-                .with_range(begin..end)
-                .finish()?;
+            let rt = tokio::runtime::Runtime::new()?;
+            let addresses = rt.block_on(async {
+                self.client
+                    .find_addresses(&seed)
+                    .with_account_index(account_index.unwrap_or(0))
+                    .with_range(begin..end)
+                    .finish()?;
+            })?;
             Ok(addresses
                 .iter()
                 .map(|addresses| (addresses.to_string(), None))

--- a/bindings/python/native/src/client/mod.rs
+++ b/bindings/python/native/src/client/mod.rs
@@ -99,7 +99,7 @@ impl Client {
         // Note: This unsafe code is actually safe, because the BECH32_HRP will be only initialized when we
         //       create the client object.
         unsafe {
-            BECH32_HRP = Box::leak(client.get_network_info().bech32_hrp.into_boxed_str());
+            BECH32_HRP = Box::leak(async {client.get_bech32_hrp().await.into_boxed_str() });
         }
         Client { client }
     }

--- a/bindings/python/native/src/client/mod.rs
+++ b/bindings/python/native/src/client/mod.rs
@@ -25,6 +25,7 @@ pub struct Client {
 #[pymethods]
 impl Client {
     #[new]
+    #[allow(clippy::too_many_arguments)]
     /// The constructor of the client instance.
     fn new(
         network: Option<&str>,

--- a/bindings/python/native/src/client/mod.rs
+++ b/bindings/python/native/src/client/mod.rs
@@ -98,8 +98,9 @@ impl Client {
         // Update the BECH32_HRP
         // Note: This unsafe code is actually safe, because the BECH32_HRP will be only initialized when we
         //       create the client object.
+        let bech32_hrp = rt.block_on(async { client.get_bech32_hrp().await.unwrap() });
         unsafe {
-            BECH32_HRP = Box::leak(async {client.get_bech32_hrp().await.into_boxed_str() });
+            BECH32_HRP = Box::leak(bech32_hrp.into_boxed_str());
         }
         Client { client }
     }

--- a/examples/address.rs
+++ b/examples/address.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! cargo run --example address --release
-use iota::{Client, Seed};
+use iota::{api::GetAddressesBuilder, Client, Seed};
 extern crate dotenv;
 use dotenv::dotenv;
 use std::env;
@@ -39,4 +39,14 @@ async fn main() {
         .unwrap();
     // bool for public addresses is false and for internal addresses true
     println!("List of generated public and internal addresses: {:?}", all_addresses);
+
+    // Or generate addresses offline with the bech32_hrp defined
+    let addresses = GetAddressesBuilder::new(&seed)
+        .with_bech32_hrp("atoi".into())
+        .with_account_index(0)
+        .with_range(0..1)
+        .finish()
+        .await
+        .unwrap();
+    println!("{:?}", addresses);
 }

--- a/examples/address.rs
+++ b/examples/address.rs
@@ -27,6 +27,7 @@ async fn main() {
         .with_account_index(0)
         .with_range(0..4)
         .finish()
+        .await
         .unwrap();
     println!("List of generated public addresses: {:?}", addresses);
     let all_addresses = iota
@@ -34,6 +35,7 @@ async fn main() {
         .with_account_index(0)
         .with_range(0..4)
         .get_all()
+        .await
         .unwrap();
     // bool for public addresses is false and for internal addresses true
     println!("List of generated public and internal addresses: {:?}", all_addresses);

--- a/examples/custom_inputs.rs
+++ b/examples/custom_inputs.rs
@@ -30,6 +30,7 @@ async fn main() {
         .with_account_index(0)
         .with_range(0..1)
         .finish()
+        .await
         .unwrap();
     println!("{:?}", address[0]);
     let outputs = iota.get_address().outputs(&address[0]).await.unwrap();

--- a/examples/search_address.rs
+++ b/examples/search_address.rs
@@ -27,6 +27,7 @@ async fn main() {
         .with_account_index(0)
         .with_range(9..10)
         .finish()
+        .await
         .unwrap();
     println!("{:?}", address);
     let res = search_address(&seed, 0, 0..10, &address[0]).await.unwrap();

--- a/examples/search_address.rs
+++ b/examples/search_address.rs
@@ -30,7 +30,9 @@ async fn main() {
         .await
         .unwrap();
     println!("{:?}", address);
-    let res = search_address(&seed, 0, 0..10, &address[0]).await.unwrap();
+    let res = search_address(&seed, iota.get_bech32_hrp().await.unwrap(), 0, 0..10, &address[0])
+        .await
+        .unwrap();
     println!(
         "Found address with address_index: {}, internal address: {}",
         res.0, res.1

--- a/examples/txspam.rs
+++ b/examples/txspam.rs
@@ -31,6 +31,7 @@ async fn main() {
         .with_account_index(0)
         .with_range(0..10)
         .finish()
+        .await
         .unwrap();
 
     let mut message_builder = iota.message().with_seed(&seed);

--- a/iota-client/src/api/address.rs
+++ b/iota-client/src/api/address.rs
@@ -56,7 +56,8 @@ impl<'a> GetAddressesBuilder<'a> {
     /// Consume the builder and get a vector of public Bech32Addresses
     pub async fn finish(self) -> Result<Vec<Bech32Address>> {
         Ok(self
-            .get_all().await?
+            .get_all()
+            .await?
             .into_iter()
             .filter(|(_, internal)| !internal)
             .map(|(a, _)| a)
@@ -119,7 +120,8 @@ pub async fn search_address(
         .find_addresses(&seed)
         .with_account_index(account_index)
         .with_range(range.clone())
-        .get_all().await?;
+        .get_all()
+        .await?;
     let mut index_counter = 0;
     for address_internal in addresses {
         if address_internal.0 == *address {

--- a/iota-client/src/api/address.rs
+++ b/iota-client/src/api/address.rs
@@ -20,6 +20,7 @@ pub struct GetAddressesBuilder<'a> {
     seed: &'a Seed,
     account_index: Option<usize>,
     range: Option<Range<usize>>,
+    bech32_hrp: Option<String>,
 }
 
 impl<'a> GetAddressesBuilder<'a> {
@@ -30,6 +31,7 @@ impl<'a> GetAddressesBuilder<'a> {
             seed,
             account_index: None,
             range: None,
+            bech32_hrp: None,
         }
     }
 
@@ -45,10 +47,16 @@ impl<'a> GetAddressesBuilder<'a> {
         self
     }
 
+    /// Set range to the builder
+    pub fn with_bech32_hrp(mut self, bech32_hrp: String) -> Self {
+        self.bech32_hrp = Some(bech32_hrp);
+        self
+    }
+
     /// Consume the builder and get a vector of public Bech32Addresses
-    pub fn finish(self) -> Result<Vec<Bech32Address>> {
+    pub async fn finish(self) -> Result<Vec<Bech32Address>> {
         Ok(self
-            .get_all()?
+            .get_all().await?
             .into_iter()
             .filter(|(_, internal)| !internal)
             .map(|(a, _)| a)
@@ -56,7 +64,7 @@ impl<'a> GetAddressesBuilder<'a> {
     }
 
     /// Consume the builder and get the vector of Bech32Address
-    pub fn get_all(self) -> Result<Vec<(Bech32Address, bool)>> {
+    pub async fn get_all(self) -> Result<Vec<(Bech32Address, bool)>> {
         let mut path = self
             .account_index
             .map(|i| BIP32Path::from_str(&crate::account_path!(i)).expect("invalid account index"))
@@ -68,10 +76,10 @@ impl<'a> GetAddressesBuilder<'a> {
         };
 
         let mut addresses = Vec::new();
+        let bech32_hrp = self.bech32_hrp.unwrap_or(self._client.get_bech32_hrp().await?);
         for i in range {
             let address = generate_address(&self.seed, &mut path, i, false)?;
             let internal_address = generate_address(&self.seed, &mut path, i, true)?;
-            let bech32_hrp = self._client.get_network_info().bech32_hrp;
             addresses.push((Bech32Address(address.to_bech32(&bech32_hrp)), false));
             addresses.push((Bech32Address(internal_address.to_bech32(&bech32_hrp)), true));
         }
@@ -111,7 +119,7 @@ pub async fn search_address(
         .find_addresses(&seed)
         .with_account_index(account_index)
         .with_range(range.clone())
-        .get_all()?;
+        .get_all().await?;
     let mut index_counter = 0;
     for address_internal in addresses {
         if address_internal.0 == *address {

--- a/iota-client/src/api/balance.rs
+++ b/iota-client/src/api/balance.rs
@@ -50,7 +50,8 @@ impl<'a> GetBalanceBuilder<'a> {
                 .find_addresses(self.seed)
                 .with_account_index(account_index)
                 .with_range(index..index + 20)
-                .get_all().await?;
+                .get_all()
+                .await?;
 
             // TODO we assume all addresses are unspent and valid if balance > 0
             let mut found_zero_balance = false;

--- a/iota-client/src/api/balance.rs
+++ b/iota-client/src/api/balance.rs
@@ -50,7 +50,7 @@ impl<'a> GetBalanceBuilder<'a> {
                 .find_addresses(self.seed)
                 .with_account_index(account_index)
                 .with_range(index..index + 20)
-                .get_all()?;
+                .get_all().await?;
 
             // TODO we assume all addresses are unspent and valid if balance > 0
             let mut found_zero_balance = false;

--- a/iota-client/src/api/message_builder.rs
+++ b/iota-client/src/api/message_builder.rs
@@ -591,7 +591,7 @@ pub async fn finish_pow(client: &Client, payload: Option<Payload>) -> Result<Mes
         let abort2 = Arc::clone(&done);
         let payload_ = payload.clone();
         let parent_messages = client.get_tips().await?;
-        let time_thread = std::thread::spawn(move || pow_timeout(tips_interval, &abort1));
+        let time_thread = std::thread::spawn(move || Ok(pow_timeout(tips_interval, &abort1)));
         let pow_thread = std::thread::spawn(move || {
             do_pow(
                 crate::client::ClientMinerBuilder::new()
@@ -624,10 +624,10 @@ pub async fn finish_pow(client: &Client, payload: Option<Payload>) -> Result<Mes
     }
 }
 
-fn pow_timeout(after_seconds: u64, done: &AtomicBool) -> Result<(u64, Option<Message>)> {
+fn pow_timeout(after_seconds: u64, done: &AtomicBool) -> (u64, Option<Message>) {
     std::thread::sleep(std::time::Duration::from_secs(after_seconds));
     done.swap(true, Ordering::Relaxed);
-    Ok((0, None))
+    (0, None)
 }
 
 /// Does PoW

--- a/iota-client/src/api/message_builder.rs
+++ b/iota-client/src/api/message_builder.rs
@@ -176,7 +176,7 @@ impl<'a> ClientMessageBuilder<'a> {
 
         let mut index = self.initial_address_index.unwrap_or(0);
 
-        let bech32_hrp = self.client.get_synced_network_info().await?.bech32_hrp;
+        let bech32_hrp = self.client.get_bech32_hrp().await?;
 
         // store (amount, address, new_created) to check later if dust is allowed
         let mut dust_and_allowance_recorders = Vec::new();
@@ -280,7 +280,7 @@ impl<'a> ClientMessageBuilder<'a> {
                         .find_addresses(self.seed.expect("No seed"))
                         .with_account_index(account_index)
                         .with_range(index..index + 20)
-                        .get_all()?;
+                        .get_all().await?;
                     // For each address, get the address outputs
                     let mut address_index = 0;
                     for (index, (address, internal)) in addresses.iter().enumerate() {

--- a/iota-client/src/api/message_builder.rs
+++ b/iota-client/src/api/message_builder.rs
@@ -280,7 +280,8 @@ impl<'a> ClientMessageBuilder<'a> {
                         .find_addresses(self.seed.expect("No seed"))
                         .with_account_index(account_index)
                         .with_range(index..index + 20)
-                        .get_all().await?;
+                        .get_all()
+                        .await?;
                     // For each address, get the address outputs
                     let mut address_index = 0;
                     for (index, (address, internal)) in addresses.iter().enumerate() {

--- a/iota-client/src/api/message_builder.rs
+++ b/iota-client/src/api/message_builder.rs
@@ -237,6 +237,7 @@ impl<'a> ClientMessageBuilder<'a> {
                             let bech32_address = output_address.to_bech32(&bech32_hrp);
                             let (address_index, internal) = search_address(
                                 &self.seed.expect("No seed"),
+                                bech32_hrp.clone(),
                                 account_index,
                                 self.input_range.clone(),
                                 &bech32_address.into(),

--- a/iota-client/src/api/unspent.rs
+++ b/iota-client/src/api/unspent.rs
@@ -49,7 +49,7 @@ impl<'a> GetUnspentAddressBuilder<'a> {
                 .find_addresses(self.seed)
                 .with_account_index(account_index)
                 .with_range(index..index + 20)
-                .finish()?;
+                .finish().await?;
 
             // TODO we assume all addresses are unspent and valid if balance > 0
             let mut address = None;

--- a/iota-client/src/api/unspent.rs
+++ b/iota-client/src/api/unspent.rs
@@ -49,7 +49,8 @@ impl<'a> GetUnspentAddressBuilder<'a> {
                 .find_addresses(self.seed)
                 .with_account_index(account_index)
                 .with_range(index..index + 20)
-                .finish().await?;
+                .finish()
+                .await?;
 
             // TODO we assume all addresses are unspent and valid if balance > 0
             let mut address = None;

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -405,7 +405,7 @@ impl Client {
         Ok(network_info.clone())
     }
 
-    /// returns the min pow score
+    /// returns the bech32_hrp
     pub async fn get_bech32_hrp(&self) -> Result<String> {
         Ok(self.get_network_info().await?.bech32_hrp)
     }
@@ -782,7 +782,7 @@ impl Client {
 
     /// Return a list of addresses from the seed regardless of their validity.
     pub fn find_addresses<'a>(&'a self, seed: &'a Seed) -> GetAddressesBuilder<'a> {
-        GetAddressesBuilder::new(self, seed)
+        GetAddressesBuilder::new(seed).with_client(&self)
     }
 
     /// Find all messages by provided message IDs and/or indexation_keys.


### PR DESCRIPTION
- You can now provide bech32_hrp to the AddressesBuilder
- AddressesBuilder get_all and finish methods are now async and are making sure if there is not user provided bech32_hrp to get it from synced network info.
- JS and Python bindings now are correctly working with the AddressesBuilder changes.
- Renamed get_synced_network_info to get_network_info and removed the old implementation.