### PR TITLE
**/Cargo.toml: fix missing features for once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ futures = { version = "0.3.17", default-features = false, optional = true }
 rumqttc = { version = "0.10.0", default-features = false, features = ["websocket"], optional = true }
 
 # also used for storage
-once_cell = { version = "1.8.0", default-features = false, optional = true }
+once_cell = { version = "1.8.0", default-features = false, features = ["std"], optional = true }
 
 # storage
 async-trait = {version = "0.1.51", default-features = false }

--- a/bindings/nodejs/native/Cargo.toml
+++ b/bindings/nodejs/native/Cargo.toml
@@ -26,7 +26,7 @@ neon = "0.8"
 iota-client = { path = "../../..", features = ["mqtt", "pow-fallback"] }
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.68", default-features = false }
-once_cell = { version = "1.8.0", default-features = false }
+once_cell = { version = "1.8.0", default-features = false, features = ["std"] }
 rand = "0.7.3"
 futures = { version = "0.3.17", default-features = false }
 backtrace = "0.3.62"

--- a/bindings/python/native/Cargo.toml
+++ b/bindings/python/native/Cargo.toml
@@ -21,7 +21,7 @@ hex = { version = "0.4.3", default-features = false }
 iota-client = { path = "../../..", features = ["mqtt", "pow-fallback"] }
 dict_derive = "0.3.0"
 serde_json = { version = "1.0.68", default-features = false }
-once_cell = { version = "1.8.0", default-features = false }
+once_cell = { version = "1.8.0", default-features = false, features = ["std"] }
 futures = { version = "0.3.17", default-features = false }
 
 [dependencies.pyo3]


### PR DESCRIPTION
Due to the resolver v2 change in Rust edition 2021, not specifying the feature we need (even though it's transitively used in our dependencies) cause problems. Specify it.

This is an attempt to fix #745 build errors.