### PR TITLE
Upgrade to Rust Edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ futures = { version = "0.3.17", default-features = false, optional = true }
 rumqttc = { version = "0.10.0", default-features = false, features = ["websocket"], optional = true }
 
 # also used for storage
-once_cell = { version = "1.8.0", default-features = false, optional = true }
+once_cell = { version = "1.8.0", default-features = false, features = ["std"], optional = true }
 
 # storage
 async-trait = {version = "0.1.51", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iota-client"
 version = "1.1.0"
 authors = ["IOTA Stiftung"]
-edition = "2018"
+edition = "2021"
 description = "The official, general-purpose IOTA client library in Rust for interaction with the IOTA network (Tangle)"
 documentation = "https://wiki.iota.org/iota.rs/welcome"
 homepage = "https://www.iota.org/"

--- a/bindings/java/native/Cargo.toml
+++ b/bindings/java/native/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iota-client-java"
 version = "0.1.0"
 authors = ["IOTA Stiftung"]
-edition = "2018"
+edition = "2021"
 description = "Java bindings for the IOTA client library"
 documentation = "https://wiki.iota.org/iota.rs/welcome"
 homepage = "https://www.iota.org/"

--- a/bindings/nodejs/native/Cargo.toml
+++ b/bindings/nodejs/native/Cargo.toml
@@ -4,7 +4,7 @@
 name = "client"
 version = "0.1.0"
 authors = ["IOTA Stiftung"]
-edition = "2018"
+edition = "2021"
 description = "Node.js bindings for the IOTA client library"
 documentation = "https://wiki.iota.org/iota.rs/welcome"
 homepage = "https://www.iota.org/"

--- a/bindings/nodejs/native/Cargo.toml
+++ b/bindings/nodejs/native/Cargo.toml
@@ -26,7 +26,7 @@ neon = "0.8"
 iota-client = { path = "../../..", features = ["mqtt", "pow-fallback"] }
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.68", default-features = false }
-once_cell = { version = "1.8.0", default-features = false }
+once_cell = { version = "1.8.0", default-features = false, features = ["std"] }
 rand = "0.7.3"
 futures = { version = "0.3.17", default-features = false }
 backtrace = "0.3.62"

--- a/bindings/python/native/Cargo.toml
+++ b/bindings/python/native/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iota-client-python"
 version = "0.2.0-alpha.3"
 authors = ["IOTA Stiftung"]
-edition = "2018"
+edition = "2021"
 description = "Python bindings for the IOTA client library"
 documentation = "https://wiki.iota.org/iota.rs/welcome"
 homepage = "https://www.iota.org/"

--- a/bindings/python/native/Cargo.toml
+++ b/bindings/python/native/Cargo.toml
@@ -21,7 +21,7 @@ hex = { version = "0.4.3", default-features = false }
 iota-client = { path = "../../..", features = ["mqtt", "pow-fallback"] }
 dict_derive = "0.3.0"
 serde_json = { version = "1.0.68", default-features = false }
-once_cell = { version = "1.8.0", default-features = false }
+once_cell = { version = "1.8.0", default-features = false, features = ["std"] }
 futures = { version = "0.3.17", default-features = false }
 
 [dependencies.pyo3]

--- a/bindings/wasm/native/Cargo.toml
+++ b/bindings/wasm/native/Cargo.toml
@@ -4,7 +4,7 @@
 name = "client-wasm"
 version = "0.0.1"
 authors = ["IOTA Stiftung"]
-edition = "2018"
+edition = "2021"
 description = "WebAssembly bindings for the IOTA client library"
 documentation = "https://wiki.iota.org/iota.rs/welcome"
 homepage = "https://www.iota.org/"


### PR DESCRIPTION
This PR changes all `edition = "2018"` in `Cargo.toml`s to `edition = "2021"`. A `cargo test --all-features` shows that this shouldn't break anything.