### PR TITLE
fix(ci): Build Node.js bindings on Ubuntu 18.04

### DIFF
--- a/.changes/ubuntu-18.md
+++ b/.changes/ubuntu-18.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Build bindings on Ubuntu 18.04 to support older versions of glibc

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
         node-version: ['10.x', '12.x', '14.x', '15.x', '16.x']
 
     steps:


### PR DESCRIPTION
Fixes #572 

Build bindings on Ubuntu 18.04 to support older versions of glibc. Tested by installing bindings and running example code on Ubuntu 18.04, Ubuntu 20.04, and Docker `node:16-stretch`