### PR TITLE
Support native TLS certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +754,8 @@ dependencies = [
  "reqwest",
  "rumqttc",
  "rusqlite",
+ "rustls 0.19.1",
+ "rustls-native-certs 0.6.1",
  "serde",
  "serde_json",
  "thiserror",
@@ -921,6 +939,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "parking_lot"
@@ -1116,6 +1140,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.19.1",
+ "rustls-native-certs 0.5.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1214,10 +1239,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls 0.19.1",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca9ebdfa27d3fc180e42879037b5338ab1c040c06affd00d8338598e7800943"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
+
+[[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1243,6 +1311,29 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1571,6 +1662,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.20.2",
+ "rustls-native-certs 0.6.1",
  "serde",
  "serde_json",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ regex = { version = "1.5.4", default-features = false, features = ["std", "unico
 zeroize = { version = "1.4.1", default-features = false }
 
 # sync
-ureq = { version = "2.2.0", default-features = false, features = ["tls", "json"], optional = true }
+ureq = { version = "2.2.0", default-features = false, features = ["json"], optional = true }
 # async
-reqwest = { version = "0.11.6", default-features = false, features = ["json", "rustls-tls", "blocking"], optional = true }
+reqwest = { version = "0.11.6", default-features = false, features = ["json", "blocking"], optional = true }
 futures = { version = "0.3.17", default-features = false, optional = true }
 
 # MQTT
@@ -58,12 +58,16 @@ bee-crypto = { version = "0.2.1-alpha", default-features = false, optional = tru
 bee-ternary = { version = "0.4.2-alpha", default-features = false, optional = true }
 bytes = { version = "1.1.0", default-features = false, optional = true }
 
+# TLS
+rustls-native-certs = { version = "0.6.1", optional = true }
+rustls = { version = "0.19.1", optional = true }
+
 [dev-dependencies]
 dotenv = { version =  "0.15.0", default-features = false }
 ureq = { version = "2.2.0", default-features = false, features = ["tls", "json"] }
 
 [features]
-default = ["async"]
+default = ["async", "reqwest-rust-tls"]
 sync = ["ureq", "tokio", "futures"]
 async = ["reqwest", "futures", "tokio"]
 mqtt = ["rumqttc", "once_cell", "futures"]
@@ -71,6 +75,13 @@ storage = ["rusqlite", "once_cell"]
 wasm = ["reqwest", "futures", "wasm-timer", "bee-crypto", "bee-ternary", "bytes"]
 #fallback to local PoW
 pow-fallback = []
+
+# TLS features
+reqwest-rust-tls = ["reqwest/rustls-tls"]
+ureq-rust-tls = ["ureq/tls"]
+reqwest-native-certs = ["reqwest/rustls-tls-native-roots", "reqwest-rust-tls"]
+ureq-native-certs = ["ureq/native-certs", "ureq/tls"]
+rumqttc-native-certs = ["rustls-native-certs", "rustls"]
 
 [[example]]
 name = "10_mqtt"


### PR DESCRIPTION
- feature: Expose native TLS certs via features
- Use wss for secure WebSocket and load native certificates

See iotaledger/iota-sdk#56, iotaledger/firefly#2111
