### PR TITLE
Clean readme and revert commit 191c7b2

### DIFF
--- a/.changes/clean_readme.md
+++ b/.changes/clean_readme.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Cleaned installation instructions in the readme

--- a/.changes/clean_readme.md
+++ b/.changes/clean_readme.md
@@ -2,4 +2,4 @@
 "nodejs-binding": patch
 ---
 
-Cleaned installation instructions in the readme
+Cleaned installation instructions and fixed the link for the API reference

--- a/.changes/default_testnet_nodes.md
+++ b/.changes/default_testnet_nodes.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Updated default testnet nodes

--- a/.changes/pow-fallback.md
+++ b/.changes/pow-fallback.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": minor
+---
+
+Added fallback to local PoW if no provided node has remote PoW enabled

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## \[2.1.0]
-
-- Updated default testnet nodes
-  - [4f060388](https://github.com/iotaledger/iota.rs/commit/4f060388a19ece1deee6b54748b13498078d0cef) Wasm binding ([#631](https://github.com/iotaledger/iota.rs/pull/631)) on 2021-09-27
-- Added fallback to local PoW if no provided node has remote PoW enabled
-  - [4f060388](https://github.com/iotaledger/iota.rs/commit/4f060388a19ece1deee6b54748b13498078d0cef) Wasm binding ([#631](https://github.com/iotaledger/iota.rs/pull/631)) on 2021-09-27
-
 ## \[2.0.0]
 
 - Changed input() to accept the output id as string instead of the transaction id and the output index

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iota/client",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "Node.js binding to the client library",
   "main": "lib/index.js",
   "repository": {

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -6,18 +6,10 @@
 
 ## Install the library:
 
-Latest Release: This version matches the main branch of this repository, is stable and will have changelogs.
 ```bash
 npm install @iota/client-wasm
 // or using yarn
 yarn add @iota/client-wasm
-```
-
-Development Release: This version matches the dev branch of this repository, may see frequent breaking changes and has the latest code changes.
-```bash
-npm install @iota/client-wasm@dev
-// or using yarn
-yarn add @iota/client-wasm@dev
 ```
 
 ## Build

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -2,7 +2,7 @@
 
 > This is the alpha version of the official WASM bindings for [IOTA client library](https://github.com/iotaledger/iota.rs).
 
-## [API Reference](docs/api-reference.md)
+## [API Reference](https://wiki.iota.org/iota.rs/libraries/wasm/api_reference)
 
 ## Install the library:
 


### PR DESCRIPTION
Cleaned the installation instructions in the readme because we will only publish one version
Added a change file for this to test if workflow works properly

Also reverts commit 191c7b2.
The workflow which applied the update failed because of the wrong path in the wasm config. That's fixed now and by reverting this commit we can run it again to release the new nodejs version