### PR TITLE
[Docs] Change API reference link to link to iota-lib-rs docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ When using the "MQTT" feature, connecting to a MQTT broker using raw ip doesn't 
 
 ## API reference
 
-You can read the [API reference](https://docs.rs/iota-core) here, or generate it yourself.
+You can read the [API reference](https://docs.rs/iota-lib-rs/) here, or generate it yourself.
 
 If you'd like to explore the implementation in more depth, the following command generates docs for the whole crate, including private modules:
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ When using the "MQTT" feature, connecting to a MQTT broker using raw ip doesn't 
 
 ## API reference
 
-You can read the [API reference](https://docs.rs/iota-lib-rs/) here, or generate it yourself.
+You can read the [API reference](https://client-lib.docs.iota.org/docs/doc/iota_client/index.html) here, or generate it yourself.
 
 If you'd like to explore the implementation in more depth, the following command generates docs for the whole crate, including private modules:
 


### PR DESCRIPTION
This is purely a documentation fix, or rather a suggestion thereof.

I noticed that the API reference link in the project's readme file links to the [iota-core docs](https://docs.rs/iota-core/), however, from what I can tell iota-core is just a subcrate of this project.

That's why I suggested to change the API reference URL to the [iota-lib-rs docs](https://docs.rs/iota-lib-rs/), as they seem to document this project as a whole.

Please let me know if this change is correct. Thank you for reading!