### PR TITLE
Get inputs for transaction

### DIFF
--- a/examples/11_get_inputs.rs
+++ b/examples/11_get_inputs.rs
@@ -1,0 +1,30 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! cargo run --example 11_get_inputs --release
+
+use iota_client::{Client, Result};
+use bee_message::prelude::TransactionId;
+use std::str::FromStr;
+
+/// In this example, we retrieve the inputs of a transaction.
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let iota = Client::builder()
+        .with_node("https://api.lb-0.h.chrysalis-devnet.iota.cafe")?
+        .finish()
+        .await?;
+
+    let transaction_id = TransactionId::from_str("131f4b296cf0e3283d6d8cfeb925bdbec4d5a42dcb58f5ef4b9f85b87f5e6f16").unwrap();
+    let inputs = iota.get_inputs(&transaction_id).await?;
+    for (idx, input) in inputs.iter().enumerate() {
+        println!(
+            "{}: {:#?}",
+            idx,
+            input,
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
# Description of change
Previously there was no way to query for a transaction's inputs given its ID. This PR aims to add a high-level function that does exactly this.

## Links to any relevant issues
- #801 

## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
I created a transaction (see [here](https://explorer.iota.org/devnet/message/7da32e3740d2fce4809415cdd63393405d19f0fd17c0674aff816c23eb394715)) and created an example querying for its specific inputs.

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes