### PR TITLE
Allow setting user agent for HTTP requests

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -212,6 +212,13 @@ impl ClientBuilder {
         self
     }
 
+    /// Set User-Agent header for requests
+    /// Default is "iota-client/[version]"
+    pub fn with_user_agent(mut self, user_agent: &str) -> Self {
+        self.node_manager_builder = self.node_manager_builder.with_user_agent(user_agent.into());
+        self
+    }
+
     /// Selects the type of network to get default nodes for it, only "testnet" is supported at the moment.
     /// Nodes that don't belong to this network are ignored. The &str must match a part or all of the networkId returned
     /// in the nodeinfo from a node. For example, if the networkId is `"private-tangle"`, `"tangle"` can be used.

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use crate::{
     builder::{ClientBuilder, NetworkInfo, GET_API_TIMEOUT},
     error::*,
     node::*,
-    node_manager::Node,
+    node_manager::{Node, DEFAULT_USER_AGENT},
 };
 use bee_common::packable::Packable;
 use bee_message::{
@@ -651,7 +651,7 @@ impl Client {
     pub async fn get_node_health(url: &str) -> Result<bool> {
         let mut url = Url::parse(url)?;
         url.set_path("health");
-        let status = crate::node_manager::HttpClient::new()
+        let status = crate::node_manager::HttpClient::new(DEFAULT_USER_AGENT.into())
             .get(Node { url, jwt: None }, GET_API_TIMEOUT)
             .await?
             .status();
@@ -689,7 +689,7 @@ impl Client {
         let path = "api/v1/info";
         url.set_path(path);
 
-        let resp: SuccessBody<NodeInfo> = crate::node_manager::HttpClient::new()
+        let resp: SuccessBody<NodeInfo> = crate::node_manager::HttpClient::new(DEFAULT_USER_AGENT.into())
             .get(Node { url, jwt }, GET_API_TIMEOUT)
             .await?
             .json()


### PR DESCRIPTION
This PR creates a default user agent for HTTP requests (`iota-client/[version]`) so that we have a user agent instead of an empty string. Library consumers such as `wallet.rs` and Firefly can also set their own if desired.

Still to do: Ask maintainers of `rumqttc` if we can set the user agent of the [initial HTTP request](https://github.com/bytebeamio/rumqtt/blob/4b76fc024dedc48428160bd59a03f160b2107277/rumqttc/src/eventloop.rs#L288) before upgrading to a WebSocket connection
