### PR TITLE
feat(wasm) Updated default feature of iota-client

### DIFF
--- a/iota-core/Cargo.toml
+++ b/iota-core/Cargo.toml
@@ -21,7 +21,7 @@ iota-client = { version = "0.5.0-alpha", path = "../iota-client", default-featur
 tokio = { version = "1.1", features = ["macros"] }
 
 [features]
-default = ["iota-client/async"]
+default = ["iota-client/default"]
 sync = ["iota-client/sync"]
 async = ["iota-client/async"]
 mqtt = ["iota-client/mqtt"]


### PR DESCRIPTION
Changed default feature to use client default, so we dont need to use tokio if we dont want to