### PR TITLE
stronghold,signing,db: add StrongholdAdapter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,10 @@ bee-pow = { git = "https://github.com/iotaledger/bee", rev = "94261b7fb4db2edab2
 # bee-pow = { path = "../bee/bee-pow",  default-features = false }
 bee-common = { version = "0.6.0", default-features = false }
 packable = { version = "0.2.1", default-features = false, features = [ "serde", "primitive-types" ] }
-iota-crypto = { version = "0.9.1", default-features = false, features = ["std", "blake2b", "ed25519", "random", "slip10", "bip39", "bip39-en"] }
+iota-crypto = { version = "0.9.1", default-features = false, features = ["std", "chacha", "blake2b", "ed25519", "random", "slip10", "bip39", "bip39-en"] }
 
-async-trait =  { version ="0.1.51", default-features = false }
+async-trait = { version ="0.1.51", default-features = false }
+derive_builder = { version = "0.11.1", default-features = false, features = ["std"]}
 hex = { version = "0.4.3", default-features = false }
 log = { version = "0.4.14", default-features = false }
 num_cpus = { version = "1.13.0", default-features = false }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,0 +1,30 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Database provider interfaces and implementations.
+
+#[cfg(feature = "stronghold")]
+mod stronghold;
+
+#[cfg(feature = "stronghold")]
+pub use self::stronghold::StrongholdDatabaseProvider;
+
+use crate::Result;
+use async_trait::async_trait;
+
+/// The interface for database providers.
+#[async_trait]
+pub trait DatabaseProvider {
+    /// Get a value out of the database.
+    async fn get(&mut self, k: &[u8]) -> Result<Option<Vec<u8>>>;
+
+    /// Insert a value into the database.
+    ///
+    /// If there exists a record under the same key as `k`, it will be replaced by the new value (`v`) and returned.
+    async fn insert(&mut self, k: &[u8], v: &[u8]) -> Result<Option<Vec<u8>>>;
+
+    /// Delete a value from the database.
+    ///
+    /// The deleted value is returned.
+    async fn delete(&mut self, k: &[u8]) -> Result<Option<Vec<u8>>>;
+}

--- a/src/db/stronghold.rs
+++ b/src/db/stronghold.rs
@@ -1,11 +1,11 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Stronghold-as-a-Signer implementation.
+//! Stronghold-as-a-Database implementation.
 
 use crate::stronghold::StrongholdAdapter;
 
-/// Stronghold as a signer.
+/// Stronghold as a database provider.
 ///
 /// This is just an alias to the all-in-one [StrongholdAdapter].
-pub type StrongholdSigner = StrongholdAdapter;
+pub type StrongholdDatabaseProvider = StrongholdAdapter;

--- a/src/error.rs
+++ b/src/error.rs
@@ -224,6 +224,14 @@ pub enum Error {
     #[cfg(feature = "stronghold")]
     #[error("a mnemonic has already been stored in the Stronghold vault")]
     StrongholdMnemonicAlreadyStored,
+    /// No password has been supplied to a Stronghold vault, or it has been cleared
+    #[cfg(feature = "stronghold")]
+    #[error("no password has been supplied, or the key has been cleared from the memory")]
+    StrongholdKeyCleared,
+    /// No snapshot path has been supplied
+    #[cfg(feature = "stronghold")]
+    #[error("no snapshot path has been supplied")]
+    StrongholdSnapshotPathMissing,
 }
 
 // map most errors to a single error but there are some errors that

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,12 +40,15 @@ pub mod api;
 pub mod builder;
 pub mod client;
 pub mod constants;
+pub mod db;
 pub mod error;
 #[cfg(feature = "message_interface")]
 pub mod message_interface;
 pub mod node_api;
 pub mod node_manager;
 pub mod signing;
+#[cfg(feature = "stronghold")]
+pub mod stronghold;
 pub mod utils;
 
 pub use bee_common as common;

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -76,15 +76,26 @@ impl SignerHandle {
 
         Ok(match signer_type {
             #[cfg(feature = "stronghold")]
-            SignerTypeDto::Stronghold(stronghold_dto) => StrongholdSigner::builder()
-                .password(&stronghold_dto.password)
-                .snapshot_path(PathBuf::from(&stronghold_dto.snapshot_path))
-                .build()
-                .into(),
+            SignerTypeDto::Stronghold(stronghold_dto) => {
+                let mut builder = StrongholdSigner::builder();
+
+                if let Some(password) = &stronghold_dto.password {
+                    builder = builder.password(password);
+                }
+
+                if let Some(snapshot_path) = &stronghold_dto.snapshot_path {
+                    builder = builder.snapshot_path(PathBuf::from(snapshot_path));
+                }
+
+                builder.build().into()
+            }
+
             #[cfg(feature = "ledger")]
             SignerTypeDto::LedgerNano => LedgerSigner::new(false),
+
             #[cfg(feature = "ledger")]
             SignerTypeDto::LedgerNanoSimulator => LedgerSigner::new(true),
+
             SignerTypeDto::Mnemonic(mnemonic) => MnemonicSigner::new(&mnemonic)?,
         })
     }

--- a/src/signing/types.rs
+++ b/src/signing/types.rs
@@ -50,10 +50,10 @@ pub enum SignerTypeDto {
 #[cfg(feature = "stronghold")]
 pub struct StrongholdDto {
     /// The Stronghold password
-    pub password: String,
+    pub password: Option<String>,
     /// The path for the Stronghold file
     #[serde(rename = "snapshotPath")]
-    pub snapshot_path: String,
+    pub snapshot_path: Option<String>,
 }
 
 /// Metadata provided to [sign_message](trait.Signer.html#method.sign_message).

--- a/src/stronghold/common.rs
+++ b/src/stronghold/common.rs
@@ -1,0 +1,46 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Commonly used constants and utilities.
+
+use zeroize::Zeroizing;
+
+/// Stronghold vault path to secrets.
+///
+/// The value has been hard-coded historically.
+pub(super) const SECRET_VAULT_PATH: &[u8] = b"iota-wallet-secret";
+
+/// Stronghold record path to a seed.
+///
+/// The value has been hard-coded historically.
+pub(super) const SEED_RECORD_PATH: &[u8] = b"iota-wallet-seed";
+
+/// Stronghold record hint.
+///
+/// The value has been hard-coded historically.
+pub(super) const RECORD_HINT: &str = "wallet.rs-derive";
+
+/// Stronghold record path to a derived SLIP-10 private key.
+///
+/// The value has been hard-coded historically.
+pub(super) const DERIVE_OUTPUT_RECORD_PATH: &[u8] = b"iota-wallet-derived";
+
+/// Filename to the Stronghold vault.
+///
+/// The value has been hard-coded historically.
+pub(super) const STRONGHOLD_FILENAME: &str = "wallet.stronghold";
+
+/// The client path for the seed.
+///
+/// The value has been hard-coded historically.
+pub(super) const PRIVATE_DATA_CLIENT_PATH: &[u8] = b"iota_seed";
+
+/// Hash a password, deriving a key, for accessing Stronghold.
+pub(super) fn derive_key_from_password(password: &str) -> Zeroizing<Vec<u8>> {
+    let mut buffer = Zeroizing::new([0u8; 64]);
+
+    // Safe to unwrap because rounds > 0.
+    crypto::keys::pbkdf::PBKDF2_HMAC_SHA512(password.as_bytes(), b"wallet.rs", 100, buffer.as_mut()).unwrap();
+
+    Zeroizing::new(buffer[..32].to_vec())
+}

--- a/src/stronghold/db.rs
+++ b/src/stronghold/db.rs
@@ -1,0 +1,131 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! The `DatabaseProvider` implementation for `StrongholdAdapter`.
+
+use super::{
+    encryption::{decrypt, encrypt},
+    StrongholdAdapter,
+};
+use crate::{db::DatabaseProvider, Error, Result};
+use async_trait::async_trait;
+use iota_stronghold::{Location, ResultMessage};
+use log::debug;
+
+/// Convert from a string to a Stronghold location that we'll use.
+fn location_from_key(key: &[u8]) -> Location {
+    // This has been the case in wallet.rs; we preserve it here.
+    Location::Generic {
+        vault_path: key.to_vec(),
+        record_path: key.to_vec(),
+    }
+}
+
+#[async_trait]
+impl DatabaseProvider for StrongholdAdapter {
+    async fn get(&mut self, k: &[u8]) -> Result<Option<Vec<u8>>> {
+        // Lazy load the snapshot (if the path is set).
+        if self.snapshot_path.is_some() {
+            self.read_stronghold_snapshot().await?;
+        }
+
+        let location = location_from_key(k);
+        let (data, status) = self.stronghold.read_from_store(location).await;
+
+        // XXX: this theoretically indicates a non-existent key, but what about other errors?
+        if let ResultMessage::Error(err) = status {
+            debug!("Stronghold reported \"{}\", but we treat it as \"key not found\".", err);
+            return Ok(None);
+        }
+
+        let locked_key = self.key.lock().await;
+        let key = if let Some(key) = &*locked_key {
+            key
+        } else {
+            return Err(Error::StrongholdKeyCleared);
+        };
+
+        decrypt(&data, key).map(Some)
+    }
+
+    async fn insert(&mut self, k: &[u8], v: &[u8]) -> Result<Option<Vec<u8>>> {
+        // Lazy load the snapshot (if the path is set).
+        if self.snapshot_path.is_some() {
+            self.read_stronghold_snapshot().await?;
+        }
+
+        let old_value = self.get(k).await?;
+
+        let encrypted_value = {
+            let locked_key = self.key.lock().await;
+            let key = if let Some(key) = &*locked_key {
+                key
+            } else {
+                return Err(Error::StrongholdKeyCleared);
+            };
+
+            encrypt(v, key)?
+        };
+
+        let location = location_from_key(k);
+        let status = self.stronghold.write_to_store(location, encrypted_value, None).await;
+
+        if let ResultMessage::Error(err) = status {
+            return Err(Error::StrongholdProcedureError(err));
+        }
+
+        Ok(old_value)
+    }
+
+    async fn delete(&mut self, k: &[u8]) -> Result<Option<Vec<u8>>> {
+        // Lazy load the snapshot (if the path is set).
+        if self.snapshot_path.is_some() {
+            self.read_stronghold_snapshot().await?;
+        }
+
+        let old_value = self.get(k).await?;
+
+        let location = location_from_key(k);
+        let status = self.stronghold.delete_from_store(location).await;
+
+        if let ResultMessage::Error(err) = status {
+            return Err(Error::StrongholdProcedureError(err));
+        }
+
+        Ok(old_value)
+    }
+}
+
+mod tests {
+    #[tokio::test]
+    async fn test_stronghold_db() {
+        use super::StrongholdAdapter;
+        use crate::db::DatabaseProvider;
+
+        let mut stronghold = StrongholdAdapter::builder().password("drowssap").build();
+
+        assert!(matches!(stronghold.get(b"test-0").await, Ok(None)));
+        assert!(matches!(stronghold.get(b"test-1").await, Ok(None)));
+        assert!(matches!(stronghold.get(b"test-2").await, Ok(None)));
+
+        assert!(matches!(stronghold.insert(b"test-0", b"test-0").await, Ok(None)));
+        assert!(matches!(stronghold.insert(b"test-1", b"test-1").await, Ok(None)));
+        assert!(matches!(stronghold.insert(b"test-2", b"test-2").await, Ok(None)));
+
+        assert!(matches!(stronghold.get(b"test-0").await, Ok(Some(_))));
+        assert!(matches!(stronghold.get(b"test-1").await, Ok(Some(_))));
+        assert!(matches!(stronghold.get(b"test-2").await, Ok(Some(_))));
+
+        assert!(matches!(stronghold.insert(b"test-0", b"0-tset").await, Ok(Some(_))));
+        assert!(matches!(stronghold.insert(b"test-1", b"1-tset").await, Ok(Some(_))));
+        assert!(matches!(stronghold.insert(b"test-2", b"2-tset").await, Ok(Some(_))));
+
+        assert!(matches!(stronghold.delete(b"test-0").await, Ok(Some(_))));
+        assert!(matches!(stronghold.delete(b"test-1").await, Ok(Some(_))));
+        assert!(matches!(stronghold.delete(b"test-2").await, Ok(Some(_))));
+
+        assert!(matches!(stronghold.get(b"test-0").await, Ok(None)));
+        assert!(matches!(stronghold.get(b"test-1").await, Ok(None)));
+        assert!(matches!(stronghold.get(b"test-2").await, Ok(None)));
+    }
+}

--- a/src/stronghold/encryption.rs
+++ b/src/stronghold/encryption.rs
@@ -1,0 +1,63 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! A symmetric encryption implementation for `StrongholdAdapter`.
+
+use crate::Result;
+use crypto::ciphers::{chacha::XChaCha20Poly1305, traits::Aead};
+
+// Fixed position indexes for referencing the concatenated parts in a ciphertext:
+//
+//         POS_TAG_END v POS_CIPHERTEXT_START
+//       +-------+-----+------------+
+//     0 | Nonce | Tag | Ciphertext | v.len()
+//       +-------+-----+------------+
+// POS_NONCE_END ^ POS_TAG_START
+//
+// This layout is how it's been historically.
+const POS_NONCE_END: usize = XChaCha20Poly1305::NONCE_LENGTH;
+const POS_TAG_START: usize = POS_NONCE_END;
+const POS_TAG_END: usize = XChaCha20Poly1305::NONCE_LENGTH + XChaCha20Poly1305::TAG_LENGTH;
+const POS_CIPHERTEXT_START: usize = POS_TAG_END;
+
+pub(super) fn encrypt(plaintext: &[u8], key: &[u8]) -> Result<Vec<u8>> {
+    let mut nonce = [0u8; XChaCha20Poly1305::NONCE_LENGTH];
+    let mut tag = vec![0u8; XChaCha20Poly1305::TAG_LENGTH];
+    let mut ciphertext = vec![0u8; plaintext.len()];
+
+    crypto::utils::rand::fill(&mut nonce)?;
+
+    XChaCha20Poly1305::encrypt(
+        key.try_into().unwrap(),
+        &nonce.try_into().unwrap(),
+        &[],
+        plaintext,
+        ciphertext.as_mut(),
+        tag.as_mut_slice().try_into().unwrap(),
+    )?;
+
+    let mut ret = nonce.to_vec();
+    ret.append(&mut tag);
+    ret.append(&mut ciphertext);
+
+    Ok(ret)
+}
+
+pub(super) fn decrypt(data: &[u8], key: &[u8]) -> Result<Vec<u8>> {
+    let nonce = &data[..POS_NONCE_END];
+    let tag = &data[POS_TAG_START..POS_TAG_END];
+    let ciphertext = &data[POS_CIPHERTEXT_START..];
+
+    let mut plaintext = vec![0u8; ciphertext.len()];
+
+    XChaCha20Poly1305::decrypt(
+        key.try_into().unwrap(),
+        nonce.try_into().unwrap(),
+        &[],
+        &mut plaintext,
+        ciphertext,
+        tag.try_into().unwrap(),
+    )?;
+
+    Ok(plaintext)
+}

--- a/src/stronghold/mod.rs
+++ b/src/stronghold/mod.rs
@@ -1,0 +1,414 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! [Stronghold] integration for iota.rs.
+//!
+//! Stronghold can be used as a multi-purpose secret service providing:
+//!
+//! - Smart-card-like secret vault
+//! - Generic key-value, encrypted database
+//!
+//! [`StrongholdAdapter`] respectively implements [`DatabaseProvider`] and [`Signer`] for the above purposes using
+//! Stronghold. Type aliases [`StrongholdDatabaseProvider`] and [`StrongholdSigner`] are also provided if one wants to
+//! have a more consistent naming when using any of the feature sets.
+//!
+//! Use [`builder()`] to construct a [`StrongholdAdapter`] with customized parameters; see documentation of methods of
+//! [`StrongholdAdapterBuilder`] for details. Alternatively, invoking [`new()`] (or using [`Default::default()`])
+//! creates a [`StrongholdAdapter`] with default parameters. The default [`StrongholdAdapter`]:
+//!
+//! - is not initialized with a password
+//! - is without a password clearing timeout
+//! - is not associated with a snapshot file on the disk (i.e. working purely in memory)
+//!
+//! These default settings limit what [`StrongholdAdapter`] can do:
+//!
+//! - Without a password, all cryptographic operations (including database operations, as they encrypt / decrypt data)
+//!   would fail.
+//! - Without a password clearing timeout, the derived key would be stored in the memory for as long as possible, and
+//!   could be used as an attack vector.
+//! - Without a snapshot path configured, all operations would be _transient_ (i.e. all data would be lost when
+//!   [`StrongholdAdapter`] is dropped).
+//!
+//! These configurations can also be set later using [`set_password()`], [`set_snapshot_path()`], etc.
+//!
+//! Stronghold is memory-based, so it's not required to use a snapshot file on the disk. Without a snapshot path set
+//! (via [`StrongholdAdapterBuilder::snapshot_path()`] or [`StrongholdAdapter::set_snapshot_path()`]),
+//! [`StrongholdAdapter`] will run purely in memory. If a snapshot path is set, then [`StrongholdAdapter`] would lazily
+//! load the file on _the first call_ that performs some actions on Stronghold. Subsequent actions are still performed
+//! in memory. If the snapshot file doesn't exist, these function calls will all fail. To load or store the Stronghold
+//! state from or to a Stronghold snapshot on disk, remember to call [`read_stronghold_snapshot()`] or
+//! [`write_stronghold_snapshot()`]; the latter can be used to create a snapshot file after creating a
+//! [`StrongholdAdapter`] with a non-existent snapshot path.
+//!
+//! [Stronghold]: iota_stronghold
+//! [`DatabaseProvider`]: crate::db::DatabaseProvider
+//! [`Signer`]: crate::signing::Signer
+//! [`StrongholdDatabaseProvider`]: crate::db::StrongholdDatabaseProvider
+//! [`StrongholdSigner`]: crate::signing::StrongholdSigner
+//! [`builder()`]: self::StrongholdAdapter::builder()
+//! [`new()`]: self::StrongholdAdapter::new()
+//! [`set_password()`]: self::StrongholdAdapter::set_password()
+//! [`set_snapshot_path()`]: self::StrongholdAdapter::set_snapshot_path()
+//! [`read_stronghold_snapshot()`]: self::StrongholdAdapter::read_stronghold_snapshot()
+//! [`write_stronghold_snapshot()`]: self::StrongholdAdapter::write_stronghold_snapshot()
+
+mod common;
+mod db;
+mod encryption;
+mod signer;
+
+use self::common::{PRIVATE_DATA_CLIENT_PATH, STRONGHOLD_FILENAME};
+use crate::{
+    signing::{SignerHandle, SignerType},
+    Error, Result,
+};
+use derive_builder::Builder;
+use iota_stronghold::{ResultMessage, Stronghold};
+use log::debug;
+use riker::actors::ActorSystem;
+use std::{path::PathBuf, sync::Arc, time::Duration};
+use tokio::{sync::Mutex, task::JoinHandle};
+use zeroize::{Zeroize, Zeroizing};
+
+/// A wrapper on [Stronghold].
+///
+/// See the [module-level documentation](self) for more details.
+#[derive(Builder)]
+#[builder(pattern = "owned", build_fn(skip))]
+pub struct StrongholdAdapter {
+    /// A stronghold instance.
+    stronghold: Stronghold,
+
+    /// A key to open the Stronghold vault.
+    ///
+    /// Note that in [`StrongholdAdapterBuilder`] there isn't a `key()` setter, because we don't want a user to
+    /// directly set this field. Instead, [`password()`] is provided to hash a user-input password string and
+    /// derive a key from it.
+    ///
+    /// [`password()`]: self::StrongholdAdapterBuilder::password()
+    #[builder(setter(custom))]
+    key: Arc<Mutex<Option<Zeroizing<Vec<u8>>>>>,
+
+    /// An interval of time, after which `key` will be cleared from the memory.
+    ///
+    /// This is an extra security measure to further prevent attacks. If a timeout is set, then upon a `key` is set, a
+    /// timer will be spawned in the background to clear ([zeroize]) the key after `timeout`.
+    ///
+    /// If a [`StrongholdAdapter`] is destroyed (dropped), then the timer will stop too.
+    #[builder(setter(strip_option))]
+    timeout: Option<Duration>,
+
+    /// A handle to the timeout task.
+    ///
+    /// Note that this field doesn't actually have a custom setter; `setter(custom)` is only for skipping the setter
+    /// generation.
+    #[builder(setter(custom))]
+    timeout_task: Arc<Mutex<Option<JoinHandle<()>>>>,
+
+    /// The path to a Stronghold snapshot file.
+    #[builder(setter(strip_option))]
+    snapshot_path: Option<PathBuf>,
+
+    /// Whether the snapshot has been loaded from the disk to the memory.
+    #[builder(setter(skip))]
+    snapshot_loaded: bool,
+}
+
+/// [`SignerHandle`]s wrapping [`Signer`]s are still required at some places.
+impl From<StrongholdAdapter> for SignerHandle {
+    fn from(signer: StrongholdAdapter) -> Self {
+        SignerHandle {
+            signer: Arc::new(Mutex::new(Box::new(signer))),
+            signer_type: SignerType::Stronghold,
+        }
+    }
+}
+
+impl Default for StrongholdAdapter {
+    fn default() -> Self {
+        // XXX: we unwrap here.
+        let system = ActorSystem::new().map_err(|err| err.to_string()).unwrap();
+        let client_path = PRIVATE_DATA_CLIENT_PATH.to_vec();
+        let options = Vec::new();
+
+        Self {
+            stronghold: Stronghold::init_stronghold_system(system, client_path, options),
+            key: Arc::new(Mutex::new(None)),
+            timeout: None,
+            timeout_task: Arc::new(Mutex::new(None)),
+            snapshot_path: None,
+            snapshot_loaded: false,
+        }
+    }
+}
+
+/// Extra / custom builder method implementations.
+impl StrongholdAdapterBuilder {
+    /// Use an user-input password string to derive a key to use Stronghold.
+    pub fn password(mut self, password: &str) -> Self {
+        // Note that derive_builder always adds another layer of Option<T>.
+        self.key = Some(Arc::new(Mutex::new(Some(self::common::derive_key_from_password(
+            password,
+        )))));
+
+        self
+    }
+
+    /// Build [`StrongholdAdapter`] from the configuration.
+    ///
+    /// If both `key` (via [`password()`]) and `timeout` (via [`timeout()`]) are set, then an asynchronous task would be
+    /// spawned in Tokio to purge ([zeroize]) `key` after `timeout`. There is a small delay (usually a few milliseconds)
+    /// from the return of this function to this task actually being spawned and set in the returned
+    /// [`StrongholdAdapter`].
+    ///
+    /// **This function must be called inside a Tokio runtime context (usually in an `async fn` invoked by a Tokio
+    /// runtime, either directly or indirectly)**, as it uses [tokio::spawn()], which requires a Tokio context.
+    /// Otherwise, the function would panic. If this is not desired, one needs to avoid calling [`password()`] and
+    /// [`timeout()`] during the building process.
+    ///
+    /// [`password()`]: Self::password()
+    /// [`timeout()`]: Self::timeout()
+    pub fn build(mut self) -> StrongholdAdapter {
+        // If both `key` and `timeout` are set, then we spawn the task and keep its join handle.
+        if let (Some(key), Some(Some(timeout))) = (&self.key, self.timeout) {
+            let timeout_task = Arc::new(Mutex::new(None));
+
+            // The key clearing task, with the data it owns.
+            let key = key.clone();
+            let task_self = timeout_task.clone();
+
+            // To keep this function synchronous (`fn`), we spawn a task that spawns the key clearing task here. It'll
+            // however panic when this function is not in a Tokio runtime context (usually in an `async fn`), albeit it
+            // itself is a `fn`. There is also a small delay from the return of this function to the task actually being
+            // spawned and set in the `struct`.
+            tokio::spawn(async move {
+                *task_self.lock().await = Some(tokio::spawn(task_key_clear(task_self.clone(), key, timeout)));
+            });
+
+            // Keep the handle in the builder; the code below checks this.
+            self.timeout_task = Some(timeout_task);
+        }
+
+        // Create the adapter per configuration and return it.
+        //
+        // False positive: we don't throw `None`s back!
+        #[allow(clippy::question_mark)]
+        StrongholdAdapter {
+            stronghold: if let Some(stronghold) = self.stronghold {
+                stronghold
+            } else {
+                // XXX: we unwrap here.
+                let system = ActorSystem::new().map_err(|err| err.to_string()).unwrap();
+                let client_path = PRIVATE_DATA_CLIENT_PATH.to_vec();
+                let options = Vec::new();
+
+                Stronghold::init_stronghold_system(system, client_path, options)
+            },
+            key: if let Some(key) = self.key {
+                key
+            } else {
+                Arc::new(Mutex::new(None))
+            },
+            timeout: if let Some(timeout) = self.timeout {
+                timeout
+            } else {
+                None
+            },
+            timeout_task: if let Some(timeout_task) = self.timeout_task {
+                timeout_task
+            } else {
+                Arc::new(Mutex::new(None))
+            },
+            snapshot_path: if let Some(snapshot_path) = self.snapshot_path {
+                snapshot_path
+            } else {
+                None
+            },
+            snapshot_loaded: false,
+        }
+    }
+}
+
+impl StrongholdAdapter {
+    /// Create a [StrongholdAdapter] with default parameters.
+    pub fn new() -> StrongholdAdapter {
+        StrongholdAdapter::default()
+    }
+
+    /// Create a builder to construct a [StrongholdAdapter].
+    pub fn builder() -> StrongholdAdapterBuilder {
+        StrongholdAdapterBuilder::default()
+    }
+
+    /// Use an user-input password string to derive a key to use Stronghold.
+    ///
+    /// This function will also spawn an asynchronous task in Tokio to automatically purge the derived key from
+    /// `password` after `timeout` (if set).
+    pub async fn set_password(&mut self, password: &str) -> &mut Self {
+        *self.key.lock().await = Some(self::common::derive_key_from_password(password));
+
+        // If a timeout is set, spawn a task to clear the key after the timeout.
+        if let Some(timeout) = self.timeout {
+            // If there has been a spawned task, stop it and re-spawn one.
+            if let Some(timeout_task) = self.timeout_task.lock().await.take() {
+                timeout_task.abort();
+            }
+
+            // The key clearing task, with the data it owns.
+            let key = self.key.clone();
+            let task_self = self.timeout_task.clone();
+
+            *self.timeout_task.lock().await = Some(tokio::spawn(task_key_clear(task_self, key, timeout)));
+        }
+
+        self
+    }
+
+    /// Set the path to a Stronghold snapshot file.
+    pub async fn set_snapshot_path(&mut self, path: PathBuf) -> &mut Self {
+        self.snapshot_path = Some(path);
+        self
+    }
+
+    /// Immediately clear ([zeroize]) the stored key.
+    ///
+    /// If a key clearing thread has been spawned, then it'll be stopped too.
+    pub async fn clear_key(&mut self) {
+        // Stop a spawned task and setting it to None first.
+        if let Some(timeout_task) = self.timeout_task.lock().await.take() {
+            timeout_task.abort();
+        }
+
+        // Purge the key, setting it to None then.
+        if let Some(mut key) = self.key.lock().await.take() {
+            key.zeroize();
+        }
+    }
+
+    /// Load Stronghold from a snapshot at `snapshot_path`, if it hasn't been loaded yet.
+    pub async fn read_stronghold_snapshot(&mut self) -> Result<()> {
+        if self.snapshot_loaded {
+            return Ok(());
+        }
+
+        // The key and the snapshot path need to be supplied first.
+        let locked_key = self.key.lock().await;
+        let key = if let Some(key) = &*locked_key {
+            key
+        } else {
+            return Err(Error::StrongholdKeyCleared);
+        };
+
+        let snapshot_path = if let Some(path) = &self.snapshot_path {
+            path
+        } else {
+            return Err(Error::StrongholdSnapshotPathMissing);
+        };
+
+        match self
+            .stronghold
+            .read_snapshot(
+                PRIVATE_DATA_CLIENT_PATH.to_vec(),
+                None,
+                &**key,
+                Some(STRONGHOLD_FILENAME.to_string()),
+                Some(snapshot_path.clone()),
+            )
+            .await
+        {
+            ResultMessage::Ok(_) => Ok(()),
+            ResultMessage::Error(err) => Err(crate::Error::StrongholdProcedureError(err)),
+        }?;
+
+        self.snapshot_loaded = true;
+
+        Ok(())
+    }
+
+    /// Persist Stronghold to a snapshot at `snapshot_path`.
+    ///
+    /// It doesn't unload the snapshot.
+    pub async fn write_stronghold_snapshot(&mut self) -> Result<()> {
+        // The key and the snapshot path need to be supplied first.
+        let locked_key = self.key.lock().await;
+        let key = if let Some(key) = &*locked_key {
+            key
+        } else {
+            return Err(Error::StrongholdKeyCleared);
+        };
+
+        let snapshot_path = if let Some(path) = &self.snapshot_path {
+            path
+        } else {
+            return Err(Error::StrongholdSnapshotPathMissing);
+        };
+
+        match self
+            .stronghold
+            .write_all_to_snapshot(
+                &**key,
+                Some(STRONGHOLD_FILENAME.to_string()),
+                Some(snapshot_path.clone()),
+            )
+            .await
+        {
+            ResultMessage::Ok(_) => Ok(()),
+            ResultMessage::Error(err) => Err(crate::Error::StrongholdProcedureError(err)),
+        }
+    }
+}
+
+/// The asynchronous key clearing task purging `key` after `timeout` spent in Tokio.
+async fn task_key_clear(
+    task_self: Arc<Mutex<Option<JoinHandle<()>>>>,
+    key: Arc<Mutex<Option<Zeroizing<Vec<u8>>>>>,
+    timeout: Duration,
+) {
+    tokio::time::sleep(timeout).await;
+
+    debug!("StrongholdAdapter is purging the key");
+    if let Some(mut key) = key.lock().await.take() {
+        key.zeroize();
+    }
+
+    // Take self, but do nothing (we're exiting anyways).
+    task_self.lock().await.take();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_clear_key() {
+        let mut client = StrongholdAdapter::builder()
+            .password("drowssap")
+            .timeout(Duration::from_millis(100))
+            .build();
+
+        // There is a small delay between `build()` and the key clearing task being actually spawned and kept.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Setting a password would spawn a task to automatically clear the key.
+        assert!(matches!(*client.key.lock().await, Some(_)));
+        assert!(matches!(client.timeout, Some(_)));
+        assert!(matches!(*client.timeout_task.lock().await, Some(_)));
+
+        // After the timeout, the key should be purged.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(matches!(*client.key.lock().await, None));
+        assert!(matches!(client.timeout, Some(_)));
+        assert!(matches!(*client.timeout_task.lock().await, None));
+
+        // Set the key again, but this time we manually purge the key.
+        client.set_password("password").await;
+        assert!(matches!(*client.key.lock().await, Some(_)));
+        assert!(matches!(client.timeout, Some(_)));
+        assert!(matches!(*client.timeout_task.lock().await, Some(_)));
+
+        client.clear_key().await;
+        assert!(matches!(*client.key.lock().await, None));
+        assert!(matches!(client.timeout, Some(_)));
+        assert!(matches!(*client.timeout_task.lock().await, None));
+    }
+}

--- a/src/stronghold/signer.rs
+++ b/src/stronghold/signer.rs
@@ -1,0 +1,355 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! The [Signer] implementation for [StrongholdAdapter].
+
+use super::{
+    common::{DERIVE_OUTPUT_RECORD_PATH, RECORD_HINT, SECRET_VAULT_PATH, SEED_RECORD_PATH},
+    StrongholdAdapter,
+};
+use crate::{
+    signing::{types::InputSigningData, GenerateAddressMetadata, SignMessageMetadata, Signer},
+    Result,
+};
+use async_trait::async_trait;
+use bee_message::{
+    address::{Address, Ed25519Address},
+    signature::{Ed25519Signature, Signature},
+    unlock_block::{SignatureUnlockBlock, UnlockBlock},
+};
+use crypto::hashes::{blake2b::Blake2b256, Digest};
+use iota_stronghold::{Location, ProcResult, Procedure, RecordHint, ResultMessage, SLIP10DeriveInput};
+use log::warn;
+use std::ops::Range;
+
+#[async_trait]
+impl Signer for StrongholdAdapter {
+    async fn store_mnemonic(&mut self, mnemonic: String) -> Result<()> {
+        // Stronghold arguments.
+        let output = Location::Generic {
+            vault_path: SECRET_VAULT_PATH.to_vec(),
+            record_path: SEED_RECORD_PATH.to_vec(),
+        };
+        let hint = RecordHint::new("wallet.rs-seed").unwrap();
+
+        // Trim the mnemonic, in case it hasn't been, as otherwise the restored seed would be wrong.
+        let trimmed_mnemonic = mnemonic.trim().to_string();
+
+        // Check if the mnemonic is valid.
+        crypto::keys::bip39::wordlist::verify(&trimmed_mnemonic, &crypto::keys::bip39::wordlist::ENGLISH)
+            .map_err(|e| crate::Error::InvalidMnemonic(format!("{:?}", e)))?;
+
+        // Try to load the snapshot to see if we're creating a new Stronghold vault or not.
+        //
+        // XXX: The current design of [Error] doesn't allow us to see if it's really a "file does
+        // not exist" error or not. Better throw errors other than that, but now we just leave it
+        // like this, as if so then later operations would throw errors too.
+        self.read_stronghold_snapshot().await.unwrap_or(());
+
+        // If the snapshot has successfully been loaded, then we need to check if there has been a
+        // mnemonic stored in Stronghold or not to prevent overwriting it.
+        if self.snapshot_loaded && self.stronghold.record_exists(output.clone()).await {
+            return Err(crate::Error::StrongholdMnemonicAlreadyStored);
+        }
+
+        // Execute the BIP-39 recovery procedure to put it into the vault (in memory).
+        self.bip39_recover(trimmed_mnemonic, None, output, hint).await?;
+
+        // Persist Stronghold to the disk, if a snapshot path has been set.
+        if self.snapshot_path.is_some() {
+            self.write_stronghold_snapshot().await?;
+        }
+
+        // Now we consider that the snapshot has been loaded; it's just in a reversed order.
+        self.snapshot_loaded = true;
+
+        Ok(())
+    }
+
+    async fn generate_addresses(
+        &mut self,
+        coin_type: u32,
+        account_index: u32,
+        address_indexes: Range<u32>,
+        internal: bool,
+        _metadata: GenerateAddressMetadata,
+    ) -> Result<Vec<Address>> {
+        // Lazy load the snapshot (if the path is set).
+        if self.snapshot_path.is_some() {
+            self.read_stronghold_snapshot().await?;
+        }
+
+        // Stronghold arguments.
+        let seed_location = SLIP10DeriveInput::Seed(Location::Generic {
+            vault_path: SECRET_VAULT_PATH.to_vec(),
+            record_path: SEED_RECORD_PATH.to_vec(),
+        });
+        let derive_location = Location::Generic {
+            vault_path: SECRET_VAULT_PATH.to_vec(),
+            record_path: DERIVE_OUTPUT_RECORD_PATH.to_vec(),
+        };
+        let hint = RecordHint::new(RECORD_HINT).unwrap();
+
+        // Addresses to return.
+        let mut addresses = Vec::new();
+
+        for address_index in address_indexes {
+            // Stronghold 0.4.1 is still using an older version of iota-crypto, so we construct a different one here.
+            let chain = crypto05::keys::slip10::Chain::from_u32_hardened(vec![
+                44u32,
+                coin_type,
+                account_index,
+                internal as u32,
+                address_index,
+            ]);
+
+            // Derive a SLIP-10 private key in the vault.
+            self.slip10_derive(chain, seed_location.clone(), derive_location.clone(), hint)
+                .await?;
+
+            // Get the Ed25519 public key from the derived SLIP-10 private key in the vault.
+            let public_key = self.ed25519_public_key(derive_location.clone()).await?;
+
+            // Hash the public key to get the address.
+            let hash = Blake2b256::digest(&public_key);
+
+            // Convert the hash into [Address].
+            let address = Address::Ed25519(Ed25519Address::new(hash.into()));
+
+            // Collect it.
+            addresses.push(address)
+        }
+
+        Ok(addresses)
+    }
+
+    async fn signature_unlock<'a>(
+        &mut self,
+        input: &InputSigningData,
+        essence_hash: &[u8; 32],
+        _: &SignMessageMetadata<'a>,
+    ) -> Result<UnlockBlock> {
+        // Lazy load the snapshot (if the path is set).
+        if self.snapshot_path.is_some() {
+            self.read_stronghold_snapshot().await?;
+        }
+
+        // Stronghold arguments.
+        let seed_location = SLIP10DeriveInput::Seed(Location::Generic {
+            vault_path: SECRET_VAULT_PATH.to_vec(),
+            record_path: SEED_RECORD_PATH.to_vec(),
+        });
+        let derive_location = Location::Generic {
+            vault_path: SECRET_VAULT_PATH.to_vec(),
+            record_path: DERIVE_OUTPUT_RECORD_PATH.to_vec(),
+        };
+        let hint = RecordHint::new(RECORD_HINT).unwrap();
+
+        // Stronghold asks for an older version of [Chain], so we have to perform a conversion here.
+        let chain = {
+            let raw: Vec<u32> = input
+                .chain
+                .as_ref()
+                .unwrap()
+                .segments()
+                .iter()
+                // XXX: "ser32(i)". RTFSC: [crypto::keys::slip10::Segment::from_u32()]
+                .map(|seg| u32::from_be_bytes(seg.bs()))
+                .collect();
+
+            crypto05::keys::slip10::Chain::from_u32_hardened(raw)
+        };
+
+        // Derive a SLIP-10 private key in the vault.
+        self.slip10_derive(chain, seed_location.clone(), derive_location.clone(), hint)
+            .await?;
+
+        // Get the Ed25519 public key from the derived SLIP-10 private key in the vault.
+        let public_key = self.ed25519_public_key(derive_location.clone()).await?;
+
+        // Sign the message with the derived SLIP-10 private key in the vault.
+        let signature = self.ed25519_sign(derive_location.clone(), essence_hash).await?;
+
+        // Convert the raw bytes into [UnlockBlock].
+        let unlock_block = UnlockBlock::Signature(SignatureUnlockBlock::new(Signature::Ed25519(
+            Ed25519Signature::new(public_key, signature),
+        )));
+
+        Ok(unlock_block)
+    }
+}
+
+/// Private methods for the signer implementation.
+impl StrongholdAdapter {
+    /// Execute [Procedure::BIP39Recover] in Stronghold to put a mnemonic into the Stronghold vault.
+    async fn bip39_recover(
+        &self,
+        mnemonic: String,
+        passphrase: Option<String>,
+        output: Location,
+        hint: RecordHint,
+    ) -> Result<()> {
+        match self
+            .stronghold
+            .runtime_exec(Procedure::BIP39Recover {
+                mnemonic,
+                passphrase,
+                output,
+                hint,
+            })
+            .await
+        {
+            // BIP-39 recovery success.
+            ProcResult::BIP39Recover(ResultMessage::Ok(_)) => Ok(()),
+            // BIP-39 recovery failure.
+            // XXX: Should we create a separate error type for this error?
+            ProcResult::BIP39Recover(ResultMessage::Error(err)) => Err(crate::Error::StrongholdProcedureError(err)),
+            // Generic Stronghold procedure failure.
+            ProcResult::Error(err) => Err(crate::Error::StrongholdProcedureError(err)),
+            // Unexpected result type, which should never happen!
+            err => {
+                warn!(
+                    "StrongholdSigner::bip39_recover(): unexpected result from Stronghold: {:?}",
+                    err
+                );
+                Err(crate::Error::StrongholdProcedureError(format!("{:?}", err)))
+            }
+        }
+    }
+
+    /// Execute [Procedure::SLIP10Derive] in Stronghold to derive a SLIP-10 private key in the Stronghold vault.
+    async fn slip10_derive(
+        &self,
+        // Stronghold 0.4.1 is still using an older version of iota-crypto, so we ask for a different one here.
+        chain: crypto05::keys::slip10::Chain,
+        input: SLIP10DeriveInput,
+        output: Location,
+        hint: RecordHint,
+    ) -> Result<()> {
+        match self
+            .stronghold
+            .runtime_exec(Procedure::SLIP10Derive {
+                chain,
+                input,
+                output,
+                hint,
+            })
+            .await
+        {
+            // SLIP-10 derivation success.
+            // We don't care about the returned value, as later we use the output in vault.
+            ProcResult::SLIP10Derive(ResultMessage::Ok(_)) => Ok(()),
+            // SLIP-10 derivation failure.
+            // XXX: Should we create a separate error type for this error?
+            ProcResult::SLIP10Derive(ResultMessage::Error(err)) => Err(crate::Error::StrongholdProcedureError(err)),
+            // Generic Stronghold procedure failure.
+            ProcResult::Error(err) => Err(crate::Error::StrongholdProcedureError(err)),
+            // Unexpected result type, which should never happen!
+            err => {
+                warn!(
+                    "StrongholdSigner::slip10_derive(): unexpected result from Stronghold: {:?}",
+                    err
+                );
+                Err(crate::Error::StrongholdProcedureError(format!("{:?}", err)))
+            }
+        }
+    }
+
+    /// Execute [Procedure::Ed25519PublicKey] in Stronghold to get an Ed25519 public key from the SLIP-10 private key
+    /// located in `private_key`.
+    async fn ed25519_public_key(&self, private_key: Location) -> Result<[u8; 32]> {
+        match self
+            .stronghold
+            .runtime_exec(Procedure::Ed25519PublicKey { private_key })
+            .await
+        {
+            // Ed25519 public key get success.
+            ProcResult::Ed25519PublicKey(ResultMessage::Ok(pubkey)) => Ok(pubkey),
+            // Ed25519 public key get failure.
+            // XXX: Should we create a separate error type for this error?
+            ProcResult::Ed25519PublicKey(ResultMessage::Error(err)) => Err(crate::Error::StrongholdProcedureError(err)),
+            // Generic Stronghold procedure failure.
+            ProcResult::Error(err) => Err(crate::Error::StrongholdProcedureError(err)),
+            // Unexpected result type, which should never happen!
+            err => {
+                warn!(
+                    "StrongholdSigner::ed25519_public_key(): unexpected result from Stronghold: {:?}",
+                    err
+                );
+                Err(crate::Error::StrongholdProcedureError(format!("{:?}", err)))
+            }
+        }
+    }
+
+    /// Execute [Procedure::Ed25519Sign] in Stronghold to sign `msg` with `private_key` stored in the Stronghold vault.
+    async fn ed25519_sign(&self, private_key: Location, msg: &[u8]) -> Result<[u8; 64]> {
+        match self
+            .stronghold
+            .runtime_exec(Procedure::Ed25519Sign {
+                private_key,
+                msg: msg.to_vec(),
+            })
+            .await
+        {
+            // Ed25519 sign success.
+            ProcResult::Ed25519Sign(ResultMessage::Ok(msg)) => Ok(msg),
+            // Ed25519 sign failure.
+            // XXX: Should we create a separate error type for this error?
+            ProcResult::Ed25519Sign(ResultMessage::Error(err)) => Err(crate::Error::StrongholdProcedureError(err)),
+            // Generic Stronghold procedure failure.
+            ProcResult::Error(err) => Err(crate::Error::StrongholdProcedureError(err)),
+            // Unexpected result type, which should never happen!
+            err => {
+                warn!(
+                    "StrongholdSigner::ed25519_sign(): unexpected result from Stronghold: {:?}",
+                    err
+                );
+                Err(crate::Error::StrongholdProcedureError(format!("{:?}", err)))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{constants::IOTA_COIN_TYPE, signing::Network};
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn test_address_generation() {
+        let stronghold_path = PathBuf::from("test.stronghold");
+        let mnemonic = String::from("giant dynamic museum toddler six deny defense ostrich bomb access mercy blood explain muscle shoot shallow glad autumn author calm heavy hawk abuse rally");
+        let mut signer = StrongholdAdapter::builder()
+            .snapshot_path(stronghold_path.clone())
+            .password("drowssap")
+            .build();
+
+        signer.store_mnemonic(mnemonic).await.unwrap();
+
+        // The snapshot should have been on the disk now.
+        assert!(stronghold_path.exists());
+
+        let addresses = signer
+            .generate_addresses(
+                IOTA_COIN_TYPE,
+                0,
+                0..1,
+                false,
+                GenerateAddressMetadata {
+                    syncing: false,
+                    network: Network::Testnet,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            addresses[0].to_bech32("atoi"),
+            "atoi1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluehe53e".to_string()
+        );
+
+        // Remove garbage after test, but don't care about the result
+        std::fs::remove_file(stronghold_path).unwrap_or(());
+    }
+}

--- a/tests/signer.rs
+++ b/tests/signer.rs
@@ -63,6 +63,6 @@ async fn stronghold_signer_dto() -> Result<()> {
     assert!(stronghold_signer.lock().await.store_mnemonic(mnemonic).await.is_err());
 
     // Remove garbage after test, but don't care about the result
-    std::fs::remove_file(storage_path).unwrap_or(());
+    std::fs::remove_file("test.stronghold").unwrap_or(());
     Ok(())
 }


### PR DESCRIPTION
StrongholdAdapter acts as an all-in-one Stronghold integration for iota.rs that can both act as a key-value database provider and a transaction signer. StrongholdSigner and StrongholdDatabaseProvider are provided as type aliases for naming consistency.

Add db module for the definition of DatabaseProvider trait.

Fix #834.