### PR TITLE
examples: fix unnecessary use of `to_vec`

### DIFF
--- a/.github/workflows/examine-core.yml
+++ b/.github/workflows/examine-core.yml
@@ -56,9 +56,7 @@ jobs:
 
   lint:
     name: Lint
-    # if: ${{ ! github.event.schedule }}
-    # FIXME: Fix clippy warnings. (#782)
-    if: ${{ false }}
+    if: ${{ ! github.event.schedule }}
     runs-on: ubuntu-latest
 
     steps:

--- a/examples/custom_payload.rs
+++ b/examples/custom_payload.rs
@@ -18,7 +18,7 @@ async fn main() {
         .await
         .unwrap();
 
-    let indexation_payload = IndexationPayload::new("Your Index".as_bytes(), &"Your Data".as_bytes().to_vec()).unwrap();
+    let indexation_payload = IndexationPayload::new("Your Index".as_bytes(), "Your Data".as_bytes()).unwrap();
 
     let message = iota
         .message()

--- a/src/api/message_builder.rs
+++ b/src/api/message_builder.rs
@@ -337,7 +337,7 @@ impl<'a> ClientMessageBuilder<'a> {
     async fn get_inputs(
         &self,
         total_to_spend: u64,
-        _dust_and_allowance_recorders: &mut Vec<(u64, Address, bool)>,
+        _dust_and_allowance_recorders: &mut [(u64, Address, bool)],
     ) -> Result<(Vec<Input>, Vec<Output>, Vec<AddressIndexRecorder>)> {
         let mut outputs = Vec::new();
         let mut dust_allowance_outputs = Vec::new();

--- a/src/client.rs
+++ b/src/client.rs
@@ -477,7 +477,7 @@ impl Client {
             return Ok(primary_node.clone());
         }
         let pool = self.node_manager.nodes.clone();
-        Ok(pool.into_iter().next().ok_or(Error::SyncedNodePoolEmpty)?)
+        pool.into_iter().next().ok_or(Error::SyncedNodePoolEmpty)
     }
 
     /// Gets the network id of the node we're connecting to.


### PR DESCRIPTION
Fix of clippy::unnecessary_to_owned provided by clippy 0.1.60 (777bb86 2022-01-20).