### PR TITLE
DOCS - use absolute image paths 

### DIFF
--- a/documentation/docs/libraries/java/examples.md
+++ b/documentation/docs/libraries/java/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-It's possible to send transactions with iota.rs, but we strongly recommend to use official `wallet.rs` library together with `stronghold.rs` enclave for value-based transfers. This combination incorporates the best security practices while dealing with seeds, related addresses and `UTXO`. See more information on [wallet docs](https://chrysalis.docs.iota.org/libraries/wallet.html).
+It's possible to send transactions with iota.rs, but we strongly recommend to use official `wallet.rs` library together with `stronghold.rs` enclave for value-based transfers. This combination incorporates the best security practices while dealing with seeds, related addresses and `UTXO`. See more information on [wallet docs](https://chrysalis.docs.iota.org/libraries/wallet).
 
 ```bash
 git clone https://github.com/iotaledger/iota.rs

--- a/documentation/docs/libraries/nodejs/examples.md
+++ b/documentation/docs/libraries/nodejs/examples.md
@@ -127,7 +127,7 @@ And there are few additional interesting notes:
 * Using different `accounts` may be useful to split addresses/keys into some independent spaces and it is up to developers to implement.<br />
 _Please note, it may have a negative impact on a performance while [account discovery](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#account-discovery) phase. So if you are planning on using many multiple accounts then you may be interested in our stateful library [wallet.rs](https://chrysalis.docs.iota.org/libraries/wallet) that incorporates all business logic needed to efficiently manage independent accounts. Also our [exchange guide](https://chrysalis.docs.iota.org/guides/exchange_guide) provides some useful tips on how different accounts may be leveraged_
 
-![address_generation](../../../static/img/libraries/nodejs/address_generation.svg)
+![address_generation](/img/libraries/nodejs/address_generation.svg)
 
 So in case of IOTA, the derivation path of address/key space is `[seed]/44/4218/{int}/{0,1}/{int}`. The levels `purpose` and `coin_type` are given, the rest levels are up to developers to integrate.
 
@@ -213,7 +213,7 @@ There are already implemented core payloads, such as `SignedTransaction`, `Miles
 
 Needless to say, the IOTA network ensures the outer structure of a message itself is valid and definitely aligned with a network consensus protocol, however the inner structure is very flexible, future-proof, and offers unmatched network extensibility.
 
-![messages_in_tangle](../../../static/img/libraries/nodejs/messages_in_tangle.svg)
+![messages_in_tangle](/img/libraries/nodejs/messages_in_tangle.svg)
 
 The current IOTA network incorporates the following core payloads:
 * `SignedTransaction`: payload that describes `UTXO` transactions that are the cornerstone of value-based transfers in the IOTA network. Via this payload, `message` can be also cryptographically signed
@@ -232,7 +232,7 @@ Simplified analogy:
 * **New state of ledger**: `Output B` = 20 tokens, `Output C` = 30 tokens and `Output D` = 50 tokens
 * Total supply remains the same. Just the number of outputs differ and some outputs were replaced by other outputs in the process
 
-![utxo](../../../static/img/libraries/nodejs/utxo.svg)
+![utxo](/img/libraries/nodejs/utxo.svg)
 
 The key takeaway of the outlined process is the fact that each unique `output` can be spent **only once**. Once the given `output` is spent, it can't be used any more and is irrelevant in regards to the ledger state.
 

