### PR TITLE
Remove duplicate Python build in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,15 +71,6 @@ jobs:
         # Restore from outdated cache for speed
         restore-keys: |
           ${{ matrix.os }}-stable-cargo-build-node-target-${{ hashFiles('**/Cargo.toml') }}
-    - name: Cache python binding cargo target
-      uses: actions/cache@v2.1.4
-      with:
-        path: bindings/python/native/target
-        # Add date to the cache to keep it up to date
-        key: ${{ matrix.os }}-stable-cargo-build-python-target-${{ hashFiles('**/Cargo.toml') }}-${{ env.CURRENT_DATE }}
-        # Restore from outdated cache for speed
-        restore-keys: |
-          ${{ matrix.os }}-stable-cargo-build-python-target-${{ hashFiles('**/Cargo.toml') }}
     - name: Cache wasm binding cargo target
       uses: actions/cache@v2.1.4
       with:
@@ -108,10 +99,6 @@ jobs:
     - name: Build nodejs binding
       run: yarn
       working-directory: bindings/nodejs
-
-    - name: Build python binding
-      run: cargo build --all --release
-      working-directory: bindings/python/native
 
     - name: Build wasm binding
       run: yarn


### PR DESCRIPTION
Since we're already building the Python bindings in the `test-python-binding` job, we don't need to build them again in `build-all-and-test-crate`﻿
