### PR TITLE
Added clone to sync httpClient

### DIFF
--- a/iota-client/src/node_manager.rs
+++ b/iota-client/src/node_manager.rs
@@ -567,6 +567,7 @@ pub(crate) struct HttpClient {
 }
 
 #[cfg(all(feature = "sync", not(feature = "async")))]
+#[derive(Clone)]
 pub(crate) struct HttpClient;
 
 #[cfg(any(feature = "async", feature = "wasm"))]


### PR DESCRIPTION
Streams needs the httpClient to be cloneable :)
So we can share our transport among multiple subscribers/authors