### PR TITLE
signing: provide default implementations

### DIFF
--- a/examples/stronghold.rs
+++ b/examples/stronghold.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
 
     let storage_path = Path::new("test.stronghold");
     let stronghold_signer =
-        StrongholdSigner::try_new_signer_handle("some_hopefully_secure_password", &storage_path).unwrap();
+        StrongholdSigner::try_new_signer_handle("some_hopefully_secure_password", storage_path).unwrap();
 
     // This example uses dotenv, which is not safe for use in production
     dotenv().ok();
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     stronghold_signer
         .lock()
         .await
-        .store_mnemonic(&storage_path, mnemonic)
+        .store_mnemonic(storage_path, mnemonic)
         .await
         .unwrap();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -153,6 +153,9 @@ pub enum Error {
     /// No input with matching ed25519 unlock condition provided
     #[error("No input with matching ed25519 unlock condition provided")]
     MissingInputWithEd25519UnlockCondition,
+    /// No mnemonic was stored, specially for the default impl of [crate::signing::Signer::store_mnemonic()].
+    #[error("No mnemonic was stored! Please implement store_mnemonic() :)")]
+    NoMnemonicWasStored,
     /// Ledger transport error
     #[cfg(feature = "ledger")]
     #[error("ledger transport error")]

--- a/src/signing/mnemonic.rs
+++ b/src/signing/mnemonic.rs
@@ -16,10 +16,7 @@ use crypto::{
     hashes::{blake2b::Blake2b256, Digest},
     keys::slip10::{Chain, Curve, Seed},
 };
-use std::{
-    ops::{Deref, Range},
-    path::Path,
-};
+use std::ops::{Deref, Range};
 
 fn generate_addresses(
     seed: &Seed,
@@ -83,20 +80,6 @@ impl MnemonicSigner {
 
 #[async_trait::async_trait]
 impl crate::signing::Signer for MnemonicSigner {
-    async fn get_ledger_status(&self, _is_simulator: bool) -> crate::signing::LedgerStatus {
-        // dummy status, function is only required in the trait because we need it for the LedgerSigner
-        crate::signing::LedgerStatus {
-            connected: false,
-            locked: false,
-            app: None,
-        }
-    }
-
-    // This function only makes sense for the Stronghold Signer
-    async fn store_mnemonic(&mut self, _storage_path: &Path, _mnemonic: String) -> crate::Result<()> {
-        Ok(())
-    }
-
     async fn generate_addresses(
         &mut self,
         // https://github.com/satoshilabs/slips/blob/master/slip-0044.md

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -111,7 +111,7 @@ pub trait Signer: Send + Sync {
     ///
     /// This is only meaningful for the Stronghold signer; other signers don't implement this.
     async fn store_mnemonic(&mut self, _: &Path, _: String) -> crate::Result<()> {
-        Ok(())
+        Err(crate::Error::NoMnemonicWasStored)
     }
 
     /// Generates an address.

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -3,9 +3,7 @@
 
 //! Implementation of [Signer] with Stronghold as the backend.
 
-use super::{
-    GenerateAddressMetadata, InputSigningData, LedgerStatus, SignMessageMetadata, Signer, SignerHandle, SignerType,
-};
+use super::{GenerateAddressMetadata, InputSigningData, SignMessageMetadata, Signer, SignerHandle, SignerType};
 use crate::Result;
 use async_trait::async_trait;
 use bee_message::{
@@ -79,15 +77,6 @@ pub struct StrongholdSigner {
 
 #[async_trait]
 impl Signer for StrongholdSigner {
-    async fn get_ledger_status(&self, _is_simulator: bool) -> LedgerStatus {
-        // Do nothing - this function is only useful for [LedgerSigner].
-        LedgerStatus {
-            connected: false,
-            locked: false,
-            app: None,
-        }
-    }
-
     async fn store_mnemonic(&mut self, _storage_path: &Path, mnemonic: String) -> Result<()> {
         // Stronghold arguments.
         let output = Location::Generic {

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -434,12 +434,12 @@ mod tests {
 
         let storage_path = Path::new("test.stronghold");
         let mnemonic = "giant dynamic museum toddler six deny defense ostrich bomb access mercy blood explain muscle shoot shallow glad autumn author calm heavy hawk abuse rally";
-        let signer = StrongholdSigner::try_new_signer_handle("", &storage_path).unwrap();
+        let signer = StrongholdSigner::try_new_signer_handle("", storage_path).unwrap();
 
         signer
             .lock()
             .await
-            .store_mnemonic(&storage_path, mnemonic.to_string())
+            .store_mnemonic(storage_path, mnemonic.to_string())
             .await
             .unwrap();
 

--- a/tests/signer.rs
+++ b/tests/signer.rs
@@ -35,7 +35,7 @@ async fn stronghold_signer_dto() -> Result<()> {
         r#"{ "Stronghold": { "password": "some_hopefully_secure_password", "snapshotPath": "test.stronghold" } }"#;
     let mnemonic = "acoustic trophy damage hint search taste love bicycle foster cradle brown govern endless depend situate athlete pudding blame question genius transfer van random vast".to_string();
 
-    let signer_type_dto: SignerTypeDto = serde_json::from_str(&stronghold_dto_str)?;
+    let signer_type_dto: SignerTypeDto = serde_json::from_str(stronghold_dto_str)?;
     let stronghold_signer = SignerHandle::from_str(&serde_json::to_string(&signer_type_dto)?)?;
 
     let storage_path = std::path::Path::new("test.stronghold");
@@ -43,7 +43,7 @@ async fn stronghold_signer_dto() -> Result<()> {
     stronghold_signer
         .lock()
         .await
-        .store_mnemonic(&storage_path, mnemonic.clone())
+        .store_mnemonic(storage_path, mnemonic.clone())
         .await
         .unwrap();
 
@@ -64,7 +64,7 @@ async fn stronghold_signer_dto() -> Result<()> {
     assert!(stronghold_signer
         .lock()
         .await
-        .store_mnemonic(&storage_path, mnemonic)
+        .store_mnemonic(storage_path, mnemonic)
         .await
         .is_err());
 


### PR DESCRIPTION
`Signer::get_ledger_status()` and `Signer::store_mnemonic()` are only for some signers; with default implementations they don't need to be implemented as stub methods any more - they're by default stubs now.

Fix #844.