### PR TITLE
Replace Tokio RwLock in Client 

### DIFF
--- a/iota-client/src/api/message_builder.rs
+++ b/iota-client/src/api/message_builder.rs
@@ -543,7 +543,7 @@ impl<'a> ClientMessageBuilder<'a> {
                 // If not, we need to create a signature unlock block
                 let private_key = self
                     .seed
-                    .expect("No seed")
+                    .ok_or(crate::Error::MissingParameter("Seed"))?
                     .derive(Curve::Ed25519, &recorder.chain)?
                     .secret_key()?;
                 let public_key = private_key.public_key().to_compressed_bytes();

--- a/iota-client/src/builder.rs
+++ b/iota-client/src/builder.rs
@@ -5,10 +5,7 @@
 use crate::{client::*, error::*};
 
 #[cfg(not(feature = "wasm"))]
-use tokio::{
-    runtime::Runtime,
-    sync::{broadcast::channel},
-};
+use tokio::{runtime::Runtime, sync::broadcast::channel};
 
 #[cfg(not(feature = "wasm"))]
 use std::collections::HashSet;
@@ -16,7 +13,7 @@ use std::collections::HashSet;
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
-    time::Duration
+    time::Duration,
 };
 
 const DEFAULT_REMOTE_POW_TIMEOUT: Duration = Duration::from_secs(50);

--- a/iota-client/src/builder.rs
+++ b/iota-client/src/builder.rs
@@ -7,14 +7,17 @@ use crate::{client::*, error::*};
 #[cfg(not(feature = "wasm"))]
 use tokio::{
     runtime::Runtime,
-    sync::{broadcast::channel, RwLock},
+    sync::{broadcast::channel},
 };
 
 #[cfg(not(feature = "wasm"))]
 use std::collections::HashSet;
-#[cfg(feature = "wasm")]
-use std::sync::RwLock;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+    time::Duration
+};
 
 const DEFAULT_REMOTE_POW_TIMEOUT: Duration = Duration::from_secs(50);
 pub(crate) const GET_API_TIMEOUT: Duration = Duration::from_secs(10);
