### PR TITLE
Pass &[InputSigningData] to verify_semantic

### DIFF
--- a/examples/offline_signing/3_send_message.rs
+++ b/examples/offline_signing/3_send_message.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
         let (local_time, milestone_index) = online_client.get_time_and_milestone_checked().await?;
 
         let conflict = verify_semantic(
-            &prepared_transaction,
+            &prepared_transaction.input_signing_data_entries,
             &signed_transaction_payload,
             milestone_index,
             local_time,


### PR DESCRIPTION
This is less restrictive that way because `AccountHandle::sign_tx_essence` doesn't have access to the `PreparedTransactionData`.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
