### PR TITLE
Use dtos in message_interface

### DIFF
--- a/src/api/message_builder/mod.rs
+++ b/src/api/message_builder/mod.rs
@@ -36,7 +36,7 @@ use self::{
 };
 use crate::{
     api::{input_selection::types::SelectedTransactionData, types::PreparedTransactionData},
-    bee_message::output::BasicOutputBuilder,
+    bee_message::{input::dto::UtxoInputDto, output::BasicOutputBuilder},
     constants::SHIMMER_COIN_TYPE,
     signing::SignerHandle,
     Client, Error, Result,
@@ -79,7 +79,7 @@ pub struct ClientMessageBuilderOptions {
     /// Initial address index
     pub initial_address_index: Option<u32>,
     /// Inputs
-    pub inputs: Option<Vec<UtxoInput>>,
+    pub inputs: Option<Vec<UtxoInputDto>>,
     /// Input range
     pub input_range: Option<Range<u32>>,
     /// Bech32 encoded output address and amount
@@ -87,7 +87,7 @@ pub struct ClientMessageBuilderOptions {
     /// Hex encoded output address and amount
     pub output_hex: Option<ClientMessageBuilderOutputAddress>,
     /// Outputs
-    pub outputs: Option<Vec<Output>>,
+    pub outputs: Option<Vec<OutputDto>>,
     /// Custom remainder address
     pub custom_remainder_address: Option<String>,
     /// Tag
@@ -253,7 +253,7 @@ impl<'a> ClientMessageBuilder<'a> {
 
         if let Some(inputs) = options.inputs {
             for input in inputs {
-                self = self.with_input(input)?;
+                self = self.with_input(UtxoInput::try_from(&input)?)?;
             }
         }
 
@@ -270,7 +270,12 @@ impl<'a> ClientMessageBuilder<'a> {
         }
 
         if let Some(outputs) = options.outputs {
-            self = self.with_outputs(outputs)?;
+            self = self.with_outputs(
+                outputs
+                    .iter()
+                    .map(|o| Ok(Output::try_from(o)?))
+                    .collect::<Result<Vec<Output>>>()?,
+            )?;
         }
 
         if let Some(custom_remainder_address) = options.custom_remainder_address {

--- a/src/message_interface/client_method.rs
+++ b/src/message_interface/client_method.rs
@@ -7,7 +7,7 @@ use bee_message::{
     input::UtxoInput,
     output::{AliasId, FoundryId, NftId, OutputId},
     payload::transaction::TransactionId,
-    Message, MessageId,
+    MessageDto, MessageId,
 };
 use serde::Deserialize;
 
@@ -84,12 +84,12 @@ pub enum ClientMethod {
     /// Post message
     PostMessage {
         /// Message
-        message: Message,
+        message: MessageDto,
     },
     /// Post message json
     PostMessageJson {
         /// Message
-        message: Message,
+        message: MessageDto,
     },
     /// Get message data
     GetMessageData {

--- a/src/message_interface/response_type.rs
+++ b/src/message_interface/response_type.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashSet;
 
-use bee_message::{address::Address, input::UtxoInput, output::OutputId, Message, MessageId};
+use bee_message::{address::dto::AddressDto, input::dto::UtxoInputDto, output::OutputId, MessageDto, MessageId};
 use bee_rest_api::types::{
     dtos::{PeerDto, ReceiptDto},
     responses::{
@@ -60,7 +60,7 @@ pub enum ResponseType {
     /// Posted message
     PostMessageSuccessful(MessageId),
     /// Message data
-    MessageData(Message),
+    MessageData(MessageDto),
     /// Message metadata
     MessageMetadata(MessageMetadataResponse),
     /// Message raw
@@ -82,35 +82,35 @@ pub enum ResponseType {
     /// Get treasury successful
     Treasury(TreasuryResponse),
     /// Get included message successful
-    IncludedMessage(Message),
+    IncludedMessage(MessageDto),
     /// Fetched output ID
     OutputId(OutputId),
     /// Fetched output IDs
     OutputIds(Vec<OutputId>),
     /// Messages
-    Messages(Vec<Message>),
+    Messages(Vec<MessageDto>),
     /// Balance
     Balance(u64),
     /// Addresses balances
     AddressesBalances(Vec<AddressBalance>),
     /// Retry
-    RetrySuccessful((MessageId, Message)),
+    RetrySuccessful((MessageId, MessageDto)),
     /// Retry until included
-    RetryUntilIncludedSuccessful(Vec<(MessageId, Message)>),
+    RetryUntilIncludedSuccessful(Vec<(MessageId, MessageDto)>),
     /// Consolidated funds
     ConsolidatedFunds(String),
     /// Found inputs
-    Inputs(Vec<UtxoInput>),
+    Inputs(Vec<UtxoInputDto>),
     /// Reattach
-    Reattached((MessageId, Message)),
+    Reattached((MessageId, MessageDto)),
     /// Promoted
-    Promoted((MessageId, Message)),
+    Promoted((MessageId, MessageDto)),
     /// Bech32 to hex
     Bech32ToHex(String),
     /// Hex to bech32
     HexToBech32(String),
     /// Parsed bech32 address
-    ParsedBech32Address(Address),
+    ParsedBech32Address(AddressDto),
     /// Is address valid
     IsAddressValid(bool),
     /// Generated mnemonic


### PR DESCRIPTION
# Description of change

Use dtos in message_interface, because it's then the same format as in the REST API of the nodes. 

## Links to any relevant issues

Related to https://github.com/iotaledger/iota.rs/issues/889 https://github.com/iotaledger/iota.rs/issues/903

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked that new and existing unit tests pass locally with my changes
