### PR TITLE
Fix Node.js API Reference Docs

### DIFF
--- a/docs/libraries/nodejs/api_reference.md
+++ b/docs/libraries/nodejs/api_reference.md
@@ -1,3 +1,3 @@
 # API Reference
 
-{{#include ../../../bindings/nodejs/README.md:31:}}
+{{#include ../../../bindings/nodejs/README.md:39:}}


### PR DESCRIPTION
Since a recent change in the Node.js binding Readme.md, the docs pointed to the wrong line
- {{#include ../../../bindings/nodejs/README.md:**31**:}}