### PR TITLE
Merge transaction signing code from signers

### DIFF
--- a/src/signing/mnemonic.rs
+++ b/src/signing/mnemonic.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use super::{types::InputSigningData, SignMessageMetadata};
 use crate::{
     constants::HD_WALLET_TYPE,
     signing::{SignerHandle, SignerType},
@@ -19,8 +20,6 @@ use std::{
     ops::{Deref, Range},
     path::Path,
 };
-
-use super::types::InputSigningData;
 
 fn generate_addresses(
     seed: &Seed,
@@ -110,10 +109,11 @@ impl crate::signing::Signer for MnemonicSigner {
         generate_addresses(self.deref(), coin_type, account_index, address_indexes, internal)
     }
 
-    async fn signature_unlock(
+    async fn signature_unlock<'a>(
         &mut self,
         input: &InputSigningData,
         essence_hash: &[u8; 32],
+        _: &SignMessageMetadata<'a>,
     ) -> crate::Result<UnlockBlock> {
         // Get the private and public key for this Ed25519 address
         let private_key = self

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -13,10 +13,11 @@ use crate::signing::{
 };
 
 use bee_message::{
-    address::Address,
+    address::{Address, AliasAddress, Ed25519Address, NftAddress},
+    output::Output,
     payload::transaction::{TransactionEssence, TransactionPayload},
     signature::Signature,
-    unlock_block::{UnlockBlock, UnlockBlocks},
+    unlock_block::{AliasUnlockBlock, NftUnlockBlock, ReferenceUnlockBlock, UnlockBlock, UnlockBlocks},
 };
 
 #[cfg(not(feature = "wasm"))]
@@ -25,6 +26,7 @@ use tokio::sync::Mutex;
 #[cfg(feature = "wasm")]
 use std::sync::Mutex;
 use std::{
+    collections::HashMap,
     fmt::{Debug, Formatter, Result},
     ops::{Deref, Range},
     path::Path,
@@ -93,7 +95,7 @@ impl Deref for SignerHandle {
 
 /// Signer interface.
 #[async_trait::async_trait]
-pub trait Signer {
+pub trait Signer: Send + Sync {
     /// Get the ledger status.
     async fn get_ledger_status(&self, is_simulator: bool) -> LedgerStatus;
     /// Initialises a mnemonic.
@@ -108,13 +110,75 @@ pub trait Signer {
         internal: bool,
         metadata: GenerateAddressMetadata,
     ) -> crate::Result<Vec<Address>>;
+    /// Sign on `essence`, unlock `input` by returning an [UnlockBlock].
+    async fn signature_unlock(
+        &mut self,
+        input: &InputSigningData,
+        essence_hash: &[u8; 32],
+    ) -> crate::Result<UnlockBlock>;
     /// Signs transaction essence.
     async fn sign_transaction_essence<'a>(
         &mut self,
         essence: &TransactionEssence,
         inputs: &mut Vec<InputSigningData>,
-        metadata: SignMessageMetadata<'a>,
-    ) -> crate::Result<Vec<UnlockBlock>>;
+        _: SignMessageMetadata<'a>,
+    ) -> crate::Result<Vec<UnlockBlock>> {
+        // The hashed_essence gets signed
+        let hashed_essence = essence.hash();
+        let mut unlock_blocks = Vec::new();
+        let mut unlock_block_indexes = HashMap::<Address, usize>::new();
+
+        for (current_block_index, input) in inputs.iter().enumerate() {
+            // Get the address that is required to unlock the input
+            let (_, input_address) = Address::try_from_bech32(&input.bech32_address)?;
+
+            // Check if we already added an [UnlockBlock] for this address
+            match unlock_block_indexes.get(&input_address) {
+                // If we already have an [UnlockBlock] for this address, add a [UnlockBlock] based on the address type
+                Some(block_index) => match input_address {
+                    Address::Alias(_alias) => {
+                        unlock_blocks.push(UnlockBlock::Alias(AliasUnlockBlock::new(*block_index as u16)?))
+                    }
+                    Address::Ed25519(_ed25519) => {
+                        unlock_blocks.push(UnlockBlock::Reference(ReferenceUnlockBlock::new(*block_index as u16)?))
+                    }
+                    Address::Nft(_nft) => {
+                        unlock_blocks.push(UnlockBlock::Nft(NftUnlockBlock::new(*block_index as u16)?))
+                    }
+                },
+                None => {
+                    // We can only sign ed25519 addresses and unlock_block_indexes needs to contain the alias or nft
+                    // address already at this point, because the reference index needs to be lower
+                    // than the current block index
+                    if input_address.kind() != Ed25519Address::KIND {
+                        return Err(crate::Error::MissingInputWithEd25519UnlockCondition);
+                    }
+
+                    let unlock_block = self.signature_unlock(input, &hashed_essence).await?;
+                    unlock_blocks.push(unlock_block);
+
+                    // Add the ed25519 address to the unlock_block_indexes, so it gets referenced if further inputs have
+                    // the same address in their unlock condition
+                    unlock_block_indexes.insert(input_address, current_block_index);
+                }
+            }
+
+            // When we have an alias or Nft output, we will add their alias or nft address to unlock_block_indexes,
+            // because they can be used to unlock outputs via [UnlockBlock::Alias] or [UnlockBlock::Nft],
+            // that have the corresponding alias or nft address in their unlock condition
+            let output = Output::try_from(&input.output_response.output)?;
+            match &output {
+                Output::Alias(a) => {
+                    unlock_block_indexes.insert(Address::Alias(AliasAddress::new(*a.alias_id())), current_block_index)
+                }
+                Output::Nft(a) => {
+                    unlock_block_indexes.insert(Address::Nft(NftAddress::new(*a.nft_id())), current_block_index)
+                }
+                _ => None,
+            };
+        }
+        Ok(unlock_blocks)
+    }
 }
 
 // todo use validation function from bee-ledger if possible

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -111,17 +111,18 @@ pub trait Signer: Send + Sync {
         metadata: GenerateAddressMetadata,
     ) -> crate::Result<Vec<Address>>;
     /// Sign on `essence`, unlock `input` by returning an [UnlockBlock].
-    async fn signature_unlock(
+    async fn signature_unlock<'a>(
         &mut self,
         input: &InputSigningData,
         essence_hash: &[u8; 32],
+        metadata: &SignMessageMetadata<'a>,
     ) -> crate::Result<UnlockBlock>;
     /// Signs transaction essence.
     async fn sign_transaction_essence<'a>(
         &mut self,
         essence: &TransactionEssence,
         inputs: &mut Vec<InputSigningData>,
-        _: SignMessageMetadata<'a>,
+        metadata: SignMessageMetadata<'a>,
     ) -> crate::Result<Vec<UnlockBlock>> {
         // The hashed_essence gets signed
         let hashed_essence = essence.hash();
@@ -154,7 +155,7 @@ pub trait Signer: Send + Sync {
                         return Err(crate::Error::MissingInputWithEd25519UnlockCondition);
                     }
 
-                    let unlock_block = self.signature_unlock(input, &hashed_essence).await?;
+                    let unlock_block = self.signature_unlock(input, &hashed_essence, &metadata).await?;
                     unlock_blocks.push(unlock_block);
 
                     // Add the ed25519 address to the unlock_block_indexes, so it gets referenced if further inputs have

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -3,7 +3,9 @@
 
 //! Implementation of [Signer] with Stronghold as the backend.
 
-use super::{GenerateAddressMetadata, InputSigningData, LedgerStatus, Signer, SignerHandle, SignerType};
+use super::{
+    GenerateAddressMetadata, InputSigningData, LedgerStatus, SignMessageMetadata, Signer, SignerHandle, SignerType,
+};
 use crate::Result;
 use async_trait::async_trait;
 use bee_message::{
@@ -186,7 +188,12 @@ impl Signer for StrongholdSigner {
         Ok(addresses)
     }
 
-    async fn signature_unlock(&mut self, input: &InputSigningData, essence_hash: &[u8; 32]) -> Result<UnlockBlock> {
+    async fn signature_unlock<'a>(
+        &mut self,
+        input: &InputSigningData,
+        essence_hash: &[u8; 32],
+        _: &SignMessageMetadata<'a>,
+    ) -> Result<UnlockBlock> {
         // Stronghold arguments.
         let seed_location = SLIP10DeriveInput::Seed(Location::Generic {
             vault_path: SECRET_VAULT_PATH.to_vec(),


### PR DESCRIPTION
Avoid duplication by reusing the loop going through transaction inputs and outputs. To achieve this without removing it from a `Signer`, `sign_transaction_essence()` is provided as a default implementation of `Signer`. `signature_unlock()` is added to `Signer` for performing the actual signs.

Fix #836.