### PR TITLE
(feat) Python binding: Add hex_public_key_to_bech32_address

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -571,6 +571,17 @@ Returns a parsed bech32 String from hex.
 
 **Returns** A String
 
+#### hex_public_key_to_bech32_address(hex, bech32_hrp (optional))
+
+Returns the bech32 address from the hex public key.
+
+| Param      | Type             | Default                | Description               |
+| ---------- | ---------------- | ---------------------- | ------------------------- |
+| bech32     | <code>str</code> | <code>undefined</code> | The address Bech32 string |
+| bech32_hrp | <code>str</code> | <code>undefined</code> | The Bech32 hrp string     |
+
+**Returns** A String
+
 #### is_address_valid(address): bool
 
 Checks if a given address is valid.

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -577,7 +577,7 @@ Returns the bech32 address from the hex public key.
 
 | Param      | Type             | Default                | Description               |
 | ---------- | ---------------- | ---------------------- | ------------------------- |
-| bech32     | <code>str</code> | <code>undefined</code> | The address Bech32 string |
+| hex        | <code>str</code> | <code>undefined</code> | Hex encoded public key    |
 | bech32_hrp | <code>str</code> | <code>undefined</code> | The Bech32 hrp string     |
 
 **Returns** A String

--- a/bindings/python/native/src/client/high_level_api.rs
+++ b/bindings/python/native/src/client/high_level_api.rs
@@ -396,6 +396,11 @@ impl Client {
             self.client.hex_to_bech32(hex, bech32_hrp).await
         })?)
     }
+    fn hex_public_key_to_bech32_address(&self, hex: &str, bech32_hrp: Option<&str>) -> Result<String> {
+        Ok(crate::block_on(async {
+            self.client.hex_public_key_to_bech32_address(hex, bech32_hrp).await
+        })?)
+    }
     fn is_address_valid(&self, address: &str) -> bool {
         RustClient::is_address_valid(address)
     }

--- a/bindings/python/native/tests/fixtures/test_vectors.json
+++ b/bindings/python/native/tests/fixtures/test_vectors.json
@@ -35,5 +35,8 @@
     ],
     "MESSAGE_ID": [
         "f541e53e98ccffdd94036f08af07f9eb060449ee7838c2279f230acc933de6d8"
-    ]
+    ],
+    "HEX_PUBLIC_KEY": "2baaf3bca8ace9f862e60184bd3e79df25ff230f7eaaa4c7f03daa9833ba854a",
+    "BECH32_HRP": "atoi",
+    "BECH32_ADDRESS": "atoi1qzt0nhsf38nh6rs4p6zs5knqp6psgha9wsv74uajqgjmwc75ugupx3y7x0r"
 }

--- a/bindings/python/native/tests/test_high_level_api.py
+++ b/bindings/python/native/tests/test_high_level_api.py
@@ -51,7 +51,8 @@ def test_get_message_index():
 
 
 def test_find_messages():
-    messages = client.find_messages(indexation_keys=[tv['INDEXATION']['INDEX'][2]])
+    messages = client.find_messages(
+        indexation_keys=[tv['INDEXATION']['INDEX'][2]])
     assert isinstance(messages, list)
 
 
@@ -122,3 +123,14 @@ def test_promote():
         assert False
     except ValueError as e:
         assert "doesn't need to be promoted or reattached" in str(e)
+
+
+def test_hex_public_key_to_bech32_address():
+
+    hex_public_key = tv['HEX_PUBLIC_KEY']
+    bech32_hrp = tv['BECH32_HRP']
+    bech32_address = tv['BECH32_ADDRESS']
+    converted_address = client.hex_public_key_to_bech32_address(
+        hex_public_key, bech32_hrp)
+
+    assert bech32_address == converted_address

--- a/documentation/docs/libraries/python/api_reference.md
+++ b/documentation/docs/libraries/python/api_reference.md
@@ -532,7 +532,7 @@ Returns the bech32 address from the hex public key.
 
 | Param      | Type  | Default     | Description               |
 | ---------- | ----- | ----------- | ------------------------- |
-| bech32     | `str` | `undefined` | The address Bech32 string |
+| hex     | `str` | `undefined` | Hex encoded public key |
 | bech32_hrp | `str` | `undefined` | The Bech32 hrp string     |
 
 **Returns** A String

--- a/documentation/docs/libraries/python/api_reference.md
+++ b/documentation/docs/libraries/python/api_reference.md
@@ -526,6 +526,17 @@ Returns a parsed bech32 String from hex.
 
 **Returns** A String
 
+#### hex_public_key_to_bech32_address(hex, bech32_hrp (optional))
+
+Returns the bech32 address from the hex public key.
+
+| Param      | Type  | Default     | Description               |
+| ---------- | ----- | ----------- | ------------------------- |
+| bech32     | `str` | `undefined` | The address Bech32 string |
+| bech32_hrp | `str` | `undefined` | The Bech32 hrp string     |
+
+**Returns** A String
+
 #### is_address_valid(address): bool
 
 Checks if a given address is valid.


### PR DESCRIPTION
- Python binding for `hex_public_key_to_bech32_address()` as a high level API
- Added the related docs
- Added the related test