### PR TITLE
(feat) Python binding: add prepare/sign_transaction functions

### DIFF
--- a/bindings/python/native/src/client/mod.rs
+++ b/bindings/python/native/src/client/mod.rs
@@ -16,8 +16,8 @@ use pyo3::prelude::*;
 use std::{collections::HashMap, time::Duration};
 use types::{
     AddressBalancePair, AddressOutputsOptions, BalanceAddressResponse, BrokerOptions, Input, Message,
-    MessageMetadataResponse, MilestoneDto, MilestoneUTXOChanges, NodeInfoWrapper, Output, OutputResponse, PeerDto,
-    ReceiptDto, TreasuryResponse, UtxoInput, BECH32_HRP,
+    MessageMetadataResponse, MilestoneDto, MilestoneUTXOChanges, NodeInfoWrapper, Output, OutputResponse, Payload,
+    PeerDto, PreparedTransactionData, ReceiptDto, TreasuryResponse, UtxoInput, BECH32_HRP,
 };
 
 /// Client builder

--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -18,7 +18,8 @@ bee-rest-api = "0.1"
 bee-message = "0.1"
 bee-pow = "0.1"
 bee-common = "0.4"
-iota-crypto = { version = "0.5", features = ["std", "blake2b", "ed25519", "random", "slip10", "bip39", "bip39-en"]}
+# TODO: Use "0.6" when the iota-crypto is updated.
+iota-crypto = { git = "https://github.com/iotaledger/crypto.rs", features = ["std", "blake2b", "ed25519", "random", "slip10", "bip39", "bip39-en"], rev = "e42be4d"}
 url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/iota-client/src/api/message_builder.rs
+++ b/iota-client/src/api/message_builder.rs
@@ -39,13 +39,20 @@ pub struct PreparedTransactionData {
 /// Structure for sorting of UnlockBlocks
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AddressIndexRecorder {
-    account_index: usize,
-    input: Input,
-    output: OutputResponse,
-    address_index: usize,
-    chain: Chain,
-    internal: bool,
-    bech32_address: String,
+    /// Index of the account
+    pub account_index: usize,
+    /// The input used
+    pub input: Input,
+    /// The output information
+    pub output: OutputResponse,
+    /// index of this address on the seed
+    pub address_index: usize,
+    /// The chain derived from seed
+    pub chain: Chain,
+    /// Whether this is an internal address
+    pub internal: bool,
+    /// The address
+    pub bech32_address: String,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
- Added `prepare_transaction` Python binding
- Added `sign_transaction` Python binding
- Small refactory of type casting between Python and Rust