### PR TITLE
Use ubuntu-18.04 for Pythong workflow

### DIFF
--- a/.github/workflows/python_binding_publish.yml
+++ b/.github/workflows/python_binding_publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   linux-wheels:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]


### PR DESCRIPTION
```
Hi. I'm trying to get the python iota_client (0.2.0-a8) running on an AWS (Linux 2) (LightSail) server.
It runs fine on my Mac (Catalina) but I'm getting an ImportError failure on first run on AWS: saying the required glibc version 2.29 is not found (AWS has glibc 2.26).
```
We had the same problem with the nodejs binding and building it with ubuntu-18.04 fixed it