### PR TITLE
Fix method name in Java example

### DIFF
--- a/bindings/java/examples/basic-app/src/main/java/org/example/ExampleApp.java
+++ b/bindings/java/examples/basic-app/src/main/java/org/example/ExampleApp.java
@@ -55,7 +55,7 @@ public class ExampleApp {
     public static void generateSeed() {
         try {
             SecretKey secret_key = SecretKey.generate();
-            System.out.println(RustHex.encode(secret_key.to_bytes()));
+            System.out.println(RustHex.encode(secret_key.toBytes()));
         } catch (ClientException e) {
             System.out.println("Error: " + e.getMessage());
         }


### PR DESCRIPTION
Method incorrectly named leading to compilation error when running Java example.

**To reproduce:**

Build and run Java example as described in `iota.rs/bindings/java/README.md`:
```
$ cd iota.rs/bindings/java
$ ./gradlew examples:basic-app:test --info
```

**Resulting error:**

```
Compiling with JDK Java compiler API.
./iota.rs/bindings/java/examples/basic-app/src/main/java/org/example/ExampleApp.java:58: error: cannot find symbol
            System.out.println(RustHex.encode(secret_key.to_bytes()));
                                                        ^
  symbol:   method to_bytes()
  location: variable secret_key of type SecretKey
1 error
```