### PR TITLE
Removed routeBasePath config to match other docs sites

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -98,7 +98,6 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          routeBasePath: '/',
           // Please change this to your repo.
           editUrl: 'https://github.com/iotaledger/iota.rs/tree/dev/documentation/',
         },


### PR DESCRIPTION
# Description of change

* Removed routeBasePath config to match other docs sites

Choose a type of change, and delete any options that are not relevant

- Documentation Fix

## How the change has been tested

Docs site was mounted locally.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