@@ -203,13 +206,13 @@ impl ClientBuilder {
 
     /// Build the Client instance.
     pub async fn finish(mut self) -> Result<Client> {
-        let network_info = Arc::new(std::sync::RwLock::new(self.network_info));
+        let network_info = Arc::new(RwLock::new(self.network_info));
         let nodes = self.node_manager_builder.nodes.clone();
         #[cfg(not(feature = "wasm"))]
         let node_sync_interval = self.node_sync_interval;
 
         #[cfg(feature = "wasm")]
-        let (sync, network_info) = (Arc::new(std::sync::RwLock::new(nodes.clone())), network_info);
+        let (sync, network_info) = (Arc::new(RwLock::new(nodes.clone())), network_info);
         #[cfg(not(feature = "wasm"))]
         let (runtime, sync, sync_kill_sender, network_info) = if self.node_sync_enabled {
             let sync = Arc::new(RwLock::new(HashSet::new()));

--- a/iota-client/src/builder.rs
+++ b/iota-client/src/builder.rs
@@ -20,8 +20,8 @@ const DEFAULT_REMOTE_POW_TIMEOUT: Duration = Duration::from_secs(50);
 pub(crate) const GET_API_TIMEOUT: Duration = Duration::from_secs(10);
 #[cfg(not(feature = "wasm"))]
 const NODE_SYNC_INTERVAL: Duration = Duration::from_secs(60);
-// Interval in seconds when new tips will be requested during PoW
-const TIPS_INTERVAL: u64 = 15;
+/// Interval in seconds when new tips will be requested during PoW
+pub const TIPS_INTERVAL: u64 = 15;
 const DEFAULT_MIN_POW: f64 = 4000f64;
 const DEFAULT_BECH32_HRP: &str = "iota";
 
@@ -61,6 +61,22 @@ pub struct ClientBuilder {
     api_timeout: HashMap<Api, Duration>,
 }
 
+impl Default for NetworkInfo {
+    fn default() -> Self {
+        Self {
+            network: None,
+            network_id: None,
+            min_pow_score: DEFAULT_MIN_POW,
+            #[cfg(not(feature = "wasm"))]
+            local_pow: true,
+            #[cfg(feature = "wasm")]
+            local_pow: false,
+            bech32_hrp: DEFAULT_BECH32_HRP.into(),
+            tips_interval: TIPS_INTERVAL,
+        }
+    }
+}
+
 impl Default for ClientBuilder {
     fn default() -> Self {
         Self {
@@ -71,17 +87,7 @@ impl Default for ClientBuilder {
             node_sync_enabled: true,
             #[cfg(feature = "mqtt")]
             broker_options: Default::default(),
-            network_info: NetworkInfo {
-                network: None,
-                network_id: None,
-                min_pow_score: DEFAULT_MIN_POW,
-                #[cfg(not(feature = "wasm"))]
-                local_pow: true,
-                #[cfg(feature = "wasm")]
-                local_pow: false,
-                bech32_hrp: DEFAULT_BECH32_HRP.into(),
-                tips_interval: TIPS_INTERVAL,
-            },
+            network_info: NetworkInfo::default(),
             request_timeout: DEFAULT_REMOTE_POW_TIMEOUT,
             api_timeout: Default::default(),
         }

--- a/iota-client/src/builder.rs
+++ b/iota-client/src/builder.rs
@@ -203,7 +203,7 @@ impl ClientBuilder {
 
     /// Build the Client instance.
     pub async fn finish(mut self) -> Result<Client> {
-        let network_info = Arc::new(RwLock::new(self.network_info));
+        let network_info = Arc::new(std::sync::RwLock::new(self.network_info));
         let nodes = self.node_manager_builder.nodes.clone();
         #[cfg(not(feature = "wasm"))]
         let node_sync_interval = self.node_sync_interval;
@@ -283,9 +283,6 @@ impl ClientBuilder {
 
         #[cfg(feature = "mqtt")]
         let (mqtt_event_tx, mqtt_event_rx) = tokio::sync::watch::channel(MqttEvent::Connected);
-        #[cfg(not(feature = "wasm"))]
-        let network_info_ = network_info.read().await.clone();
-        #[cfg(feature = "wasm")]
         let network_info_ = network_info.read().expect("Can't read network info").clone();
         let client = Client {
             node_manager: self.node_manager_builder.build(network_info_, sync.clone()).await?,

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -4,7 +4,7 @@
 //! The Client module to connect through HORNET or Bee with API usages
 use crate::{
     api::*,
-    builder::{ClientBuilder, NetworkInfo, GET_API_TIMEOUT, TIPS_INTERVAL},
+    builder::{ClientBuilder, NetworkInfo, GET_API_TIMEOUT},
     error::*,
     node::*,
 };
@@ -34,6 +34,8 @@ use crypto::{
 
 use zeroize::Zeroize;
 
+#[cfg(not(feature = "wasm"))]
+use crate::builder::TIPS_INTERVAL;
 #[cfg(feature = "mqtt")]
 use rumqttc::AsyncClient as MqttClient;
 #[cfg(any(feature = "mqtt", not(feature = "wasm")))]

--- a/iota-client/src/client.rs
+++ b/iota-client/src/client.rs
@@ -37,9 +37,7 @@ use zeroize::Zeroize;
 #[cfg(feature = "mqtt")]
 use rumqttc::AsyncClient as MqttClient;
 #[cfg(any(feature = "mqtt", not(feature = "wasm")))]
-use tokio::sync::{
-    watch::{Receiver as WatchReceiver, Sender as WatchSender},
-};
+use tokio::sync::watch::{Receiver as WatchReceiver, Sender as WatchSender};
 #[cfg(not(feature = "wasm"))]
 use tokio::{
     runtime::Runtime,
@@ -460,11 +458,12 @@ impl Client {
     /// Gets the network related information such as network_id and min_pow_score
     /// and if it's the default one, sync it first.
     pub async fn get_network_info(&self) -> Result<NetworkInfo> {
-        let not_synced = self.network_info
-                .read()
-                .expect("Couln't read network info")
-                .network_id
-                .is_none();
+        let not_synced = self
+            .network_info
+            .read()
+            .expect("Couln't read network info")
+            .network_id
+            .is_none();
 
         if not_synced {
             let info = self.get_info().await?.nodeinfo;
@@ -476,9 +475,7 @@ impl Client {
                 client_network_info.bech32_hrp = info.bech32_hrp;
             }
         }
-        let res = self.network_info.read()
-            .expect("Failed to read network info")
-            .clone();
+        let res = self.network_info.read().expect("Failed to read network info").clone();
         Ok(res)
     }
 
@@ -495,7 +492,10 @@ impl Client {
     /// returns the tips interval
     #[cfg(not(feature = "wasm"))]
     pub async fn get_tips_interval(&self) -> u64 {
-        self.network_info.read().expect("Failed to read network info").tips_interval
+        self.network_info
+            .read()
+            .expect("Failed to read network info")
+            .tips_interval
     }
 
     /// returns the local pow
@@ -506,7 +506,11 @@ impl Client {
     /// returns the unsynced nodes.
     #[cfg(not(feature = "wasm"))]
     pub async fn unsynced_nodes(&self) -> HashSet<&Url> {
-        let synced = self.node_manager.synced_nodes.read().expect("Failed to read synced nodes");
+        let synced = self
+            .node_manager
+            .synced_nodes
+            .read()
+            .expect("Failed to read synced nodes");
         self.node_manager
             .nodes
             .iter()

--- a/iota-client/src/error.rs
+++ b/iota-client/src/error.rs
@@ -48,6 +48,9 @@ pub enum Error {
     /// Error on API request
     #[error("Failed to get an answer from all nodes")]
     NodeError,
+    /// Error on RwLock read
+    #[error("Failed to read node RwLock")]
+    NodeReadError,
     /// Hex string convert error
     #[error("{0}")]
     FromHexError(#[from] hex::FromHexError),
@@ -136,4 +139,8 @@ pub enum Error {
     /// Error when parsing from bech32 to hex
     #[error("Failed to parse bech32 to hex")]
     FailedToParseBech32ToHex,
+    #[cfg(not(feature = "wasm"))]
+    /// Tokio task join error
+    #[error("{0}")]
+    TaskJoinError(#[from] tokio::task::JoinError),
 }

--- a/iota-client/src/node/mqtt.rs
+++ b/iota-client/src/node/mqtt.rs
@@ -68,7 +68,12 @@ async fn get_mqtt_client(client: &mut Client) -> Result<&mut MqttClient> {
             let nodes = if client.node_manager.sync {
                 #[cfg(not(feature = "wasm"))]
                 {
-                    client.node_manager.synced_nodes.read().expect("Failed to read synced nodes").clone()
+                    client
+                        .node_manager
+                        .synced_nodes
+                        .read()
+                        .expect("Failed to read synced nodes")
+                        .clone()
                 }
                 #[cfg(feature = "wasm")]
                 {

--- a/iota-client/src/node/mqtt.rs
+++ b/iota-client/src/node/mqtt.rs
@@ -72,8 +72,7 @@ async fn get_mqtt_client(client: &mut Client) -> Result<&mut MqttClient> {
                         .node_manager
                         .synced_nodes
                         .read()
-                        .expect("Failed to read synced nodes")
-                        .clone()
+                        .map_or(client.node_manager.nodes.clone(), |synced_nodes| synced_nodes.clone())
                 }
                 #[cfg(feature = "wasm")]
                 {

--- a/iota-client/src/node/mqtt.rs
+++ b/iota-client/src/node/mqtt.rs
@@ -68,7 +68,7 @@ async fn get_mqtt_client(client: &mut Client) -> Result<&mut MqttClient> {
             let nodes = if client.node_manager.sync {
                 #[cfg(not(feature = "wasm"))]
                 {
-                    client.node_manager.synced_nodes.read().await.clone()
+                    client.node_manager.synced_nodes.read().expect("Failed to read synced nodes").clone()
                 }
                 #[cfg(feature = "wasm")]
                 {

--- a/iota-client/src/node_manager.rs
+++ b/iota-client/src/node_manager.rs
@@ -11,10 +11,7 @@ use serde_json::Value;
 use crate::error::{Error, Result};
 use log::warn;
 use regex::Regex;
-#[cfg(feature = "wasm")]
 use std::sync::RwLock;
-#[cfg(not(feature = "wasm"))]
-use tokio::sync::RwLock;
 #[cfg(all(feature = "sync", not(feature = "async")))]
 use ureq::{Agent, AgentBuilder};
 use url::Url;
@@ -80,7 +77,7 @@ impl NodeManager {
         let nodes = if self.sync {
             #[cfg(not(feature = "wasm"))]
             {
-                self.synced_nodes.read().await.clone()
+                self.synced_nodes.read().expect("Failed to read synced nodes").clone()
             }
             #[cfg(feature = "wasm")]
             {

--- a/iota-client/src/node_manager.rs
+++ b/iota-client/src/node_manager.rs
@@ -60,7 +60,7 @@ impl NodeManager {
     pub(crate) fn builder() -> NodeManagerBuilder {
         NodeManagerBuilder::new()
     }
-    pub(crate) async fn get_urls(&self, path: &str, query: Option<&str>, remote_pow: bool) -> Vec<Url> {
+    pub(crate) async fn get_urls(&self, path: &str, query: Option<&str>, remote_pow: bool) -> Result<Vec<Url>> {
         let mut urls = Vec::new();
         if remote_pow {
             if let Some(mut pow_node) = self.primary_pow_node.clone() {
@@ -77,7 +77,10 @@ impl NodeManager {
         let nodes = if self.sync {
             #[cfg(not(feature = "wasm"))]
             {
-                self.synced_nodes.read().expect("Failed to read synced nodes").clone()
+                self.synced_nodes
+                    .read()
+                    .map_err(|_| crate::Error::NodeReadError)?
+                    .clone()
             }
             #[cfg(feature = "wasm")]
             {
@@ -91,7 +94,7 @@ impl NodeManager {
             url.set_query(query);
             urls.push(url);
         }
-        urls
+        Ok(urls)
     }
 
     pub(crate) async fn get_request<T: serde::de::DeserializeOwned>(
@@ -117,7 +120,7 @@ impl NodeManager {
         let mut result: HashMap<String, usize> = HashMap::new();
         // submit message with local PoW should use primary pow node
         // Get urls and set path
-        let urls = self.get_urls(path, query, false).await;
+        let urls = self.get_urls(path, query, false).await?;
         if self.quorum && quorum_regexes.iter().any(|re| re.is_match(&path)) && urls.len() < self.quorum_size {
             return Err(Error::QuorumPoolSizeError(urls.len(), self.quorum_size));
         }
@@ -143,10 +146,7 @@ impl NodeManager {
                         });
                     }
                 }
-                for res in futures::future::try_join_all(tasks)
-                    .await
-                    .expect("failed to sync address")
-                {
+                for res in futures::future::try_join_all(tasks).await? {
                     match res {
                         Ok(res) => {
                             if let Ok(res_text) = res.text().await {
@@ -225,7 +225,7 @@ impl NodeManager {
     // Only used for api/v1/messages/{messageID}/raw, that's why we don't need the quorum stuff
     pub(crate) async fn get_request_text(&self, path: &str, query: Option<&str>, timeout: Duration) -> Result<String> {
         // Get urls and set path
-        let urls = self.get_urls(path, query, false).await;
+        let urls = self.get_urls(path, query, false).await?;
         // Send requests
         for url in urls {
             if let Ok(res) = self.http_client.get(url.as_str(), timeout).await {
@@ -246,7 +246,7 @@ impl NodeManager {
         body: &[u8],
         remote_pow: bool,
     ) -> Result<T> {
-        let urls = self.get_urls(path, None, remote_pow).await;
+        let urls = self.get_urls(path, None, remote_pow).await?;
         // Send requests
         for url in urls {
             if let Ok(res) = self.http_client.post_bytes(url.as_str(), timeout, body).await {
@@ -267,7 +267,7 @@ impl NodeManager {
         json: Value,
         remote_pow: bool,
     ) -> Result<T> {
-        let urls = self.get_urls(path, None, remote_pow).await;
+        let urls = self.get_urls(path, None, remote_pow).await?;
         // Send requests
         for url in urls {
             if let Ok(res) = self.http_client.post_json(url.as_str(), timeout, json.clone()).await {


### PR DESCRIPTION
For whatever reason, the `tokio::sync::rwlock` deadlocks when used in succession within streams. After replacing the `network_info` and `synced_nodes` RwLock with a `std::sync::RwLock` these issues are no longer a problem. 