### PR TITLE
bindings/java: fix useless use of `format!`

### DIFF
--- a/bindings/java/native/src/foreign_types/attributes.rs
+++ b/bindings/java/native/src/foreign_types/attributes.rs
@@ -40,14 +40,12 @@ pub fn class_to_string(code: &mut Vec<u8>, class_name: &str) {
     let insert_pos = class_pos + needle.len();
     code.splice(
         insert_pos..insert_pos,
-        format!(
-            r#"
+        r#"
     @Override
     public String toString() {{
         return this.to_string();
     }}
-"#
-        )
+"#.to_string()
         .as_bytes()
         .iter()
         .copied(),

--- a/bindings/java/native/src/foreign_types/attributes.rs
+++ b/bindings/java/native/src/foreign_types/attributes.rs
@@ -45,7 +45,8 @@ pub fn class_to_string(code: &mut Vec<u8>, class_name: &str) {
     public String toString() {{
         return this.to_string();
     }}
-"#.to_string()
+"#
+        .to_string()
         .as_bytes()
         .iter()
         .copied(),


### PR DESCRIPTION
A Clippy run across the crates gives an advice on changing a `format!` without any argument with `.to_string()`. This PR applies the advice.