### PR TITLE
Remove pow-fallback feature and add a method to the client builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,6 @@ async = ["reqwest", "futures", "tokio"]
 mqtt = ["rumqttc", "once_cell", "futures"]
 storage = ["rusqlite", "once_cell"]
 wasm = ["reqwest", "futures", "gloo-timers", "instant", "bee-ternary", "bytes"]
-#fallback to local PoW
-pow-fallback = []
 
 [[example]]
 name = "10_mqtt"

--- a/bindings/java/native/Cargo.toml
+++ b/bindings/java/native/Cargo.toml
@@ -17,7 +17,7 @@ name = "iota_client"
 crate-type = ["cdylib"]
 
 [dependencies]
-iota-client = { path = "../../..", features = ["mqtt", "pow-fallback"] }
+iota-client = { path = "../../..", features = ["mqtt"] }
 
 # Java gen
 jni = "0.19.0"

--- a/bindings/nodejs/native/Cargo.toml
+++ b/bindings/nodejs/native/Cargo.toml
@@ -23,7 +23,7 @@ neon-build = "0.5"
 
 [dependencies]
 neon = "0.8"
-iota-client = { path = "../../..", features = ["mqtt", "pow-fallback"] }
+iota-client = { path = "../../..", features = ["mqtt"] }
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.68", default-features = false }
 once_cell = { version = "1.8.0", default-features = false, features = ["std"] }

--- a/bindings/python/native/Cargo.toml
+++ b/bindings/python/native/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 [dependencies]
 tokio = { version = "1.12.0", default-features = false, features = ["macros"] }
 hex = { version = "0.4.3", default-features = false }
-iota-client = { path = "../../..", features = ["mqtt", "pow-fallback"] }
+iota-client = { path = "../../..", features = ["mqtt"] }
 dict_derive = "0.3.0"
 serde_json = { version = "1.0.68", default-features = false }
 once_cell = { version = "1.8.0", default-features = false, features = ["std"] }

--- a/bindings/wasm/native/Cargo.toml
+++ b/bindings/wasm/native/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { version = "1.0.68", default-features = false }
 wasm-bindgen = { version = "0.2.78", features = ["serde-serialize"] }
 wasm-bindgen-futures = { version = "0.4.28", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-iota-client = { path = "../../..", features = ["wasm", "pow-fallback"], default-features = false }
+iota-client = { path = "../../..", features = ["wasm"], default-features = false }
 
 # import needed for the wasm-bindgen feature
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/api/message_builder.rs
+++ b/src/api/message_builder.rs
@@ -701,7 +701,7 @@ impl<'a> ClientMessageBuilder<'a> {
             None => finish_pow(self.client, payload).await?,
         };
 
-        let msg_id = self.client.post_message(&final_message).await?;
+        let msg_id = self.client.post_message_json(&final_message).await?;
         // Get message if we use remote PoW, because the node will change parents and nonce
         match self.client.get_local_pow().await {
             true => Ok(final_message),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -42,6 +42,9 @@ pub struct NetworkInfo {
     /// Local proof of work
     #[serde(rename = "localPow")]
     pub local_pow: bool,
+    /// Fallback to local proof of work if the node doesn't support remote PoW
+    #[serde(rename = "fallbackToLocalPow")]
+    pub fallback_to_local_pow: bool,
     /// Tips request interval during PoW in seconds
     #[serde(rename = "tipsInterval")]
     pub tips_interval: u64,
@@ -73,6 +76,7 @@ impl Default for NetworkInfo {
             local_pow: true,
             #[cfg(feature = "wasm")]
             local_pow: false,
+            fallback_to_local_pow: true,
             bech32_hrp: DEFAULT_BECH32_HRP.into(),
             tips_interval: TIPS_INTERVAL,
         }
@@ -231,6 +235,12 @@ impl ClientBuilder {
     /// Sets whether the PoW should be done locally or remotely.
     pub fn with_local_pow(mut self, local: bool) -> Self {
         self.network_info.local_pow = local;
+        self
+    }
+
+    /// Sets whether the PoW should be done locally in case a node doesn't support remote PoW.
+    pub fn with_fallback_to_local_pow(mut self, fallback_to_local_pow: bool) -> Self {
+        self.network_info.fallback_to_local_pow = fallback_to_local_pow;
         self
     }
 


### PR DESCRIPTION
Easier to use with no additional feature and can now also be used in threads.
Before one got this error 
```
within `impl Future<Output = [async output]>`, the trait `Send` is not implemented for `std::sync::RwLockWriteGuard<'_, NetworkInfo>`
```