### PR TITLE
Bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "iota-client"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bee-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota-client"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 description = "The official, general-purpose IOTA client library in Rust for interaction with the IOTA network (Tangle)"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add `iota-client` as a dependency in `Cargo.toml`:
 
 ```toml
 [dependencies]
-iota-client = "1.1.0"
+iota-client = "1.1.1"
 ```
 
 Or, for the latest changes:

--- a/bindings/python/native/tests/test_full_node_api.py
+++ b/bindings/python/native/tests/test_full_node_api.py
@@ -31,7 +31,7 @@ def test_get_peers():
         assert isinstance(peers, list)
     except ValueError as e:
         # Else the error must be access forbidden
-        assert "Forbidden" in str(e)
+        assert "status code 400" in str(e)
 
 
 def test_get_tips():


### PR DESCRIPTION
1.1.0 doesn't compile anymore because of the bee-dependencies that had a breaking change, so we need to publish a new version