### PR TITLE
Fix address type

### DIFF
--- a/bindings/nodejs/lib/types/models.d.ts
+++ b/bindings/nodejs/lib/types/models.d.ts
@@ -57,7 +57,7 @@ export declare interface BrokerOptions {
   maxReconnectionAttempts?: number
 }
 
-export declare type Address = 'string'
+export declare type Address = string
 
 export declare interface AddressBalance {
   address: Address


### PR DESCRIPTION
The type for address was `'string'` (with quotation-marks), instead of just `string`, which could result in unnecessary TS errors.