### PR TITLE
fix(ci): Fix python binding build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -109,7 +109,5 @@ jobs:
       working-directory: bindings/nodejs
 
     - name: Build python binding
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --manifest-path=bindings/python/native/Cargo.toml --all --release
+      run: cargo build --all --release
+      working-directory: bindings/python/native

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -102,5 +102,4 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --all --release
-        working-directory: bindings/python/native
+        args: --manifest-path=bindings/python/native/Cargo.toml --all --release

--- a/bindings/python/native/.cargo/config.toml
+++ b/bindings/python/native/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
The python binding is [not actually being built](https://github.com/iotaledger/iota.rs/runs/1878559223#step:15:1) because of an issue with the CI script. `working-directory` is only valid for `run` steps (for running an arbitrary shell command). When an action such as `actions-rs/cargo@v1` is used, GHA does not natively support setting the working directory. ~~To get around this, we can pass `--manifest-path` to `cargo`~~ Specifying `--manifest-path` seems to ignore the `.cargo/config.toml`, so we can use a `run` step here