--- a/documentation/docs/libraries/python/examples.md
+++ b/documentation/docs/libraries/python/examples.md
@@ -113,7 +113,7 @@ And there are few additional interesting notes:
 Please note, it may have a negative impact on a performance while [account discovery](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#account-discovery) phase. So if you are after using many multiple accounts then you may be interested in our stateful library [wallet.rs](https://chrysalis.docs.iota.org/libraries/wallet) that incorporates all business logic needed to efficiently manage independent accounts. Also our [exchange guide](https://chrysalis.docs.iota.org/guides/exchange_guide) provides some useful tips how different accounts may be leveraged
 :::
 
-![address_generation](../../../static/img/libraries/python/address_generation.svg)
+![address_generation](/img/libraries/python/address_generation.svg)
 
 So in case of IOTA, the derivation path of address/key space is `[seed]/44/4218/{int}/{0,1}/{int}`. The levels `purpose` and `coin_type` are given, the rest levels are up to developers to integrate.
 
@@ -212,7 +212,7 @@ There are already implemented core payloads, such as `SignedTransaction`, `Miles
 
 Needless to say, IOTA network ensures the outer structure of message itself is valid and definitely aligned with a network consensus protocol, however the inner structure is very flexible, future-proof, and offer an unmatched network extensibility.
 
-![messages_in_tangle](../../../static/img/libraries/python/messages_in_tangle.svg)
+![messages_in_tangle](/img/libraries/python/messages_in_tangle.svg)
 
 The current IOTA network incorporates the following core payloads:
 * `SignedTransaction`: payload that describes `UTXO` transactions that are cornerstone of value-based transfers in IOTA network. Via this payload, `message` can be also cryptographically signed
@@ -231,7 +231,7 @@ Simplified analogy:
 * **New state of ledger**: `Output B` = 20 tokens, `Output C` = 30 tokens and `Output D` = 50 tokens
 * Total supply remains the same. Just number of outputs differs and some outputs were replaced by other outputs in the process
 
-![utxo](../../../static/img/libraries/python/utxo.svg)
+![utxo](/img/libraries/python/utxo.svg)
 
 The key takeaway of the outlined process is the fact that each unique `output` can be spent **only once**. Once the given `output` is spent, can't be used any more and is irrelevant in regards to the ledger state.
 

--- a/documentation/docs/overview.md
+++ b/documentation/docs/overview.md
@@ -16,7 +16,7 @@ Your application communicates with iota.rs either directly in Rust or through on
 
 Different nodes could run on a different software, but they always expose the same interface to clients. For example, one node could be a [Hornet](https://hornet.docs.iota.org/) node and the other could be a [Bee](https://bee.docs.iota.org/) node, and they both would appear the same for any client.
 
-![A diagram that illustrates the text above. It has three layers: the application layer that includes iota.rs and its bindings, communication layer (the Internet network), and IOTA network layer with nodes that operate on one of the IOTA networks.](../static/img/overview/layered_overview.svg "An overview of IOTA layers.")
+![A diagram that illustrates the text above. It has three layers: the application layer that includes iota.rs and its bindings, communication layer (the Internet network), and IOTA network layer with nodes that operate on one of the IOTA networks.](/img/overview/layered_overview.svg "An overview of IOTA layers.")
 
 ## API Design
 

--- a/documentation/docs/overview.md
+++ b/documentation/docs/overview.md
@@ -4,7 +4,7 @@ To communicate with the IOTA network, you have to connect and interact with a [n
 
 Beyond establishing the initial connection to a node, iota.rs has no state. Operations use only the data that you pass during a call and have no effect on your software beyond returning a value. You are in full control of the data flow in your application.
 
-This stateless approach makes iota.rs easier for you to use and understand. But since you are in full control of the data management, you also fully responsible for it, which could feel overwhelming if you have to handle complex or sensitive data. If you plan on managing funds in your application, take a look at our [wallet.rs](https://wallet-lib.docs.iota.org/) library instead. It allows you to safely manage your user's funds, and it already includes our best security practices. It uses [stronghold.rs](https://stronghold-docs.iota.org/) to store sensitive data and iota.rs to communicate with the IOTA network. Unlike iota.rs, it has a state.
+This stateless approach makes iota.rs easier for you to use and understand. But since you are in full control of the data management, you also fully responsible for it, which could feel overwhelming if you have to handle complex or sensitive data. If you plan on managing funds in your application, take a look at our [wallet.rs](https://wallet-lib.docs.iota.org/) library instead. It allows you to safely manage your user's funds, and it already includes our best security practices. It uses [stronghold.rs](https://stronghold.docs.iota.org/) to store sensitive data and iota.rs to communicate with the IOTA network. Unlike iota.rs, it has a state.
 
 ## Supported Languages
 


### PR DESCRIPTION
# Description of change

* Updated all docs images to use absolute paths instead of relative so they can be integrated into the upcoming wiki
* Fixed broken links

## Type of change

- [ ] Documentation Fix

## How the change has been tested
Changes were tested on a local docs site. 


## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
