### PR TITLE
Removed deploy instructions from the docusaurus readme

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -23,11 +23,3 @@ yarn build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-## Deployment
-
-```console
-GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.


### PR DESCRIPTION
# Description of change

* Removed deploy instructions from the docusaurus readme as these can cause a CNAME error

## Links to any relevant issues

## Type of change

- Documentation Fix

## How the change has been tested

They haven't, it's a 2 line text delete from a README file

## Change checklist

- [ ] I have made corresponding changes to the documentation
