### PR TITLE
Make Cargo-udeps Happy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ homepage = "https://www.iota.org"
 documentation = "https://docs.rs/iota-client"
 license = "Apache-2.0"
 
+[package.metadata.cargo-udeps.ignore]
+normal = ["async-trait"]
+
 [dependencies]
 bee-rest-api = { version = "0.1.3", default-features = false }
 bee-message = { version  = "0.1.5", default-features = false, features = ["serde"] }

--- a/bindings/wasm/native/Cargo.toml
+++ b/bindings/wasm/native/Cargo.toml
@@ -25,14 +25,10 @@ wasm-bindgen = { version = "0.2.78", features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4.28", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 iota-client = { path = "../../..", features = ["wasm", "pow-fallback"], default-features = false }
-web-sys = {version = "0.3.52", features = ["console"] }
 
 # import needed for the wasm-bindgen feature
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] }
-
-[dev-dependencies]
-wasm-bindgen-test = { version = "0.3" }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = true


### PR DESCRIPTION
A `cargo udeps` run across the crates shows that:

- `async-trait` could be unused, but it _is_ used (as attribute markups only).
- `web-sys` and `wasm-bindgen-test` are not used in the WebAssembly bindings.

This PR fixes the above problems by:

- telling `cargo-udeps` to ignore `async-trait` (as it's a false-positive)
- removing `web-sys` and `wasm-bindgen-test` (as they're really not used)