### PR TITLE
Remove gh-pages deploy action

### DIFF
--- a/.github/workflows/deploy-docs-to-gh-pages.yml
+++ b/.github/workflows/deploy-docs-to-gh-pages.yml
@@ -26,28 +26,3 @@ jobs:
           npm i
           fi
           npm run build
-  gh-release:
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: Build
-        run: |
-          cd documentation
-          if [ -e yarn.lock ]; then
-          yarn install --frozen-lockfile
-          elif [ -e package-lock.json ]; then
-          npm ci
-          else
-          npm i
-          fi
-          npm run build
-      - name: Release to GitHub Pages
-        uses: iotaledger/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./documentation/build
-          cname: client-lib.docs.iota.org


### PR DESCRIPTION
# Description of change

I removed the GitHub action to stop the documentation deployment as we now have the wiki as single point of knowledge and should keep the old sites running.

Now there are multiple solutions how this could work in the future:
- Merge this PR. PRs for the docs will still be tested by the action
- Remove the complete page. That will also disable the test of PRs
- Add the wiki-cli like identity did. That way you could clean up the documentation folder and use the wiki-cli for testing.
Check their folder content here: https://github.com/iotaledger/identity.rs/tree/dev/documentation

I will keep this PR a draft until you tell me how you want to proceed and I will implement it that way on this PR.

TO-DOs:
- [ ] Decide how to proceed
- [ ] Don't forget to disable GH pages

## Type of change

- Documentation Fix