### PR TITLE
Use Node.js 14.x for Node.js bindings in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: ['14.x']
 
     steps:
     - uses: actions/checkout@v2
@@ -26,6 +27,11 @@ jobs:
       with:
         toolchain: stable
         override: true
+
+    - name: Set up Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
 
     - name: Get current date
       run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV


### PR DESCRIPTION
This PR fixes the CI failures on Windows for Node.js. The current version of Neon does not support past Node.js 15 on Windows IIRC, and it seems like GitHub Actions is now using Node.js 16 by default.