### PR TITLE
Add dummy test to fix Python CI

### DIFF
--- a/bindings/python/native/tests/test_full_node_api.py
+++ b/bindings/python/native/tests/test_full_node_api.py
@@ -1,0 +1,3 @@
+def test_dummy():
+    # Use dummy test currently until all apis are stable and ready to add tests
+    pass


### PR DESCRIPTION
Will need to add real testings when all the APIs are stable and ready to test.