### PR TITLE
signing: refactor trait Signer, struct *Signer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ regex = { version = "1.5.4", default-features = false, features = ["std", "unico
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.68", default-features = false }
 thiserror = { version = "1.0.29", default-features = false }
-tokio = { version = "1.12.0", default-features = false, features = ["macros", "rt-multi-thread", "time", "sync"], optional = true }
+tokio = { version = "1.12.0", default-features = false, features = ["macros", "rt-multi-thread", "time", "fs", "sync"], optional = true }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
 zeroize = { version = "1.5.3", default-features = false }
 

--- a/examples/02_mnemonic.rs
+++ b/examples/02_mnemonic.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<()> {
     let mnemonic = Client::generate_mnemonic()?;
     println!("Mnemonic: {}", mnemonic);
 
-    let signer = MnemonicSigner::new(&mnemonic)?;
+    let signer = MnemonicSigner::try_from_mnemonic(&mnemonic)?;
 
     // Generate addresses with custom account index and range
     let addresses = GetAddressesBuilder::new(&signer)

--- a/examples/03_generate_addresses.rs
+++ b/examples/03_generate_addresses.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
 
     // This example uses dotenv, which is not safe for use in production
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     // Generate addresses with default account index and range
     let addresses = client.get_addresses(&signer).finish().await.unwrap();

--- a/examples/05_get_address_balance.rs
+++ b/examples/05_get_address_balance.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
 
     // This example uses dotenv, which is not safe for use in production
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     // Generate the first address
     let addresses = client

--- a/examples/09_transaction.rs
+++ b/examples/09_transaction.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     let message = client
         .message()

--- a/examples/consolidation.rs
+++ b/examples/consolidation.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
 
-    let seed = MnemonicSigner::new_from_seed(&env::var("NONSECURE_USE_OF_DEVELOPMENT_SEED_1").unwrap())?;
+    let seed = MnemonicSigner::try_from_hex_seed(&env::var("NONSECURE_USE_OF_DEVELOPMENT_SEED_1").unwrap())?;
 
     // Here all funds will be send to the address with the lowest index in the range
     let address = consolidate_funds(&client, &seed, 0, address_range).await?;

--- a/examples/custom_inputs.rs
+++ b/examples/custom_inputs.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     dotenv().ok();
 
     // First address from the seed below is atoi1qzt0nhsf38nh6rs4p6zs5knqp6psgha9wsv74uajqgjmwc75ugupx3y7x0r
-    let seed = MnemonicSigner::new_from_seed(&env::var("NONSECURE_USE_OF_DEVELOPMENT_SEED_1").unwrap())?;
+    let seed = MnemonicSigner::try_from_hex_seed(&env::var("NONSECURE_USE_OF_DEVELOPMENT_SEED_1").unwrap())?;
 
     let addresses = client.get_addresses(&seed).with_range(0..1).finish().await?;
     println!("{:?}", addresses[0]);

--- a/examples/custom_remainder_address.rs
+++ b/examples/custom_remainder_address.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     dotenv().ok();
 
     // First address from the seed below is atoi1qzt0nhsf38nh6rs4p6zs5knqp6psgha9wsv74uajqgjmwc75ugupx3y7x0r
-    let seed = MnemonicSigner::new_from_seed(&env::var("NONSECURE_USE_OF_DEVELOPMENT_SEED_1").unwrap())?;
+    let seed = MnemonicSigner::try_from_hex_seed(&env::var("NONSECURE_USE_OF_DEVELOPMENT_SEED_1").unwrap())?;
 
     let addresses = client.get_addresses(&seed).with_range(0..3).finish().await?;
 

--- a/examples/get_funds.rs
+++ b/examples/get_funds.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     dotenv().ok();
 
-    let seed = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let seed = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
     let addresses = client
         .get_addresses(&seed)
         .with_account_index(0)

--- a/examples/indexer.rs
+++ b/examples/indexer.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     let address = client.get_addresses(&signer).with_range(0..1).get_raw().await?[0];
 

--- a/examples/ledger.rs
+++ b/examples/ledger.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     let ledger_signer = LedgerSigner::new(false);
 
     // Generate addresses with custom account index and range
-    let addresses = iota
+    let addresses = client
         .get_addresses(&ledger_signer)
         .with_account_index(0)
         .with_range(0..2)

--- a/examples/offline_signing/0_address_generation.rs
+++ b/examples/offline_signing/0_address_generation.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
 
     // This example uses dotenv, which is not safe for use in production
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     // Generate addresses offline
     let addresses = offline_client

--- a/examples/output.rs
+++ b/examples/output.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     let address = client.get_addresses(&signer).with_range(0..1).get_raw().await?[0];
     request_funds_from_faucet(

--- a/examples/outputs/alias.rs
+++ b/examples/outputs/alias.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     let address = client.get_addresses(&signer).with_range(0..1).get_raw().await?[0];
     request_funds_from_faucet(

--- a/examples/outputs/all.rs
+++ b/examples/outputs/all.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     let address = client.get_addresses(&signer).with_range(0..1).get_raw().await?[0];
     println!(

--- a/examples/outputs/all_automatic_input_selection.rs
+++ b/examples/outputs/all_automatic_input_selection.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     let address = client.get_addresses(&signer).with_range(0..1).get_raw().await?[0];
     println!(

--- a/examples/outputs/basic.rs
+++ b/examples/outputs/basic.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     let address = client.get_addresses(&signer).with_range(0..1).get_raw().await?[0];
     println!(

--- a/examples/outputs/foundry.rs
+++ b/examples/outputs/foundry.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     let address = client.get_addresses(&signer).with_range(0..1).get_raw().await?[0];
     println!(

--- a/examples/outputs/native_tokens.rs
+++ b/examples/outputs/native_tokens.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     let address = client.get_addresses(&signer).with_range(0..1).get_raw().await?[0];
     request_funds_from_faucet(

--- a/examples/outputs/nft.rs
+++ b/examples/outputs/nft.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     let address = client.get_addresses(&signer).with_range(0..1).get_raw().await?[0];
     request_funds_from_faucet(

--- a/examples/quorum.rs
+++ b/examples/quorum.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
 
     // This example uses dotenv, which is not safe for use in production
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     // Generate the first address
     let addresses = client

--- a/examples/search_address.rs
+++ b/examples/search_address.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     dotenv().ok();
 
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     let addresses = client
         .get_addresses(&signer)

--- a/examples/send_all.rs
+++ b/examples/send_all.rs
@@ -34,8 +34,8 @@ async fn main() -> Result<()> {
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
 
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
-    let seed_2 = MnemonicSigner::new_from_seed(&env::var("NONSECURE_USE_OF_DEVELOPMENT_SEED_2").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let seed_2 = MnemonicSigner::try_from_hex_seed(&env::var("NONSECURE_USE_OF_DEVELOPMENT_SEED_2").unwrap())?;
 
     // Get output ids of outputs that can be controlled by this address without further unlock constraints
     let output_ids = client

--- a/examples/split_funds.rs
+++ b/examples/split_funds.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     // This example uses dotenv, which is not safe for use in production
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
-    let signer = MnemonicSigner::new(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
+    let signer = MnemonicSigner::try_from_mnemonic(&env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap())?;
 
     let address = client.get_addresses(&signer).with_range(0..1).get_raw().await?[0];
     println!(

--- a/examples/stronghold.rs
+++ b/examples/stronghold.rs
@@ -3,12 +3,11 @@
 
 //! cargo run --example stronghold --features=stronghold --release
 
+use dotenv::dotenv;
 use iota_client::{
     signing::{stronghold::StrongholdSigner, Signer},
     Client, Result,
 };
-extern crate dotenv;
-use dotenv::dotenv;
 use std::{env, path::PathBuf};
 
 /// In this example we will create addresses with a stronghold signer
@@ -31,11 +30,11 @@ async fn main() -> Result<()> {
     dotenv().ok();
     let mnemonic = env::var("NONSECURE_USE_OF_DEVELOPMENT_MNEMONIC1").unwrap();
     // The mnemonic only needs to be stored the first time
-    stronghold_signer.store_mnemonic(mnemonic).await.unwrap();
+    stronghold_signer.signer_init(Some(&mnemonic)).await.unwrap();
 
     // Generate addresses with custom account index and range
-    let addresses = iota
-        .get_addresses(&stronghold_signer.into())
+    let addresses = client
+        .get_addresses(&stronghold_signer)
         .with_account_index(0)
         .with_range(0..2)
         .finish()

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -38,8 +38,8 @@ async fn main() -> Result<()> {
     // Configure your own seed in ".env". Since the output amount cannot be zero, the seed must contain non-zero balance
     dotenv().ok();
 
-    let signer_1 = MnemonicSigner::new_from_seed(&env::var("NONSECURE_USE_OF_DEVELOPMENT_signer_1").unwrap())?;
-    let signer_2 = MnemonicSigner::new_from_seed(&env::var("NONSECURE_USE_OF_DEVELOPMENT_signer_1").unwrap())?;
+    let signer_1 = MnemonicSigner::try_from_hex_seed(&env::var("NONSECURE_USE_OF_DEVELOPMENT_signer_1").unwrap())?;
+    let signer_2 = MnemonicSigner::try_from_hex_seed(&env::var("NONSECURE_USE_OF_DEVELOPMENT_signer_1").unwrap())?;
 
     let message = client
         .message()

--- a/src/api/consolidation.rs
+++ b/src/api/consolidation.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     api::message_builder::ClientMessageBuilder, node_api::indexer_api::query_parameters::QueryParameter,
-    signing::SignerHandle, Client, Result,
+    signing::Signer, Client, Result,
 };
 
 use bee_message::{
@@ -18,7 +18,7 @@ use std::{ops::Range, str::FromStr};
 /// Returns the address to which the funds got consolidated, if any were available
 pub async fn consolidate_funds(
     client: &Client,
-    signer: &SignerHandle,
+    signer: &dyn Signer,
     account_index: u32,
     address_range: Range<u32>,
 ) -> Result<String> {

--- a/src/api/message_builder/input_selection/automatic.rs
+++ b/src/api/message_builder/input_selection/automatic.rs
@@ -58,12 +58,7 @@ pub(crate) async fn get_inputs(
         // Get the addresses in the BIP path/index ~ path/index+20
         let addresses = message_builder
             .client
-            .get_addresses(
-                message_builder
-                    .signer
-                    .as_ref()
-                    .ok_or(crate::Error::MissingParameter("signer"))?,
-            )
+            .get_addresses(message_builder.signer.ok_or(crate::Error::MissingParameter("signer"))?)
             .with_account_index(account_index)
             .with_range(gap_index..gap_index + ADDRESS_GAP_RANGE)
             .get_all()

--- a/src/api/message_builder/mod.rs
+++ b/src/api/message_builder/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     api::{input_selection::types::SelectedTransactionData, types::PreparedTransactionData},
     bee_message::output::BasicOutputBuilder,
     constants::SHIMMER_COIN_TYPE,
-    signing::SignerHandle,
+    signing::Signer,
     Client, Error, Result,
 };
 
@@ -44,7 +44,7 @@ use transaction::{prepare_transaction, sign_transaction};
 /// Builder of the message API
 pub struct ClientMessageBuilder<'a> {
     client: &'a Client,
-    signer: Option<&'a SignerHandle>,
+    signer: Option<&'a dyn Signer>,
     coin_type: u32,
     account_index: u32,
     initial_address_index: u32,
@@ -117,7 +117,7 @@ impl<'a> ClientMessageBuilder<'a> {
     }
 
     /// Sets the seed.
-    pub fn with_signer(mut self, signer: &'a SignerHandle) -> Self {
+    pub fn with_signer(mut self, signer: &'a dyn Signer) -> Self {
         self.signer.replace(signer);
         self
     }

--- a/src/api/message_builder/transaction.rs
+++ b/src/api/message_builder/transaction.rs
@@ -106,7 +106,7 @@ pub async fn prepare_transaction(message_builder: &ClientMessageBuilder<'_>) -> 
 /// Sign the transaction
 pub async fn sign_transaction(
     message_builder: &ClientMessageBuilder<'_>,
-    mut prepared_transaction_data: PreparedTransactionData,
+    prepared_transaction_data: PreparedTransactionData,
 ) -> Result<Payload> {
     log::debug!("[sign_transaction]");
     let mut input_addresses = Vec::new();
@@ -115,16 +115,12 @@ pub async fn sign_transaction(
         input_addresses.push(address);
     }
     let signer = message_builder.signer.ok_or(Error::MissingParameter("signer"))?;
-    #[cfg(feature = "wasm")]
-    let mut signer = signer.lock().unwrap();
-    #[cfg(not(feature = "wasm"))]
-    let mut signer = signer.lock().await;
     let unlock_blocks = signer
         .sign_transaction_essence(
             // IOTA_COIN_TYPE,
             // message_builder.account_index.unwrap_or(0),
             &prepared_transaction_data.essence,
-            &mut prepared_transaction_data.input_signing_data_entrys,
+            &prepared_transaction_data.input_signing_data_entrys,
             // todo set correct data
             SignMessageMetadata {
                 remainder_value: 0,

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,7 @@ use crate::{
     error::{Error, Result},
     node_api::{high_level::GetAddressBuilder, indexer_api::query_parameters::QueryParameter},
     node_manager::node::{Node, NodeAuth},
-    signing::SignerHandle,
+    signing::Signer,
     utils::{
         bech32_to_hex, generate_mnemonic, hash_network, hex_public_key_to_bech32_address, hex_to_bech32,
         is_address_valid, mnemonic_to_hex_seed, mnemonic_to_seed, parse_bech32_address,
@@ -608,7 +608,7 @@ impl Client {
     }
 
     /// Return a list of addresses from the signer regardless of their validity.
-    pub fn get_addresses<'a>(&'a self, signer: &'a SignerHandle) -> GetAddressesBuilder<'a> {
+    pub fn get_addresses<'a>(&'a self, signer: &'a dyn Signer) -> GetAddressesBuilder<'a> {
         GetAddressesBuilder::new(signer).with_client(self)
     }
 
@@ -724,7 +724,7 @@ impl Client {
     /// Returns the address to which the funds got consolidated, if any were available
     pub async fn consolidate_funds(
         &self,
-        signer: &SignerHandle,
+        signer: &dyn Signer,
         account_index: u32,
         address_range: Range<u32>,
     ) -> crate::Result<String> {

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -4,38 +4,6 @@
 //! Signing module to allow using different signer types for address generation and transaction essence signing
 
 #[cfg(feature = "ledger")]
-use self::ledger::LedgerSigner;
-#[cfg(feature = "stronghold")]
-use self::stronghold::StrongholdSigner;
-use crate::signing::{
-    mnemonic::MnemonicSigner,
-    types::{InputSigningData, SignerTypeDto},
-};
-
-use bee_message::{
-    address::{Address, AliasAddress, Ed25519Address, NftAddress},
-    output::Output,
-    payload::transaction::{TransactionEssence, TransactionPayload},
-    signature::Signature,
-    unlock_block::{AliasUnlockBlock, NftUnlockBlock, ReferenceUnlockBlock, UnlockBlock, UnlockBlocks},
-};
-
-#[cfg(feature = "wasm")]
-use std::sync::Mutex;
-#[cfg(not(feature = "wasm"))]
-use tokio::sync::Mutex;
-
-use std::{
-    collections::HashMap,
-    fmt::{Debug, Formatter, Result},
-    ops::{Deref, Range},
-    sync::Arc,
-};
-
-#[cfg(feature = "stronghold")]
-use std::path::PathBuf;
-
-#[cfg(feature = "ledger")]
 pub mod ledger;
 /// Module for signing with a mnemonic or seed
 pub mod mnemonic;
@@ -45,94 +13,70 @@ pub mod stronghold;
 /// Signing related types
 pub mod types;
 
-pub use types::{GenerateAddressMetadata, LedgerStatus, Network, SignMessageMetadata, SignerType};
+#[cfg(feature = "ledger")]
+pub use self::ledger::LedgerSigner;
+#[cfg(feature = "stronghold")]
+pub use self::stronghold::StrongholdSigner;
+pub use self::{
+    mnemonic::MnemonicSigner,
+    types::{GenerateAddressMetadata, LedgerStatus, Network, SignMessageMetadata, SignerType},
+};
 
-/// SignerHandle, possible signers are mnemonic, Stronghold and Ledger
-#[derive(Clone)]
-pub struct SignerHandle {
-    pub(crate) signer: Arc<Mutex<Box<dyn Signer + Sync + Send>>>,
-    /// SignerType
-    pub signer_type: SignerType,
-}
+use self::types::{InputSigningData, SignerTypeDto};
+use async_trait::async_trait;
+use bee_message::{
+    address::{Address, AliasAddress, Ed25519Address, NftAddress},
+    output::Output,
+    payload::transaction::{TransactionEssence, TransactionPayload},
+    signature::Signature,
+    unlock_block::{AliasUnlockBlock, NftUnlockBlock, ReferenceUnlockBlock, UnlockBlock, UnlockBlocks},
+};
+#[cfg(feature = "stronghold")]
+use std::path::PathBuf;
+use std::{collections::HashMap, ops::Range, str::FromStr};
 
-impl Debug for SignerHandle {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{:?}", self.signer_type)
-    }
-}
-
-impl SignerHandle {
-    /// Create a new SignerHandle
-    pub fn new(signer_type: SignerType, signer: Box<dyn Signer + Sync + Send>) -> Self {
-        Self {
-            signer_type,
-            signer: Arc::new(Mutex::new(signer)),
-        }
-    }
-    /// Create a new SignerHandle from a serialized SignerTypeDto
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str(data: &str) -> crate::Result<Self> {
-        let signer_type: SignerTypeDto = serde_json::from_str(data)?;
-
-        Ok(match signer_type {
-            #[cfg(feature = "stronghold")]
-            SignerTypeDto::Stronghold(stronghold_dto) => {
-                let mut builder = StrongholdSigner::builder();
-
-                if let Some(password) = &stronghold_dto.password {
-                    builder = builder.password(password);
-                }
-
-                if let Some(snapshot_path) = &stronghold_dto.snapshot_path {
-                    builder = builder.snapshot_path(PathBuf::from(snapshot_path));
-                }
-
-                builder.build().into()
-            }
-
-            #[cfg(feature = "ledger")]
-            SignerTypeDto::LedgerNano => LedgerSigner::new(false),
-
-            #[cfg(feature = "ledger")]
-            SignerTypeDto::LedgerNanoSimulator => LedgerSigner::new(true),
-
-            SignerTypeDto::Mnemonic(mnemonic) => MnemonicSigner::new(&mnemonic)?,
-        })
-    }
-}
-
-impl Deref for SignerHandle {
-    type Target = Arc<Mutex<Box<dyn Signer + Sync + Send>>>;
-    fn deref(&self) -> &Self::Target {
-        &self.signer
-    }
-}
-
-/// Signer interface.
-#[async_trait::async_trait]
+/// The interface for a signer capable to perform various cryptographic operations.
+#[async_trait]
 pub trait Signer: Send + Sync {
-    /// Get the ledger status.
+    /// Type of the signer.
     ///
-    /// This is only meaningful for the Ledger hardware; other signers don't implement this.
-    async fn get_ledger_status(&self, _: bool) -> LedgerStatus {
-        LedgerStatus {
-            app: None,
-            connected: false,
-            locked: false,
-        }
-    }
-
-    /// Initialises a mnemonic.
+    /// The current design still needs to distinguish between signers behind a trait object. To achieve this, signers
+    /// need to provide their own type via this method.
     ///
-    /// This is only meaningful for the Stronghold signer; other signers don't implement this.
-    async fn store_mnemonic(&mut self, _: String) -> crate::Result<()> {
-        Err(crate::Error::NoMnemonicWasStored)
-    }
+    /// Providing signers that aren't listed in [`SignerType`] aren't currently supported.
+    async fn signer_type(&self) -> SignerType;
 
-    /// Generates an address.
-    async fn generate_addresses(
-        &mut self,
-        // https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+    /// Initialize the signer.
+    ///
+    /// This should be called after the signer has been created to allow the signer to initialize itself (because not
+    /// all tasks can be done upon `struct` construction).
+    ///
+    /// When `mnemonic` is supplied, the signer is prompted to store or use it. However, the exact behavior of signer
+    /// is not defined. For example, [`StrongholdSigner`] will return an error if a mnemonic has been initialized, but
+    /// [`MnemonicSigner`] will happily replace the mnemonic it stores instead.
+    async fn signer_init(&mut self, mnemonic: Option<&str>) -> crate::Result<()>;
+
+    /// Synchronize the signer state.
+    ///
+    /// This method may be called from time to time. The signer can do some chores here. For example, synchronizing the
+    /// state in the memory to the disk.
+    async fn signer_sync(&mut self) -> crate::Result<()>;
+
+    /// Provide a password for the signer to perform any cryptographic action.
+    ///
+    /// The signer then stores and caches the password. Use [`Signer::signer_clear_password()`] to clear the cache.
+    async fn signer_set_password(&mut self, password: &str);
+
+    /// Purge the cached password from the memory.
+    ///
+    /// This is preferably be done using the [zeroize] crate.
+    async fn signer_clear_password(&mut self);
+
+    /// Generate addresses.
+    ///
+    /// For `coin_type`, see also <https://github.com/satoshilabs/slips/blob/master/slip-0044.md>.
+    async fn signer_gen_addrs(
+        &self,
         coin_type: u32,
         account_index: u32,
         address_indexes: Range<u32>,
@@ -140,26 +84,23 @@ pub trait Signer: Send + Sync {
         metadata: GenerateAddressMetadata,
     ) -> crate::Result<Vec<Address>>;
 
-    /// Sign on `essence`, unlock `input` by returning an [UnlockBlock].
-    async fn signature_unlock<'a>(
-        &mut self,
-        _input: &InputSigningData,
-        _essence_hash: &[u8; 32],
-        _metadata: &SignMessageMetadata<'a>,
-    ) -> crate::Result<UnlockBlock> {
-        // Return error unless implemented otherwise.
-        Err(crate::Error::NoMnemonicWasStored)
-    }
+    /// Sign on `essence_hash`, unlock `input` by returning an [`UnlockBlock`].
+    async fn signer_unlock<'a>(
+        &self,
+        input: &InputSigningData,
+        essence_hash: &[u8; 32],
+        metadata: &SignMessageMetadata<'a>,
+    ) -> crate::Result<UnlockBlock>;
 
     /// Signs transaction essence.
     ///
     /// Signers usually don't implement this, as the default implementation has taken care of the placement of blocks
-    /// (e.g. references between them). [Signer::signature_unlock()] will be invoked every time a necessary signing
-    /// action needs to be performed.
+    /// (e.g. references between them). [Signer::signer_unlock()] will be invoked every time a necessary signing action
+    /// needs to be performed.
     async fn sign_transaction_essence<'a>(
-        &mut self,
+        &self,
         essence: &TransactionEssence,
-        inputs: &mut Vec<InputSigningData>,
+        inputs: &[InputSigningData],
         metadata: SignMessageMetadata<'a>,
     ) -> crate::Result<Vec<UnlockBlock>> {
         // The hashed_essence gets signed
@@ -193,7 +134,7 @@ pub trait Signer: Send + Sync {
                         return Err(crate::Error::MissingInputWithEd25519UnlockCondition);
                     }
 
-                    let unlock_block = self.signature_unlock(input, &hashed_essence, &metadata).await?;
+                    let unlock_block = self.signer_unlock(input, &hashed_essence, &metadata).await?;
                     unlock_blocks.push(unlock_block);
 
                     // Add the ed25519 address to the unlock_block_indexes, so it gets referenced if further inputs have
@@ -223,6 +164,50 @@ pub trait Signer: Send + Sync {
             };
         }
         Ok(unlock_blocks)
+    }
+
+    /// Get the status of a Ledger hardware.
+    ///
+    /// This is only meaningful for [`LedgerSigner`]; other signers don't implement this.
+    async fn get_ledger_status(&self, _is_simulator: bool) -> LedgerStatus {
+        LedgerStatus {
+            app: None,
+            connected: false,
+            locked: false,
+        }
+    }
+}
+
+impl FromStr for Box<dyn Signer> {
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> crate::Result<Self> {
+        let signer_type: SignerTypeDto = serde_json::from_str(s)?;
+
+        Ok(match signer_type {
+            #[cfg(feature = "stronghold")]
+            SignerTypeDto::Stronghold(stronghold_dto) => {
+                let mut builder = StrongholdSigner::builder();
+
+                if let Some(password) = &stronghold_dto.password {
+                    builder = builder.password(password);
+                }
+
+                if let Some(snapshot_path) = &stronghold_dto.snapshot_path {
+                    builder = builder.snapshot_path(PathBuf::from(snapshot_path));
+                }
+
+                Box::new(builder.build())
+            }
+
+            #[cfg(feature = "ledger")]
+            SignerTypeDto::LedgerNano => Box::new(LedgerSigner::new(false)),
+
+            #[cfg(feature = "ledger")]
+            SignerTypeDto::LedgerNanoSimulator => Box::new(LedgerSigner::new(true)),
+
+            SignerTypeDto::Mnemonic(mnemonic) => Box::new(MnemonicSigner::try_from_mnemonic(&mnemonic)?),
+        })
     }
 }
 

--- a/tests/addresses.rs
+++ b/tests/addresses.rs
@@ -11,8 +11,9 @@ use iota_client::{
 #[tokio::test]
 async fn addresses() {
     let signer =
-        MnemonicSigner::new_from_seed("256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b2").unwrap();
+        MnemonicSigner::try_from_hex_seed("256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b2").unwrap();
     let addresses = GetAddressesBuilder::new(&signer)
+        .with_coin_type(IOTA_COIN_TYPE)
         .with_bech32_hrp("atoi".into())
         .with_account_index(0)
         .with_range(0..1)
@@ -48,7 +49,7 @@ async fn public_key_to_address() {
 #[tokio::test]
 async fn mnemonic_address_generation_iota() {
     let mnemonic = "acoustic trophy damage hint search taste love bicycle foster cradle brown govern endless depend situate athlete pudding blame question genius transfer van random vast";
-    let signer = MnemonicSigner::new(mnemonic).unwrap();
+    let signer = MnemonicSigner::try_from_mnemonic(mnemonic).unwrap();
 
     // account 0, address 0 and 1
     let addresses = GetAddressesBuilder::new(&signer)
@@ -88,7 +89,7 @@ async fn mnemonic_address_generation_iota() {
 #[tokio::test]
 async fn mnemonic_address_generation_shimmer() {
     let mnemonic = "acoustic trophy damage hint search taste love bicycle foster cradle brown govern endless depend situate athlete pudding blame question genius transfer van random vast";
-    let signer = MnemonicSigner::new(mnemonic).unwrap();
+    let signer = MnemonicSigner::try_from_mnemonic(mnemonic).unwrap();
 
     // account 0, address 0 and 1
     let addresses = GetAddressesBuilder::new(&signer)

--- a/tests/node_api.rs
+++ b/tests/node_api.rs
@@ -111,7 +111,7 @@ async fn test_post_message_with_transaction() {
 
     // Insert your seed. Since the output amount cannot be zero. The seed must contain non-zero balance.
     let signer =
-        MnemonicSigner::new_from_seed("256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b2").unwrap();
+        MnemonicSigner::try_from_hex_seed("256a818b2aac458941f7274985a410e57fb750f3a3a67969ece5bd9ae7eef5b2").unwrap();
     let message_id = iota
         .message()
         .with_signer(&signer)

--- a/tests/signer.rs
+++ b/tests/signer.rs
@@ -4,7 +4,7 @@
 use iota_client::{
     api::GetAddressesBuilder,
     constants::SHIMMER_TESTNET_BECH32_HRP,
-    signing::{types::SignerTypeDto, SignerHandle},
+    signing::{types::SignerTypeDto, Signer},
     Result,
 };
 
@@ -12,9 +12,9 @@ use iota_client::{
 async fn mnemonic_signer_dto() -> Result<()> {
     let mnemonic = "acoustic trophy damage hint search taste love bicycle foster cradle brown govern endless depend situate athlete pudding blame question genius transfer van random vast".to_string();
     let signer_type_dto = SignerTypeDto::Mnemonic(mnemonic);
-    let signer = SignerHandle::from_str(&serde_json::to_string(&signer_type_dto)?)?;
+    let signer: Box<dyn Signer> = serde_json::to_string(&signer_type_dto)?.parse()?;
 
-    let addresses = GetAddressesBuilder::new(&signer)
+    let addresses = GetAddressesBuilder::new(&*signer)
         .with_bech32_hrp(SHIMMER_TESTNET_BECH32_HRP.to_string())
         .with_account_index(0)
         .with_range(0..1)
@@ -37,17 +37,12 @@ async fn stronghold_signer_dto() -> Result<()> {
     let mnemonic = "acoustic trophy damage hint search taste love bicycle foster cradle brown govern endless depend situate athlete pudding blame question genius transfer van random vast".to_string();
 
     let signer_type_dto: SignerTypeDto = serde_json::from_str(stronghold_dto_str)?;
-    let stronghold_signer = SignerHandle::from_str(&serde_json::to_string(&signer_type_dto)?)?;
+    let mut stronghold_signer: Box<dyn Signer> = serde_json::to_string(&signer_type_dto)?.parse()?;
 
     // The mnemonic only needs to be stored the first time
-    stronghold_signer
-        .lock()
-        .await
-        .store_mnemonic(mnemonic.clone())
-        .await
-        .unwrap();
+    stronghold_signer.signer_init(Some(&mnemonic)).await.unwrap();
 
-    let addresses = GetAddressesBuilder::new(&stronghold_signer)
+    let addresses = GetAddressesBuilder::new(&*stronghold_signer)
         .with_bech32_hrp(SHIMMER_TESTNET_BECH32_HRP.to_string())
         .with_account_index(0)
         .with_range(0..1)
@@ -61,7 +56,7 @@ async fn stronghold_signer_dto() -> Result<()> {
     );
 
     // Calling store_mnemonic() twice should fail, because we would otherwise overwrite the stored entry
-    assert!(stronghold_signer.lock().await.store_mnemonic(mnemonic).await.is_err());
+    assert!(stronghold_signer.signer_init(Some(&mnemonic)).await.is_err());
 
     // Remove garbage after test, but don't care about the result
     std::fs::remove_file("test.stronghold").unwrap_or(());


### PR DESCRIPTION
The Signer trait now gets a few more general methods for every signer implementation to implement: type, init, sync, set_password, clear_password, gen_addrs (prev. generate_addresses), and unlock (prev. signature_unlock).

SignerHandle is removed because now Signer implementations can supply their typing information via signer_type(). Related code are refactored too.

MnemonicSigner and LedgerSigner w/ their usages around the repo have been refactored, although todo methods are still left todo.

StrongholdAdapter also creates a backup every time a snapshot is flushed to the disk by copying the just-written snapshot to a new one with a UNIX timestamp in the filename.

This PR is an extension of #883, and a part of #834.