### PR TITLE
Update RelationDto

### DIFF
--- a/bindings/python/native/src/client/types.rs
+++ b/bindings/python/native/src/client/types.rs
@@ -1037,7 +1037,7 @@ impl From<RustRelationDto> for RelationDto {
             RustRelationDto::Unknown => Self {
                 relation: "unknown".to_string(),
             },
-            RustRelationDto::Discovered => Self {
+            RustRelationDto::Autopeered => Self {
                 relation: "discovered".to_string(),
             },
         }


### PR DESCRIPTION
Update the RelationDto type in python binding due to the updated bee-rest-api version