### PR TITLE
Update bee-rest-api dependency

### DIFF
--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -15,7 +15,7 @@ name = "iota_client"
 
 [dependencies]
 # TODO: Use crates.io versions when bee-rest-api got updated.
-bee-rest-api = { git = "https://github.com/iotaledger/bee", rev = "c5b44f0a2867bb1655960e9418a87599e6565418" }
+bee-rest-api = { git = "https://github.com/iotaledger/bee", rev = "66fff6f4d5406c439240c9f7461b254a818a6a01" }
 # bee-message = "0.1"
 # bee-pow = "0.1"
 # bee-common = "0.4"


### PR DESCRIPTION
## Description of change
Update the commit pinned by the `bee-rest-api` dependency to fix compilation for the `wasm32-unknown-unknown` target in dependent projects.

New pinned commit: https://github.com/iotaledger/bee/commit/66fff6f4d5406c439240c9f7461b254a818a6a01

## Motivation

The new commit is still on the `chrysalis-pt-2` branch for `bee`, and is simply the latest commit to include PR https://github.com/iotaledger/bee/pull/673, which fixes Wasm compilation.

Specifically, the error we've been having at https://github.com/iotaledger/identity.rs is that `bee-network` attempts to use `libp2p::dns` and `libp2p::tcp`, which are unavailable when compiling to the `wasm32-unknown-unknown` target. Compilation error:

```
[INFO]: Checking for the Wasm target...
[INFO]: Compiling to Wasm...
   Compiling bee-network v0.2.1 (https://github.com/iotaledger/bee.git?branch=dev#a7118063)
error[E0432]: unresolved imports `libp2p::dns`, `libp2p::tcp`
  --> C:\Users\<...>\.cargo\git\checkouts\bee-781893e298f3299f\a711806\bee-network\src\swarm\builder.rs:13:5
   |
13 |     dns, identity, mplex, noise,
   |     ^^^ no `dns` in the root
14 |     swarm::SwarmBuilder,
15 |     tcp, yamux, Swarm, Transport,
   |     ^^^ no `tcp` in the root

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: could not compile `bee-network`
```

## How the change has been tested
Tests pass locally with `cargo test` and compiling `identity.rs` to the `wasm32-unknown-unknown` target succeeds with this change.