### PR TITLE
Trim mnemonic, because empty spaces could create a different seed

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -576,6 +576,8 @@ impl Client {
 
     /// Returns a hex encoded seed for a mnemonic.
     pub fn mnemonic_to_hex_seed(mnemonic: &str) -> Result<String> {
+        // trim because empty spaces could create a different seed https://github.com/iotaledger/crypto.rs/issues/125
+        let mnemonic = mnemonic.trim();
         // first we check if the mnemonic is valid to give meaningful errors
         crypto::keys::bip39::wordlist::verify(mnemonic, &crypto::keys::bip39::wordlist::ENGLISH)
             .map_err(|e| crate::Error::InvalidMnemonic(format!("{:?}", e)))?;

--- a/tests/mnemonic.rs
+++ b/tests/mnemonic.rs
@@ -10,5 +10,12 @@ async fn mnemonic() -> Result<()> {
     assert!(Client::mnemonic_to_hex_seed("until fire hat mountain zoo grocery real deny advance change marble taste goat ivory wheat bubble panic banner tattoo client ticket action race rocket").is_ok());
     assert!(Client::mnemonic_to_hex_seed("fire until hat mountain zoo grocery real deny advance change marble taste goat ivory wheat bubble panic banner tattoo client ticket action race rocket").is_err());
     assert!(Client::mnemonic_to_hex_seed("invalid mnemonic").is_err());
+    // mnemonic with space at the beginning or end should return the same as without
+    let mnemonic = "until fire hat mountain zoo grocery real deny advance change marble taste goat ivory wheat bubble panic banner tattoo client ticket action race rocket";
+    let mnemonic_with_spaces = " until fire hat mountain zoo grocery real deny advance change marble taste goat ivory wheat bubble panic banner tattoo client ticket action race rocket ";
+    assert_eq!(
+        Client::mnemonic_to_hex_seed(mnemonic).unwrap(),
+        Client::mnemonic_to_hex_seed(mnemonic_with_spaces).unwrap()
+    );
     Ok(())
 }


### PR DESCRIPTION
# Description of change

Trim mnemonic, because empty spaces could create a different seed

## Links to any relevant issues

Fixes #778 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

With the added test

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
