### PR TITLE
Update required nodejs versions

### DIFF
--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -18,7 +18,7 @@ $ yarn add @iota/client
 
 ## Requirements
 
-One of the following Node.js version: '10.x', '12.x', '14.x', '15.x', '16.x'
+One of the following Node.js version: '12.x', '14.x', '16.x'
 
 If there is no prebuilt binary available for your system you need `Rust` and `Cargo`, to build it yourself. Install them [here](https://doc.rust-lang.org/cargo/getting-started/installation.html).
 

--- a/documentation/docs/libraries/nodejs/api_reference.md
+++ b/documentation/docs/libraries/nodejs/api_reference.md
@@ -28,7 +28,7 @@ $ yarn add @iota/client
 
 ## Requirements
 
-One of the following Node.js version: '10.x', '12.x', '14.x', '15.x', '16.x'
+One of the following Node.js version: '12.x', '14.x', '16.x'
 
 If there is no prebuilt binary available for your system you need `Rust` and `Cargo`, to build it yourself. Install them [here](https://doc.rust-lang.org/cargo/getting-started/installation.html).
 


### PR DESCRIPTION
# Description of change

Update required nodejs versions, because we don't build binaries for the other versions anymore

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota.rs/issues/810

## Type of change

- Documentation Fix

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have made corresponding changes to the documentation
