### PR TITLE
Revert "apply version updates (#693)"

### DIFF
--- a/.changes/default_testnet_nodes.md
+++ b/.changes/default_testnet_nodes.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Updated default testnet nodes

--- a/.changes/pow-fallback.md
+++ b/.changes/pow-fallback.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": minor
+---
+
+Added fallback to local PoW if no provided node has remote PoW enabled

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## \[2.1.0]
-
-- Updated default testnet nodes
-  - [4f060388](https://github.com/iotaledger/iota.rs/commit/4f060388a19ece1deee6b54748b13498078d0cef) Wasm binding ([#631](https://github.com/iotaledger/iota.rs/pull/631)) on 2021-09-27
-- Added fallback to local PoW if no provided node has remote PoW enabled
-  - [4f060388](https://github.com/iotaledger/iota.rs/commit/4f060388a19ece1deee6b54748b13498078d0cef) Wasm binding ([#631](https://github.com/iotaledger/iota.rs/pull/631)) on 2021-09-27
-
 ## \[2.0.0]
 
 - Changed input() to accept the output id as string instead of the transaction id and the output index

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iota/client",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "Node.js binding to the client library",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
This reverts commit 191c7b25d3d55ed20f14dff099bb89322f30dce9.
The workflow which applied the update failed because of the wrong path in the wasm config. That's fixed now and by reverting this commit we can run it again to release the new nodejs version