### PR TITLE
Added new rumqttc version to prevent removed feature warning

### DIFF
--- a/iota-client/Cargo.toml
+++ b/iota-client/Cargo.toml
@@ -42,7 +42,8 @@ reqwest = { version = "0.11", features = ["json", "rustls-tls", "blocking"], def
 futures = { version = "0.3", optional = true }
 
 # MQTT
-rumqttc = { version = "0.5", features = ["websocket"], optional = true}
+rumqttc = { git = "https://github.com/bytebeamio/rumqtt", rev = "621a7b526936450e4e54a999eae0171bfd5bff6f", features = ["websocket"], optional = true}
+
 # also used for storage
 once_cell = { version = "1.7", optional = true }
 


### PR DESCRIPTION
Buyilding gives me the following error:

error[E0557]: feature has been removed
 --> /home/brord/.cargo/registry/src/github.com-1ecc6299db9ec823/async_io_stream-0.2.0/src/lib.rs:1:40
  |
1 | #![cfg_attr( nightly, feature(doc_cfg, external_doc) )]
  |                                        ^^^^^^^^^^^^ feature has been removed
  |
  = note: use #[doc = include_str!("filename")] instead, which handles macro invocations

Updating to a new revision fixes it