### PR TITLE
Downgrade zeroize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = { version = "1.0.29", default-features = false }
 num_cpus = { version = "1.13.0", default-features = false }
 log = { version = "0.4.14", default-features = false }
 regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-perl"] }
-zeroize = { version = "1.5.3", default-features = false }
+zeroize = { version = "1.4.3", default-features = false }
 
 # sync
 ureq = { version = "2.2.0", default-features = false, features = ["json"], optional = true }


### PR DESCRIPTION
# Description of change

Downgrade zeroize, because it was requested from the identity team, since they get a conflict with the latest version.