### PR TITLE
bindings/java: suppress UB warnings from bindgen

### DIFF
--- a/bindings/java/native/src/jni_c_header.rs
+++ b/bindings/java/native/src/jni_c_header.rs
@@ -1,12 +1,15 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+// deref_nullptr: supressing UB warnings in bindgen generated code. See:
+// https://github.com/rust-lang/rust-bindgen/issues/1651
 #![allow(
     non_upper_case_globals,
     dead_code,
     non_camel_case_types,
     improper_ctypes,
     non_snake_case,
+    deref_nullptr,
     clippy::unreadable_literal,
     clippy::const_static_lifetime
 )]


### PR DESCRIPTION
A test build on the Java bindings creates a lot of warnings from the bindgen generated test cases trying to test target ABI conformance. The warning starts from rustc 1.53 (see: rust-lang/rust-bindgen#1651). This PR tries to suppress the warning, as the upstream doesn't seem to have a plan to fix it.