### PR TITLE
Fix sync client build failures

### DIFF
--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -23,7 +23,7 @@ url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hex = "0.4"
-tokio = { version = "1.5", features = ["macros", "sync", "rt-multi-thread", "rt"], optional = true }
+tokio = { version = "1.5", features = ["macros", "sync", "rt-multi-thread", "rt", "time"], optional = true }
 thiserror = "1.0"
 num_cpus = "1.13"
 log= "0.4"

--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -47,7 +47,7 @@ rusqlite = { version = "0.24", features = ["bundled"], optional = true }
 
 [features]
 default = ["async", "tokio", "futures"]
-sync = ["ureq, tokio, futures"]
+sync = ["ureq", "tokio", "futures"]
 async = ["reqwest", "futures"]
 mqtt = ["rumqttc", "once_cell", "futures"]
 storage = ["rusqlite", "once_cell"]

--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -47,7 +47,7 @@ rusqlite = { version = "0.24", features = ["bundled"], optional = true }
 
 [features]
 default = ["async", "tokio", "futures"]
-sync = ["ureq"]
+sync = ["ureq, tokio, futures"]
 async = ["reqwest", "futures"]
 mqtt = ["rumqttc", "once_cell", "futures"]
 storage = ["rusqlite", "once_cell"]

--- a/iota-client/src/node_manager.rs
+++ b/iota-client/src/node_manager.rs
@@ -540,6 +540,8 @@ impl HttpClient {
         Self {}
     }
 
+    pub(crate) fn clone(&self) -> Self { Self {} }
+
     pub(crate) async fn get(&self, url: &str, timeout: Duration) -> Result<Response> {
         Ok(Self::get_ureq_agent(timeout).get(url).call()?.into())
     }

--- a/iota-client/src/node_manager.rs
+++ b/iota-client/src/node_manager.rs
@@ -540,7 +540,9 @@ impl HttpClient {
         Self {}
     }
 
-    pub(crate) fn clone(&self) -> Self { Self {} }
+    pub(crate) fn clone(&self) -> Self {
+        Self {}
+    }
 
     pub(crate) async fn get(&self, url: &str, timeout: Duration) -> Result<Response> {
         Ok(Self::get_ureq_agent(timeout).get(url).call()?.into())

--- a/iota-core/Cargo.toml
+++ b/iota-core/Cargo.toml
@@ -16,7 +16,7 @@ iota-client = { version = "0.5.0-alpha", path = "../iota-client", default-featur
 
 [features]
 default = ["iota-client/default"]
-sync = ["iota-client/sync"]
+sync = ["iota-client/sync", "iota-client/futures", "iota-client/tokio"]
 async = ["iota-client/async"]
 mqtt = ["iota-client/mqtt"]
 storage = ["iota-client/storage"]

--- a/iota-core/Cargo.toml
+++ b/iota-core/Cargo.toml
@@ -16,7 +16,7 @@ iota-client = { version = "0.5.0-alpha", path = "../iota-client", default-featur
 
 [features]
 default = ["iota-client/default"]
-sync = ["iota-client/sync", "iota-client/futures", "iota-client/tokio"]
+sync = ["iota-client/sync"]
 async = ["iota-client/async"]
 mqtt = ["iota-client/mqtt"]
 storage = ["iota-client/storage"]


### PR DESCRIPTION
A quick feature flag fix to allow the sync feature to build correctly. `Sync` feature still requires the `tokio` and `futures` features to be enabled on the client, but they can't be passed to client through core without using default atm. This allows them to be passed forward with just the sync flag so that the build can complete. 