### PR TITLE
Add native tokens when foundry got created

### DIFF
--- a/src/api/message_builder/input_selection/native_token_helpers.rs
+++ b/src/api/message_builder/input_selection/native_token_helpers.rs
@@ -52,10 +52,12 @@ pub(crate) fn get_minted_and_burned_native_tokens(
     let mut burned_native_tokens: HashMap<TokenId, U256> = HashMap::new();
     for output in outputs {
         if let Output::Foundry(output_foundry) = output {
+            let mut initial_creation = true;
             for input in inputs {
                 if let Output::Foundry(input_foundry) = input {
                     let token_id = TokenId::build(output_foundry.id(), *output_foundry.token_tag());
                     if output_foundry.id() == input_foundry.id() {
+                        initial_creation = false;
                         match output_foundry
                             .circulating_supply()
                             .cmp(input_foundry.circulating_supply())
@@ -86,6 +88,19 @@ pub(crate) fn get_minted_and_burned_native_tokens(
                             }
                             Ordering::Equal => {}
                         }
+                    }
+                }
+            }
+            // If we created the foundry with this transaction, then we need to add the circulating supply as minted
+            // tokens
+            if initial_creation {
+                let token_id = TokenId::build(output_foundry.id(), *output_foundry.token_tag());
+                match minted_native_tokens.entry(token_id) {
+                    Entry::Vacant(e) => {
+                        e.insert(*output_foundry.circulating_supply());
+                    }
+                    Entry::Occupied(mut e) => {
+                        *e.get_mut() += *output_foundry.circulating_supply();
                     }
                 }
             }

--- a/src/api/message_builder/input_selection/native_token_helpers.rs
+++ b/src/api/message_builder/input_selection/native_token_helpers.rs
@@ -95,12 +95,15 @@ pub(crate) fn get_minted_and_burned_native_tokens(
             // tokens
             if initial_creation {
                 let token_id = TokenId::build(output_foundry.id(), *output_foundry.token_tag());
-                match minted_native_tokens.entry(token_id) {
-                    Entry::Vacant(e) => {
-                        e.insert(*output_foundry.circulating_supply());
-                    }
-                    Entry::Occupied(mut e) => {
-                        *e.get_mut() += *output_foundry.circulating_supply();
+                let circulating_supply = output_foundry.circulating_supply();
+                if *circulating_supply != U256::from(0) {
+                    match minted_native_tokens.entry(token_id) {
+                        Entry::Vacant(e) => {
+                            e.insert(*circulating_supply);
+                        }
+                        Entry::Occupied(mut e) => {
+                            *e.get_mut() += *circulating_supply;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Description of change

Add native tokens when foundry got created, because before we only added them if there was a difference to a previous input, but there can be a circulating supply on creation already.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

By creating a new foundry with circulating supply > 0

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked that new and existing unit tests pass locally with my changes
