### PR TITLE
feat: bech32 is bip-173 compliant

### DIFF
--- a/src/node/mqtt.rs
+++ b/src/node/mqtt.rs
@@ -54,7 +54,7 @@ impl Topic {
             Regex::new(r"messages/([A-Fa-f0-9]{64})/metadata").expect("regex failed"),
             Regex::new(r"outputs/([A-Fa-f0-9]{64})(\d{4})").expect("regex failed"),
             // BIP-173 compliant bech32 address
-            Regex::new("addresses/[\x22-\x7E]{1,30}1[A-Za-z0-9]+/outputs").expect("regex failed"),
+            Regex::new("addresses/[\x21-\x7E]{1,30}1[A-Za-z0-9]+/outputs").expect("regex failed"),
             // ED25519 address hex
             Regex::new("addresses/ed25519/([A-Fa-f0-9]{64})/outputs").expect("regex failed"),
             Regex::new(r"messages/indexation/([a-f0-9]{2,128})").expect("regex failed"),

--- a/src/node/mqtt.rs
+++ b/src/node/mqtt.rs
@@ -53,8 +53,8 @@ impl Topic {
           [
             Regex::new(r"messages/([A-Fa-f0-9]{64})/metadata").expect("regex failed"),
             Regex::new(r"outputs/([A-Fa-f0-9]{64})(\d{4})").expect("regex failed"),
-            // bech32 address
-            Regex::new("addresses/(iota|atoi|iot|toi)1[A-Za-z0-9]+/outputs").expect("regex failed"),
+            // BIP-173 compliant bech32 address
+            Regex::new("addresses/[\x22-\x7E]{1,30}1[A-Za-z0-9]+/outputs").expect("regex failed"),
             // ED25519 address hex
             Regex::new("addresses/ed25519/([A-Fa-f0-9]{64})/outputs").expect("regex failed"),
             Regex::new(r"messages/indexation/([a-f0-9]{2,128})").expect("regex failed"),

--- a/src/node_manager.rs
+++ b/src/node_manager.rs
@@ -86,8 +86,8 @@ impl NodeManager {
               Regex::new(r"messages/([A-Fa-f0-9]{64})/children").expect("regex failed"),
               Regex::new(r"outputs/([A-Fa-f0-9]{64})(\d{4})").expect("regex failed"),
               // BIP-173 compliant bech32 address
-              Regex::new("addresses/[\x22-\x7E]{1,30}1[A-Za-z0-9]").expect("regex failed"),
-              Regex::new("addresses/[\x22-\x7E]{1,30}1[A-Za-z0-9]+/outputs").expect("regex failed"),
+              Regex::new("addresses/[\x21-\x7E]{1,30}1[A-Za-z0-9]").expect("regex failed"),
+              Regex::new("addresses/[\x21-\x7E]{1,30}1[A-Za-z0-9]+/outputs").expect("regex failed"),
               // ED25519 address hex
               Regex::new("addresses/ed25519/([A-Fa-f0-9]{64})").expect("regex failed"),
               Regex::new("addresses/ed25519/([A-Fa-f0-9]{64})/outputs").expect("regex failed"),
@@ -155,8 +155,8 @@ impl NodeManager {
               Regex::new(r"messages/([A-Fa-f0-9]{64})/metadata").expect("regex failed"),
               Regex::new(r"outputs/([A-Fa-f0-9]{64})(\d{4})").expect("regex failed"),
               // BIP-173 compliant bech32 address
-              Regex::new("addresses/[\x22-\x7E]{1,30}1[A-Za-z0-9]").expect("regex failed"),
-              Regex::new("addresses/[\x22-\x7E]{1,30}1[A-Za-z0-9]+/outputs").expect("regex failed"),
+              Regex::new("addresses/[\x21-\x7E]{1,30}1[A-Za-z0-9]").expect("regex failed"),
+              Regex::new("addresses/[\x21-\x7E]{1,30}1[A-Za-z0-9]+/outputs").expect("regex failed"),
               // ED25519 address hex
               Regex::new("addresses/ed25519/([A-Fa-f0-9]{64})").expect("regex failed"),
               Regex::new("addresses/ed25519/([A-Fa-f0-9]{64})/outputs").expect("regex failed"),

--- a/src/node_manager.rs
+++ b/src/node_manager.rs
@@ -85,9 +85,9 @@ impl NodeManager {
               Regex::new(r"messages/([A-Fa-f0-9]{64})/metadata").expect("regex failed"),
               Regex::new(r"messages/([A-Fa-f0-9]{64})/children").expect("regex failed"),
               Regex::new(r"outputs/([A-Fa-f0-9]{64})(\d{4})").expect("regex failed"),
-              // bech32 address
-              Regex::new("addresses/(iota|atoi|iot|toi)1[A-Za-z0-9]").expect("regex failed"),
-              Regex::new("addresses/(iota|atoi|iot|toi)1[A-Za-z0-9]+/outputs").expect("regex failed"),
+              // BIP-173 compliant bech32 address
+              Regex::new("addresses/[\x22-\x7E]{1,30}1[A-Za-z0-9]").expect("regex failed"),
+              Regex::new("addresses/[\x22-\x7E]{1,30}1[A-Za-z0-9]+/outputs").expect("regex failed"),
               // ED25519 address hex
               Regex::new("addresses/ed25519/([A-Fa-f0-9]{64})").expect("regex failed"),
               Regex::new("addresses/ed25519/([A-Fa-f0-9]{64})/outputs").expect("regex failed"),
@@ -154,9 +154,9 @@ impl NodeManager {
             [
               Regex::new(r"messages/([A-Fa-f0-9]{64})/metadata").expect("regex failed"),
               Regex::new(r"outputs/([A-Fa-f0-9]{64})(\d{4})").expect("regex failed"),
-              // bech32 address
-              Regex::new("addresses/(iota|atoi|iot|toi)1[A-Za-z0-9]").expect("regex failed"),
-              Regex::new("addresses/(iota|atoi|iot|toi)1[A-Za-z0-9]+/outputs").expect("regex failed"),
+              // BIP-173 compliant bech32 address
+              Regex::new("addresses/[\x22-\x7E]{1,30}1[A-Za-z0-9]").expect("regex failed"),
+              Regex::new("addresses/[\x22-\x7E]{1,30}1[A-Za-z0-9]+/outputs").expect("regex failed"),
               // ED25519 address hex
               Regex::new("addresses/ed25519/([A-Fa-f0-9]{64})").expect("regex failed"),
               Regex::new("addresses/ed25519/([A-Fa-f0-9]{64})/outputs").expect("regex failed"),


### PR DESCRIPTION
# Description of change

Iota addresses are defined as bech32 addresses. These consists of a Human Readable Part (HRP) + Separator + Hash of the public key. Currently, HRP only allows the following strings: `iota | atoi | iot | toi`. The HRP can be extended with the arbitrary strings according to [BIP-173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32). This PR aims to implement the different HRP's.

## Links to any relevant issues

closes: https://github.com/iotaledger/iota.rs/issues/789

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Created a private tangle with different HRP's and checked if cli-wallet can create new accounts.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
