### PR TITLE
(feat) Python binding: added offline signing examples and fixed bugs

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -357,9 +357,53 @@ Build a message.
 | [data_str]               | <code>str</code>                     | <code>undefined</code> | The data string                              |
 | [parents]                | <code>list[str]</code>               | <code>undefined</code> | The message ids of the parents               |
 
-**Returns** the built [Message](#message).
+#### get_output_amount_and_address(output): (int, AddressDto, bool)
+
+Get the output amount and address from the provided OutputDto.
+
+| Param    | Type                   | Default                | Description                                   |
+| -------- | ---------------------- | ---------------------- | --------------------------------------------- |
+| [output] | <code>OutputDto</code> | <code>undefined</code> | The outputs where we want to send them tokens |
+
+**Returns** the tuple of (the amount of tokens, the address, the indicator of the output type: `true` for `SignatureLockedSingle`, `false` for `SignatureLockedDustAllowance`).
+
+#### prepare_transaction(inputs, outputs): PreparedTransactionData
+
+Prepare a transaction.
+
+| Param     | Type                         | Default                | Description                                      |
+| --------- | ---------------------------- | ---------------------- | ------------------------------------------------ |
+| [inputs]  | <code>list[UtxoInput]</code> | <code>undefined</code> | The UTXOInputs where we want to send tokens from |
+| [outputs] | <code>list[Output]</code>    | <code>undefined</code> | The outputs where we want to send them tokens    |
+
+**Returns** the prepared transaction data.
+
+#### sign_transaction(prepared_transaction_data, seed, start_index, end_index): Payload
+
+Sign the transaction.
+
+| Param                       | Type                                 | Default                | Description                      |
+| --------------------------- | ------------------------------------ | ---------------------- | -------------------------------- |
+| [prepared_transaction_data] | <code>PreparedTransactionData</code> | <code>undefined</code> | The prepared transaction data    |
+| [seed]                      | <code>str</code>                     | <code>undefined</code> | The seed                         |
+| [start_index]               | <code>int</code>                     | <code>undefined</code> | The start address index          |
+| [end_index]                 | <code>int</code>                     | <code>undefined</code> | The end address index (excluded) |
+
+**Returns** the [Payload](#payload).
+
+#### finish_message(payload): Message
+
+Construct the message by payload.
+
+| Param     | Type                 | Default                | Description             |
+| --------- | -------------------- | ---------------------- | ----------------------- |
+| [payload] | <code>Payload</code> | <code>undefined</code> | The [Payload](#payload) |
+
+**Returns** the [Message](#message).
 
 #### get_message_metadata(message_id): MessageMetadataResponse
+
+Get the message metadata by message_id.
 
 | Param        | Type             | Default                | Description    |
 | ------------ | ---------------- | ---------------------- | -------------- |
@@ -444,13 +488,14 @@ Gets a valid unspent address.
 
 Finds addresses from the seed regardless of their validity.
 
-| Param               | Type              | Default                | Description                    |
-| ------------------- | ----------------- | ---------------------- | ------------------------------ |
-| [seed]              | <code>str</code>  | <code>undefined</code> | The hex-encoded seed to search |
-| [account_index]     | <code>int</code>  | <code>undefined</code> | The account index              |
-| [input_range_begin] | <code>int</code>  | <code>undefined</code> | The begin of the address range |
-| [input_range_end]   | <code>int</code>  | <code>undefined</code> | The end of the address range   |
-| [get_all]           | <code>bool</code> | <code>undefined</code> | Get all addresses              |
+| Param               | Type                | Default                | Description                    |
+| ------------------- | ------------------- | ---------------------- | ------------------------------ |
+| [seed]              | <code>str</code>    | <code>undefined</code> | The hex-encoded seed to search |
+| [account_index]     | <code>int</code>    | <code>undefined</code> | The account index              |
+| [input_range_begin] | <code>int</code>    | <code>undefined</code> | The begin of the address range |
+| [input_range_end]   | <code>int</code>    | <code>undefined</code> | The end of the address range   |
+| [bech32_hrp]        | <code>string</code> | <code>undefined</code> | The Bech32 HRP                 |
+| [get_all]           | <code>bool</code>   | <code>undefined</code> | Get all addresses              |
 
 **Returns** a list of tuples with type of `(str, int)` as the address and corresponding index in the account.
 
@@ -838,6 +883,9 @@ payload = {
     'transaction': list[Transaction], # (optional)
     'milestone': list[Milestone], # (optional)
     'indexation': list[Indexation], # (optional)
+    'receipt': List[Receipt], # (optional)
+    'treasury_transaction': List[TreasuryTransaction], # (optional)
+
 }
 ```
 

--- a/bindings/python/examples/offline_signing.py
+++ b/bindings/python/examples/offline_signing.py
@@ -1,0 +1,99 @@
+# Copyright 2021 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+import iota_client
+import time
+import os
+import hashlib
+
+# Create the Client object in offline mode
+client_offline = iota_client.Client(offline=True)
+
+# Create the Client object in online mode
+client = iota_client.Client(
+    nodes_name_password=[['https://api.lb-0.testnet.chrysalis2.com']])
+
+# Random seed (NOTE: DO NOT USE THIS for production)
+rnd_seed = hashlib.sha256(os.urandom(256)).hexdigest()
+
+
+def generate_addresses():
+    """Return the generate addresses in offline mode."""
+
+    print('Start to generate addresses...')
+
+    # Generate addresses offline
+    addresses_index = client_offline.get_addresses(
+        rnd_seed, input_range_begin=0, input_range_end=10, bech32_hrp="atoi")
+
+    # Get the addresses only
+    addresses = [a[0] for a in addresses_index]
+
+    print(f'Generated offline addresses:\n{addresses}')
+
+    return addresses
+
+
+def transaction_preparation(addresses):
+    """Return the prepared transaction data."""
+
+    print("Start to prepare the transaction...")
+
+    # Address to which we want to send the amount
+    address = "atoi1qruzprxum2934lr3p77t96pzlecxv8pjzvtjrzdcgh2f5exa22n6gek0qdq"
+    amount = 1_000_000
+
+    inputs = client.find_inputs(addresses, amount)
+    print(f'Inputs: {inputs}')
+
+    # Prepare transaction
+    prepared_transaction_data = client.prepare_transaction(
+        inputs=inputs, outputs=[{'address': address, 'amount': amount}])
+
+    print(f'Prepared transaction data {prepared_transaction_data}')
+
+    return prepared_transaction_data
+
+
+def transaction_signing(prepared_transaction_data):
+    """Return the singed transaction."""
+
+    print("Start to sign the transaction...")
+
+    # Sign prepared transaction offline
+    signed_transaction = client_offline.sign_transaction(
+        prepared_transaction_data=prepared_transaction_data, seed=rnd_seed, start_index=0, end_index=100)
+
+    print(f'Singed transaction: {signed_transaction}')
+
+    return signed_transaction
+
+
+def message_sending(signed_transaction):
+    """Send the message"""
+
+    print("Start to send the message...")
+
+    # Send offline signed transaction online
+    message = client.finish_message(signed_transaction)
+    print(f'Sent message: {message}')
+    message_id = message['message_id']
+
+    print(
+        f'Transaction sent: https://explorer.iota.org/testnet/message/{message_id}')
+
+
+if __name__ == '__main__':
+    addresses = generate_addresses()
+
+    address = addresses[0]
+    print(f'Please send tokens to {address}')
+    print('Websites to send tokens: https://faucet.testnet.chrysalis2.com/ or https://faucet.tanglekit.de/')
+    print(
+        f'After sending tokens, please check https://explorer.iota.org/testnet/addr/{address}')
+    input(
+        f'Press Enter to continue after the address already gets tokens successfully...')
+
+    prepared_transaction_data = transaction_preparation(addresses)
+    signed_transaction = transaction_signing(prepared_transaction_data)
+    message_sending(signed_transaction)

--- a/bindings/python/native/src/client/high_level_api.rs
+++ b/bindings/python/native/src/client/high_level_api.rs
@@ -139,6 +139,10 @@ impl Client {
         })?
         .try_into()
     }
+    fn finish_message(&self, payload: Payload) -> Result<Message> {
+        let payload: RustPayload = payload.try_into()?;
+        crate::block_on(async { self.client.message().finish_message(Some(payload)).await })?.try_into()
+    }
     /// Get the message data from the message_id.
     ///
     /// Args:

--- a/bindings/python/native/src/client/high_level_api.rs
+++ b/bindings/python/native/src/client/high_level_api.rs
@@ -9,7 +9,7 @@ use crate::client::{
 use iota_client::{
     api::{ClientMessageBuilder as RustClientMessageBuilder, PreparedTransactionData as RustPreparedTransactionData},
     bee_message::prelude::{
-        Message as RustMessage, MessageId as RustMessageId, TransactionId as RustTransactionId,
+        Message as RustMessage, MessageId as RustMessageId, Payload as RustPayload, TransactionId as RustTransactionId,
         UtxoInput as RustUtxoInput,
     },
     bee_rest_api::types::dtos::MessageDto as BeeMessageDto,
@@ -108,11 +108,11 @@ impl Client {
         let (output_amount, address, single) = RustClientMessageBuilder::get_output_amount_and_address(&output.into())?;
         Ok((output_amount, address.into(), single))
     }
-    fn prepare_transaction(&self, inputs: Vec<Input>, outputs: Vec<Output>) -> Result<PreparedTransactionData> {
+    fn prepare_transaction(&self, inputs: Vec<UtxoInput>, outputs: Vec<Output>) -> Result<PreparedTransactionData> {
         let mut prepare_transaction_builder = self.client.message();
         for input in inputs {
             prepare_transaction_builder = prepare_transaction_builder.with_input(RustUtxoInput::new(
-                RustTransactionId::from_str(&input.transaction_id[..])?,
+                RustTransactionId::new(input.transaction_id.try_into().unwrap()),
                 input.index,
             )?);
         }
@@ -277,6 +277,7 @@ impl Client {
         account_index: Option<usize>,
         input_range_begin: Option<usize>,
         input_range_end: Option<usize>,
+        bech32_hrp: Option<String>,
         get_all: Option<bool>,
     ) -> Result<Vec<(String, Option<bool>)>> {
         let seed = RustSeed::from_bytes(&hex::decode(&seed[..])?);
@@ -291,12 +292,22 @@ impl Client {
         let end: usize = input_range_end.unwrap_or(0);
         if get_all.unwrap_or(false) {
             let addresses = crate::block_on(async {
-                self.client
-                    .get_addresses(&seed)
-                    .with_account_index(account_index.unwrap_or(0))
-                    .with_range(begin..end)
-                    .get_all()
-                    .await
+                if let Some(bech32_hrp) = bech32_hrp {
+                    self.client
+                        .get_addresses(&seed)
+                        .with_account_index(account_index.unwrap_or(0))
+                        .with_range(begin..end)
+                        .with_bech32_hrp(bech32_hrp)
+                        .get_all()
+                        .await
+                } else {
+                    self.client
+                        .get_addresses(&seed)
+                        .with_account_index(account_index.unwrap_or(0))
+                        .with_range(begin..end)
+                        .get_all()
+                        .await
+                }
             })?;
             Ok(addresses
                 .iter()
@@ -304,12 +315,22 @@ impl Client {
                 .collect())
         } else {
             let addresses = crate::block_on(async {
-                self.client
-                    .get_addresses(&seed)
-                    .with_account_index(account_index.unwrap_or(0))
-                    .with_range(begin..end)
-                    .finish()
-                    .await
+                if let Some(bech32_hrp) = bech32_hrp {
+                    self.client
+                        .get_addresses(&seed)
+                        .with_account_index(account_index.unwrap_or(0))
+                        .with_range(begin..end)
+                        .with_bech32_hrp(bech32_hrp)
+                        .finish()
+                        .await
+                } else {
+                    self.client
+                        .get_addresses(&seed)
+                        .with_account_index(account_index.unwrap_or(0))
+                        .with_range(begin..end)
+                        .finish()
+                        .await
+                }
             })?;
             Ok(addresses
                 .iter()

--- a/bindings/python/native/src/client/mod.rs
+++ b/bindings/python/native/src/client/mod.rs
@@ -145,13 +145,16 @@ impl Client {
         }
         let client = crate::block_on(async { client.finish().await.unwrap() });
 
-        // Update the BECH32_HRP
-        // Note: This unsafe code is actually safe, because the BECH32_HRP will be only initialized when we
-        //       create the client object.
-        let bech32_hrp = crate::block_on(async { client.get_bech32_hrp().await.unwrap() });
-        // Note that mutable static is unsafe and requires unsafe function or block
-        unsafe {
-            BECH32_HRP = Box::leak(bech32_hrp.into_boxed_str());
+        // If not in the offline mode
+        if offline != Some(true) {
+            // Update the BECH32_HRP
+            // Note: This unsafe code is actually safe, because the BECH32_HRP will be only initialized when we
+            //       create the client object.
+            let bech32_hrp = crate::block_on(async { client.get_bech32_hrp().await.unwrap() });
+            // Note that mutable static is unsafe and requires unsafe function or block
+            unsafe {
+                BECH32_HRP = Box::leak(bech32_hrp.into_boxed_str());
+            }
         }
         Client { client }
     }

--- a/bindings/python/native/src/client/types.rs
+++ b/bindings/python/native/src/client/types.rs
@@ -1422,11 +1422,15 @@ impl TryFrom<RegularEssence> for RustRegularEssence {
 impl TryFrom<Ed25519Signature> for RustSignatureUnlock {
     type Error = Error;
     fn try_from(signature: Ed25519Signature) -> Result<Self> {
-        let mut public_key = [0u8; 32];
-        hex::decode_to_slice(signature.public_key, &mut public_key)?;
-        let mut signature_bytes = [0u8; 64];
-        hex::decode_to_slice(signature.signature, &mut signature_bytes)?;
-        Ok(RustEd25519Signature::new(public_key, signature_bytes).into())
+        Ok(RustEd25519Signature::new(
+            signature.public_key,
+            signature
+                .signature
+                .clone()
+                .try_into()
+                .unwrap_or_else(|_| panic!("Invalid Signature: {:?}", signature.signature)),
+        )
+        .into())
     }
 }
 

--- a/bindings/python/native/src/client/types.rs
+++ b/bindings/python/native/src/client/types.rs
@@ -1353,12 +1353,12 @@ impl TryFrom<RegularEssence> for RustRegularEssence {
                 if let Some(output) = &output.signature_locked_single {
                     converted_output = Some(
                         RustSignatureLockedSingleOutput::new(
-                            RustAddress::from(RustEd25519Address::from_str(&output.address[..]).unwrap_or_else(|_| {
+                            RustAddress::try_from_bech32(&output.address[..]).unwrap_or_else(|_| {
                                 panic!(
                                     "invalid SignatureLockedSingleOutput with output address: {}",
                                     output.address
                                 )
-                            })),
+                            }),
                             output.amount,
                         )
                         .unwrap_or_else(|_| {


### PR DESCRIPTION
- Fixed the `prepare_transaction()` input type to be `Vec<UtxoInput>`
- Fixed the Client builder bug in offline mode
- Supported bech32_hrp parameter in `get_addresses()`
- Fixed `Ed25519Signature` type conversion bug
- Fixed `Ed25519Address` type conversion bug
- Added offline singing example
- Updated REAMDE