### PR TITLE
Fix request_timeout

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 const DEFAULT_REMOTE_POW_TIMEOUT: Duration = Duration::from_secs(50);
-pub(crate) const GET_API_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const GET_API_TIMEOUT: Duration = Duration::from_secs(15);
 #[cfg(not(feature = "wasm"))]
 const NODE_SYNC_INTERVAL: Duration = Duration::from_secs(60);
 /// Interval in seconds when new tips will be requested during PoW
@@ -94,7 +94,7 @@ impl Default for ClientBuilder {
             #[cfg(feature = "mqtt")]
             broker_options: Default::default(),
             network_info: NetworkInfo::default(),
-            request_timeout: DEFAULT_REMOTE_POW_TIMEOUT,
+            request_timeout: GET_API_TIMEOUT,
             api_timeout: Default::default(),
             offline: false,
         }
@@ -307,35 +307,43 @@ impl ClientBuilder {
         let mut api_timeout = HashMap::new();
         api_timeout.insert(
             Api::GetInfo,
-            self.api_timeout.remove(&Api::GetInfo).unwrap_or(GET_API_TIMEOUT),
+            self.api_timeout.remove(&Api::GetInfo).unwrap_or(self.request_timeout),
         );
         api_timeout.insert(
             Api::GetPeers,
-            self.api_timeout.remove(&Api::GetPeers).unwrap_or(GET_API_TIMEOUT),
+            self.api_timeout.remove(&Api::GetPeers).unwrap_or(self.request_timeout),
         );
         api_timeout.insert(
             Api::GetHealth,
-            self.api_timeout.remove(&Api::GetHealth).unwrap_or(GET_API_TIMEOUT),
+            self.api_timeout.remove(&Api::GetHealth).unwrap_or(self.request_timeout),
         );
         api_timeout.insert(
             Api::GetMilestone,
-            self.api_timeout.remove(&Api::GetMilestone).unwrap_or(GET_API_TIMEOUT),
+            self.api_timeout
+                .remove(&Api::GetMilestone)
+                .unwrap_or(self.request_timeout),
         );
         api_timeout.insert(
             Api::GetBalance,
-            self.api_timeout.remove(&Api::GetBalance).unwrap_or(GET_API_TIMEOUT),
+            self.api_timeout
+                .remove(&Api::GetBalance)
+                .unwrap_or(self.request_timeout),
         );
         api_timeout.insert(
             Api::GetMessage,
-            self.api_timeout.remove(&Api::GetMessage).unwrap_or(GET_API_TIMEOUT),
+            self.api_timeout
+                .remove(&Api::GetMessage)
+                .unwrap_or(self.request_timeout),
         );
         api_timeout.insert(
             Api::GetTips,
-            self.api_timeout.remove(&Api::GetTips).unwrap_or(GET_API_TIMEOUT),
+            self.api_timeout.remove(&Api::GetTips).unwrap_or(self.request_timeout),
         );
         api_timeout.insert(
             Api::PostMessage,
-            self.api_timeout.remove(&Api::PostMessage).unwrap_or(GET_API_TIMEOUT),
+            self.api_timeout
+                .remove(&Api::PostMessage)
+                .unwrap_or(self.request_timeout),
         );
         api_timeout.insert(
             Api::PostMessageWithRemotePow,
@@ -345,7 +353,7 @@ impl ClientBuilder {
         );
         api_timeout.insert(
             Api::GetOutput,
-            self.api_timeout.remove(&Api::GetOutput).unwrap_or(GET_API_TIMEOUT),
+            self.api_timeout.remove(&Api::GetOutput).unwrap_or(self.request_timeout),
         );
 
         #[cfg(feature = "mqtt")]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -16,7 +16,7 @@ use std::{
     time::Duration,
 };
 
-const DEFAULT_REMOTE_POW_TIMEOUT: Duration = Duration::from_secs(50);
+const DEFAULT_REMOTE_POW_TIMEOUT: Duration = Duration::from_secs(100);
 pub(crate) const GET_API_TIMEOUT: Duration = Duration::from_secs(15);
 #[cfg(not(feature = "wasm"))]
 const NODE_SYNC_INTERVAL: Duration = Duration::from_secs(60);

--- a/src/node_manager.rs
+++ b/src/node_manager.rs
@@ -655,7 +655,7 @@ impl HttpClient {
     }
 
     pub(crate) async fn get(&self, node: Node, _timeout: Duration) -> Result<Response> {
-        let syc_start_time = std::time::Instant::now();
+        let start_time = std::time::Instant::now();
         let mut request_builder = self.client.get(node.url.clone());
         if let Some(jwt) = node.jwt {
             request_builder = request_builder.bearer_auth(jwt);
@@ -668,7 +668,7 @@ impl HttpClient {
         let response = Self::parse_response(resp).await;
         log::debug!(
             "GET request took {:?} ms for {}",
-            syc_start_time.elapsed().as_millis(),
+            start_time.elapsed().as_millis(),
             node.url
         );
         response


### PR DESCRIPTION
# Description of change

Fix request_timeout, because before it got ignored and only the `GET_API_TIMEOUT` was used.
Also update the timeouts because it was requested from the identity team.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

```Rust
#[tokio::main]
async fn main() {
    let iota = Client::builder()
        .with_node("https://api.lb-0.h.chrysalis-devnet.iota.cafe/")
        .unwrap()
        .with_request_timeout(std::time::Duration::from_millis(1))
        //.with_api_timeout(iota_client::Api::GetInfo, std::time::Duration::from_millis(1))
        .finish()
        .await
        .unwrap();

    let info = iota.get_info().await;
    println!("Node Info: {:?}", info);
}
```
Returns a timeout error now, before not.

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked that new and existing unit tests pass locally with my changes
