### PR TITLE
Update networkinfo with wasm feature every time

### DIFF
--- a/src/api/message_builder/transaction.rs
+++ b/src/api/message_builder/transaction.rs
@@ -29,19 +29,6 @@ use std::{collections::HashSet, str::FromStr};
 /// Prepare a transaction
 pub async fn prepare_transaction(message_builder: &ClientMessageBuilder<'_>) -> Result<PreparedTransactionData> {
     log::debug!("[prepare_transaction]");
-    // To be enabled when https://github.com/iotaledger/iota.rs/issues/830 gets implemented also for the difficulty
-    // #[cfg(feature = "wasm")]
-    // // With wasm we don't have the background syncing of nodes which updates the NetworkInfo in an interval, so we
-    // need // to get the data every time we send a function, because the data could otherwise be outdated (the
-    // values could be // changed via milestones later)
-    // let rent_structure = message_builder
-    //     .client
-    //     .get_info()
-    //     .await?
-    //     .nodeinfo
-    //     .protocol
-    //     .rent_structure;
-    // #[cfg(not(feature = "wasm"))]
     let byte_cost_config = message_builder.client.get_byte_cost_config().await?;
 
     let mut governance_transition: Option<HashSet<AliasId>> = None;

--- a/src/client.rs
+++ b/src/client.rs
@@ -279,7 +279,7 @@ impl Client {
         // For WASM we don't have the node syncing process, which updates the network_info every 60 seconds, but the PoW
         // difficulty or the byte cost could change via a milestone, so we request the nodeinfo every time, so we don't
         // create invalid transactions/messages
-        if not_synced || wasm {
+        if not_synced || cfg!(feature = "wasm") {
             let info = self.get_info().await?.nodeinfo;
             let network_id = hash_network(&info.protocol.network_name).ok();
             {

--- a/src/client.rs
+++ b/src/client.rs
@@ -272,10 +272,6 @@ impl Client {
     pub async fn get_network_info(&self) -> Result<NetworkInfo> {
         let not_synced = self.network_info.read().map_or(true, |info| info.network_id.is_none());
 
-        #[cfg(not(feature = "wasm"))]
-        let wasm = false;
-        #[cfg(feature = "wasm")]
-        let wasm = true;
         // For WASM we don't have the node syncing process, which updates the network_info every 60 seconds, but the PoW
         // difficulty or the byte cost could change via a milestone, so we request the nodeinfo every time, so we don't
         // create invalid transactions/messages

--- a/src/client.rs
+++ b/src/client.rs
@@ -272,7 +272,14 @@ impl Client {
     pub async fn get_network_info(&self) -> Result<NetworkInfo> {
         let not_synced = self.network_info.read().map_or(true, |info| info.network_id.is_none());
 
-        if not_synced {
+        #[cfg(not(feature = "wasm"))]
+        let wasm = false;
+        #[cfg(feature = "wasm")]
+        let wasm = true;
+        // For WASM we don't have the node syncing process, which updates the network_info every 60 seconds, but the PoW
+        // difficulty or the byte cost could change via a milestone, so we request the nodeinfo every time, so we don't
+        // create invalid transactions/messages
+        if not_synced || wasm {
             let info = self.get_info().await?.nodeinfo;
             let network_id = hash_network(&info.protocol.network_name).ok();
             {


### PR DESCRIPTION
# Description of change

For the WASM binding we don't have the node syncing process, which updates it every 60 seconds and in the future if there will be a change via milestones a Client could construct invalid messages then, if we don't update it every time before sending a message

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota.rs/issues/830

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked that new and existing unit tests pass locally with my changes
