### PR TITLE
Fix Workflows

### DIFF
--- a/.github/workflows/examine-core.yml
+++ b/.github/workflows/examine-core.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - dev
     paths:
       - '.github/workflows/examine-core.yml'
       - '.github/actions/**'
@@ -14,6 +15,7 @@ on:
   pull_request:
     branches:
       - develop
+      - dev
     paths:
       - '.github/workflows/examine-core.yml'
       - '.github/actions/**'
@@ -48,6 +50,12 @@ jobs:
           cache-job-id: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
           cache-hash: ${{ hashFiles('.github/workflows/examine-core.yml') }}
 
+      - name: Install Required Dependencies (Ubuntu)
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install libudev-dev libusb-1.0-0-dev
+
       - name: Run Cargo Test
         uses: actions-rs/cargo@v1
         with:
@@ -71,6 +79,11 @@ jobs:
           cache: true
           cache-job-id: ${{ github.workflow }}-${{ github.job }}
           cache-hash: ${{ hashFiles('.github/workflows/examine-core.yml') }}
+
+      - name: Install Required Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libudev-dev libusb-1.0-0-dev
 
       - name: Run Clippy
         uses: actions-rs/clippy-check@v1
@@ -146,4 +159,15 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --file Cargo.lock --deny warnings
+          # The ignored security advisories:
+          #
+          # - RUSTSEC-2020-0026: linked-hash-map creates uninitialized NonNull pointer.
+          #   - A transitive dependency of riker. A new version of Stronghold should fix this.
+          # - RUSTSEC-2020-0159: Potential segfault in `localtime_r` invocations.
+          #   - From chrono, depended bt riker, depended by iota_stronghold. A new version of Stronghold should fix this.
+          # - RUSTSEC-2020-0071: Potential segfault in the time crate.
+          #   - A dependency of chrono; related to RUSTSEC-2020-0159. A new version of Stronghold should fix this.
+          # - RUSTSEC-2021-0119: Out-of-bounds write in nix::unistd::getgrouplist.
+          #   - A dependency of iota-ledger; it should be updated.
+          #   - We don't call this API, so we should be fine.
+          args: --file Cargo.lock --deny warnings --ignore RUSTSEC-2020-0026 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0119

--- a/.github/workflows/examine-python-bindings.yml
+++ b/.github/workflows/examine-python-bindings.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - dev
     paths:
       - '.github/workflows/examine-python-bindings.yml'
       - '.github/actions/**'
@@ -14,6 +15,7 @@ on:
   pull_request:
     branches:
       - develop
+      - dev
     paths:
       - '.github/workflows/examine-python-bindings.yml'
       - '.github/actions/**'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [ "iota", "tangle", "client" ]
 categories = [ "cryptography::cryptocurrencies" ]
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["async-trait"]
+normal = [ "async-trait", "derive_builder", "slog-stdlog", "ureq" ]
 
 [dependencies]
 bee-rest-api = { git = "https://github.com/iotaledger/bee", rev = "b3588a58ec007dce975bed979426f7d03cc34aa7", default-features = false }
@@ -55,12 +55,6 @@ riker = { version = "0.4.2", default-features = false, optional = true }
 # for stronghold
 crypto05 = { package = "iota-crypto", version = "0.5.1", default-features = false, features = [ "slip10" ], optional = true }
 
-# wasm
-instant = { version = "0.1.12", default-features = false, optional = true }
-gloo-timers = { version = "0.2.3", default-features = false, features = [ "futures" ], optional = true }
-# single thread pow for wasm
-bee-ternary = { version = "0.6.0", default-features = false, optional = true }
-
 # message_interface
 backtrace = { version = "0.3.62", default-features = false, features = [ "std" ], optional = true }
 
@@ -68,16 +62,20 @@ backtrace = { version = "0.3.62", default-features = false, features = [ "std" ]
 # https://github.com/slog-rs/stdlog/releases/tag/v4.1.1
 slog-stdlog = { version = "4.1.1" }
 
+[target.'cfg(target_family = "wasm")'.dependencies]
+instant = { version = "0.1.12", default-features = false }
+gloo-timers = { version = "0.2.3", default-features = false, features = [ "futures" ] }
+# single thread pow for wasm
+bee-ternary = { version = "0.5.2", default-features = false }
+
 [dev-dependencies]
-dotenv = { version =  "0.15.0", default-features = false }
-ureq = { version = "2.2.0", default-features = false, features = [ "tls", "json" ] }
+dotenv = { version = "0.15.0", default-features = false }
 
 [features]
 default = [ "async", "tls" ]
 sync = [ "ureq", "tokio", "futures" ]
 async = [ "reqwest", "futures", "tokio" ]
 mqtt = [ "rumqttc", "once_cell", "futures" ]
-wasm = [ "reqwest", "futures", "gloo-timers", "instant", "bee-ternary" ]
 ledger = [ "iota-ledger" ]
 tls = [ "reqwest/rustls-tls", "ureq/tls" ]
 stronghold = [ "iota_stronghold", "riker", "crypto05" ]

--- a/examples/10_mqtt.rs
+++ b/examples/10_mqtt.rs
@@ -47,8 +47,8 @@ async fn main() -> Result<()> {
             match &event.payload {
                 MqttPayload::Json(val) => println!("{}", serde_json::to_string(&val).unwrap()),
                 MqttPayload::Message(msg) => println!("{:?}", msg),
-                MqttPayload::MilestonePayload(_) => todo!(),
-                MqttPayload::Receipt(_) => todo!(),
+                MqttPayload::MilestonePayload(ms) => println!("{:?}", ms),
+                MqttPayload::Receipt(receipt) => println!("{:?}", receipt),
             }
             tx.lock().unwrap().send(()).unwrap();
         })

--- a/examples/custom_remainder_address.rs
+++ b/examples/custom_remainder_address.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<()> {
         "automatically funding sender address with faucet: {}",
         request_funds_from_faucet(
             "https://faucet.alphanet.iotaledger.net/api/plugins/faucet/v1/enqueue",
-            &sender_address
+            sender_address
         )
         .await?
     );
@@ -64,11 +64,11 @@ async fn main() -> Result<()> {
         .with_secret_manager(&secret_manager)
         .with_output(
             // We generate an address from our seed so that we send the funds to ourselves
-            &receiver_address,
+            receiver_address,
             9_000_000,
         )?
         // We send the remainder to an address where we don't have access to.
-        .with_custom_remainder_address(&remainder_address)?
+        .with_custom_remainder_address(remainder_address)?
         .finish()
         .await?;
 

--- a/examples/offline_signing/2_transaction_signing.rs
+++ b/examples/offline_signing/2_transaction_signing.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
         )
         .await?;
     let unlock_blocks = UnlockBlocks::new(unlock_blocks)?;
-    let signed_transaction = TransactionPayload::new(prepared_transaction.essence.clone(), unlock_blocks.clone())?;
+    let signed_transaction = TransactionPayload::new(prepared_transaction.essence.clone(), unlock_blocks)?;
 
     println!("Signed transaction.");
 

--- a/examples/offline_signing/3_send_message.rs
+++ b/examples/offline_signing/3_send_message.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
 
         let conflict = verify_semantic(
             &prepared_transaction.input_signing_data_entries,
-            &signed_transaction_payload,
+            signed_transaction_payload,
             milestone_index,
             local_time,
         )?;

--- a/examples/output.rs
+++ b/examples/output.rs
@@ -40,12 +40,11 @@ async fn main() -> Result<()> {
     )
     .await?;
 
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Basic(
+    let outputs = vec![Output::Basic(
         BasicOutputBuilder::new_with_amount(1_000_000)?
             .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
             .finish()?,
-    ));
+    )];
 
     let message = client
         .message()

--- a/examples/outputs/alias.rs
+++ b/examples/outputs/alias.rs
@@ -50,8 +50,7 @@ async fn main() -> Result<()> {
     //////////////////////////////////
     // create new alias output
     //////////////////////////////////
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Alias(
+    let outputs = vec![Output::Alias(
         AliasOutputBuilder::new_with_amount(1_000_000, AliasId::from([0; 20]))?
             .with_state_index(0)
             .with_foundry_counter(0)
@@ -65,7 +64,7 @@ async fn main() -> Result<()> {
                 address,
             )))
             .finish()?,
-    ));
+    )];
 
     let message = client
         .message()
@@ -85,8 +84,7 @@ async fn main() -> Result<()> {
     //////////////////////////////////
     let alias_output_id = get_alias_output_id(message.payload().unwrap());
     let alias_id = AliasId::from(alias_output_id);
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Alias(
+    let outputs = vec![Output::Alias(
         AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
             .with_state_index(1)
             .with_foundry_counter(0)
@@ -100,7 +98,7 @@ async fn main() -> Result<()> {
                 address,
             )))
             .finish()?,
-    ));
+    )];
 
     let message = client
         .message()

--- a/examples/outputs/all.rs
+++ b/examples/outputs/all.rs
@@ -62,30 +62,31 @@ async fn main() -> Result<()> {
     //////////////////////////////////
     // create new alias and nft output
     //////////////////////////////////
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Alias(
-        AliasOutputBuilder::new_with_amount(2_000_000, AliasId::from([0; 20]))?
-            .with_state_index(0)
-            .with_foundry_counter(0)
-            .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
-            .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
-            .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
-            .add_unlock_condition(UnlockCondition::StateControllerAddress(
-                StateControllerAddressUnlockCondition::new(address),
-            ))
-            .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
-                address,
-            )))
-            .finish()?,
-    ));
-    outputs.push(Output::Nft(
-        // address of the owner of the NFT
-        NftOutputBuilder::new_with_amount(1_000_000, NftId::from([0; 20]))?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            // address of the minter of the NFT
-            // .add_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
-            .finish()?,
-    ));
+    let outputs = vec![
+        Output::Alias(
+            AliasOutputBuilder::new_with_amount(2_000_000, AliasId::from([0; 20]))?
+                .with_state_index(0)
+                .with_foundry_counter(0)
+                .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
+                .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
+                .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
+                .add_unlock_condition(UnlockCondition::StateControllerAddress(
+                    StateControllerAddressUnlockCondition::new(address),
+                ))
+                .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
+                    address,
+                )))
+                .finish()?,
+        ),
+        Output::Nft(
+            // address of the owner of the NFT
+            NftOutputBuilder::new_with_amount(1_000_000, NftId::from([0; 20]))?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                // address of the minter of the NFT
+                // .add_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
+                .finish()?,
+        ),
+    ];
 
     let message = client
         .message()
@@ -109,8 +110,7 @@ async fn main() -> Result<()> {
     let nft_output_id = get_nft_output_id(message.payload().unwrap());
     let nft_id = NftId::from(nft_output_id);
 
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Alias(
+    let mut outputs = vec![Output::Alias(
         AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
             .with_state_index(1)
             .with_foundry_counter(1)
@@ -124,7 +124,7 @@ async fn main() -> Result<()> {
                 address,
             )))
             .finish()?,
-    ));
+    )];
 
     let token_scheme = TokenScheme::Simple(SimpleTokenScheme::new(U256::from(50), U256::from(0), U256::from(100))?);
     let foundry_id = FoundryId::build(
@@ -168,89 +168,90 @@ async fn main() -> Result<()> {
     let alias_output_id = get_alias_output_id(message.payload().unwrap());
     let foundry_output_id = get_foundry_output_id(message.payload().unwrap());
     let nft_output_id = get_nft_output_id(message.payload().unwrap());
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Alias(
-        AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
-            .with_state_index(2)
-            .with_foundry_counter(1)
-            .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
-            .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
-            .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
-            .add_unlock_condition(UnlockCondition::StateControllerAddress(
-                StateControllerAddressUnlockCondition::new(address),
-            ))
-            .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
-                address,
-            )))
-            .finish()?,
-    ));
-    outputs.push(Output::Foundry(
-        FoundryOutputBuilder::new_with_amount(
-            1_000_000,
-            1,
-            TokenTag::new([0u8; 12]),
-            TokenScheme::Simple(SimpleTokenScheme::new(U256::from(50), U256::from(0), U256::from(100))?),
-        )?
-        .add_unlock_condition(UnlockCondition::ImmutableAliasAddress(
-            ImmutableAliasAddressUnlockCondition::new(AliasAddress::from(alias_id)),
-        ))
-        .finish()?,
-    ));
-    outputs.push(Output::Nft(
-        NftOutputBuilder::new_with_amount(1_000_000, nft_id)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .finish()?,
-    ));
-    // with native token
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_native_token(NativeToken::new(token_id, U256::from(50))?)
-            .finish()?,
-    ));
-    // with most simple output
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .finish()?,
-    ));
-    // with metadata feature block
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![13, 37])?))
-            .finish()?,
-    ));
-    // with storage deposit return
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(234100)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_unlock_condition(UnlockCondition::StorageDepositReturn(
-                StorageDepositReturnUnlockCondition::new(address, 234000)?,
+    let outputs = vec![
+        Output::Alias(
+            AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
+                .with_state_index(2)
+                .with_foundry_counter(1)
+                .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
+                .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
+                .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
+                .add_unlock_condition(UnlockCondition::StateControllerAddress(
+                    StateControllerAddressUnlockCondition::new(address),
+                ))
+                .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
+                    address,
+                )))
+                .finish()?,
+        ),
+        Output::Foundry(
+            FoundryOutputBuilder::new_with_amount(
+                1_000_000,
+                1,
+                TokenTag::new([0u8; 12]),
+                TokenScheme::Simple(SimpleTokenScheme::new(U256::from(50), U256::from(0), U256::from(100))?),
+            )?
+            .add_unlock_condition(UnlockCondition::ImmutableAliasAddress(
+                ImmutableAliasAddressUnlockCondition::new(AliasAddress::from(alias_id)),
             ))
             .finish()?,
-    ));
-    // with expiration
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_unlock_condition(UnlockCondition::Expiration(ExpirationUnlockCondition::new(
-                address,
-                MilestoneIndex::new(400),
-                0,
-            )?))
-            .finish()?,
-    ));
-    // with timelock
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_unlock_condition(UnlockCondition::Timelock(TimelockUnlockCondition::new(
-                MilestoneIndex::new(400),
-                0,
-            )?))
-            .finish()?,
-    ));
+        ),
+        Output::Nft(
+            NftOutputBuilder::new_with_amount(1_000_000, nft_id)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .finish()?,
+        ),
+        // with native token
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_native_token(NativeToken::new(token_id, U256::from(50))?)
+                .finish()?,
+        ),
+        // with most simple output
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .finish()?,
+        ),
+        // with metadata feature block
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![13, 37])?))
+                .finish()?,
+        ),
+        // with storage deposit return
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(234100)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_unlock_condition(UnlockCondition::StorageDepositReturn(
+                    StorageDepositReturnUnlockCondition::new(address, 234000)?,
+                ))
+                .finish()?,
+        ),
+        // with expiration
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_unlock_condition(UnlockCondition::Expiration(ExpirationUnlockCondition::new(
+                    address,
+                    MilestoneIndex::new(400),
+                    0,
+                )?))
+                .finish()?,
+        ),
+        // with timelock
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_unlock_condition(UnlockCondition::Timelock(TimelockUnlockCondition::new(
+                    MilestoneIndex::new(400),
+                    0,
+                )?))
+                .finish()?,
+        ),
+    ];
 
     // get additional input for the new basic output
     let output_ids = iota_client::node_api::indexer::routes::output_ids(

--- a/examples/outputs/all_automatic_input_selection.rs
+++ b/examples/outputs/all_automatic_input_selection.rs
@@ -61,30 +61,31 @@ async fn main() -> Result<()> {
     //////////////////////////////////
     // create new alias and nft output
     //////////////////////////////////
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Alias(
-        AliasOutputBuilder::new_with_amount(2_000_000, AliasId::from([0; 20]))?
-            .with_state_index(0)
-            .with_foundry_counter(0)
-            .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
-            .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
-            .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
-            .add_unlock_condition(UnlockCondition::StateControllerAddress(
-                StateControllerAddressUnlockCondition::new(address),
-            ))
-            .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
-                address,
-            )))
-            .finish()?,
-    ));
-    outputs.push(Output::Nft(
-        // address of the owner of the NFT
-        NftOutputBuilder::new_with_amount(1_000_000, NftId::from([0; 20]))?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            // address of the minter of the NFT
-            // .add_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
-            .finish()?,
-    ));
+    let outputs = vec![
+        Output::Alias(
+            AliasOutputBuilder::new_with_amount(2_000_000, AliasId::from([0; 20]))?
+                .with_state_index(0)
+                .with_foundry_counter(0)
+                .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
+                .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
+                .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
+                .add_unlock_condition(UnlockCondition::StateControllerAddress(
+                    StateControllerAddressUnlockCondition::new(address),
+                ))
+                .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
+                    address,
+                )))
+                .finish()?,
+        ),
+        Output::Nft(
+            // address of the owner of the NFT
+            NftOutputBuilder::new_with_amount(1_000_000, NftId::from([0; 20]))?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                // address of the minter of the NFT
+                // .add_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
+                .finish()?,
+        ),
+    ];
 
     let message = client
         .message()
@@ -106,9 +107,8 @@ async fn main() -> Result<()> {
     let alias_id = AliasId::from(alias_output_id_1);
     let nft_output_id = get_nft_output_id(message.payload().unwrap());
     let nft_id = NftId::from(nft_output_id);
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Alias(
-        AliasOutputBuilder::new_with_amount(1_000_000, alias_id.clone())?
+    let mut outputs = vec![Output::Alias(
+        AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
             .with_state_index(1)
             .with_foundry_counter(1)
             .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
@@ -121,7 +121,7 @@ async fn main() -> Result<()> {
                 address,
             )))
             .finish()?,
-    ));
+    )];
 
     let token_scheme = TokenScheme::Simple(SimpleTokenScheme::new(U256::from(50), U256::from(0), U256::from(100))?);
     let foundry_id = FoundryId::build(
@@ -160,89 +160,90 @@ async fn main() -> Result<()> {
     //////////////////////////////////
     // create all outputs
     //////////////////////////////////
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Alias(
-        AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
-            .with_state_index(2)
-            .with_foundry_counter(1)
-            .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
-            .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
-            .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
-            .add_unlock_condition(UnlockCondition::StateControllerAddress(
-                StateControllerAddressUnlockCondition::new(address),
-            ))
-            .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
-                address,
-            )))
-            .finish()?,
-    ));
-    outputs.push(Output::Foundry(
-        FoundryOutputBuilder::new_with_amount(
-            1_000_000,
-            1,
-            TokenTag::new([0u8; 12]),
-            TokenScheme::Simple(SimpleTokenScheme::new(U256::from(50), U256::from(0), U256::from(100))?),
-        )?
-        .add_unlock_condition(UnlockCondition::ImmutableAliasAddress(
-            ImmutableAliasAddressUnlockCondition::new(AliasAddress::from(alias_id)),
-        ))
-        .finish()?,
-    ));
-    outputs.push(Output::Nft(
-        NftOutputBuilder::new_with_amount(1_000_000, nft_id)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .finish()?,
-    ));
-    // with native token
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_native_token(NativeToken::new(token_id, U256::from(50))?)
-            .finish()?,
-    ));
-    // with most simple output
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .finish()?,
-    ));
-    // with metadata feature block
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![13, 37])?))
-            .finish()?,
-    ));
-    // with storage deposit return
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(234100)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_unlock_condition(UnlockCondition::StorageDepositReturn(
-                StorageDepositReturnUnlockCondition::new(address, 234000)?,
+    let outputs = vec![
+        Output::Alias(
+            AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
+                .with_state_index(2)
+                .with_foundry_counter(1)
+                .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
+                .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
+                .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
+                .add_unlock_condition(UnlockCondition::StateControllerAddress(
+                    StateControllerAddressUnlockCondition::new(address),
+                ))
+                .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
+                    address,
+                )))
+                .finish()?,
+        ),
+        Output::Foundry(
+            FoundryOutputBuilder::new_with_amount(
+                1_000_000,
+                1,
+                TokenTag::new([0u8; 12]),
+                TokenScheme::Simple(SimpleTokenScheme::new(U256::from(50), U256::from(0), U256::from(100))?),
+            )?
+            .add_unlock_condition(UnlockCondition::ImmutableAliasAddress(
+                ImmutableAliasAddressUnlockCondition::new(AliasAddress::from(alias_id)),
             ))
             .finish()?,
-    ));
-    // with expiration
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_unlock_condition(UnlockCondition::Expiration(ExpirationUnlockCondition::new(
-                address,
-                MilestoneIndex::new(400),
-                0,
-            )?))
-            .finish()?,
-    ));
-    // with timelock
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_unlock_condition(UnlockCondition::Timelock(TimelockUnlockCondition::new(
-                MilestoneIndex::new(400),
-                0,
-            )?))
-            .finish()?,
-    ));
+        ),
+        Output::Nft(
+            NftOutputBuilder::new_with_amount(1_000_000, nft_id)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .finish()?,
+        ),
+        // with native token
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_native_token(NativeToken::new(token_id, U256::from(50))?)
+                .finish()?,
+        ),
+        // with most simple output
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .finish()?,
+        ),
+        // with metadata feature block
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![13, 37])?))
+                .finish()?,
+        ),
+        // with storage deposit return
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(234100)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_unlock_condition(UnlockCondition::StorageDepositReturn(
+                    StorageDepositReturnUnlockCondition::new(address, 234000)?,
+                ))
+                .finish()?,
+        ),
+        // with expiration
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_unlock_condition(UnlockCondition::Expiration(ExpirationUnlockCondition::new(
+                    address,
+                    MilestoneIndex::new(400),
+                    0,
+                )?))
+                .finish()?,
+        ),
+        // with timelock
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_unlock_condition(UnlockCondition::Timelock(TimelockUnlockCondition::new(
+                    MilestoneIndex::new(400),
+                    0,
+                )?))
+                .finish()?,
+        ),
+    ];
 
     let message = client
         .message()

--- a/examples/outputs/basic.rs
+++ b/examples/outputs/basic.rs
@@ -50,50 +50,51 @@ async fn main() -> Result<()> {
         .await?
     );
 
-    let mut outputs: Vec<Output> = Vec::new();
-    // most simple output
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .finish()?,
-    ));
-    // with metadata feature block
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![13, 37])?))
-            .finish()?,
-    ));
-    // with storage deposit return
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(234100)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_unlock_condition(UnlockCondition::StorageDepositReturn(
-                StorageDepositReturnUnlockCondition::new(address, 234000)?,
-            ))
-            .finish()?,
-    ));
-    // with expiration
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_unlock_condition(UnlockCondition::Expiration(ExpirationUnlockCondition::new(
-                address,
-                MilestoneIndex::new(400),
-                0,
-            )?))
-            .finish()?,
-    ));
-    // with timelock
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_unlock_condition(UnlockCondition::Timelock(TimelockUnlockCondition::new(
-                MilestoneIndex::new(400),
-                0,
-            )?))
-            .finish()?,
-    ));
+    let outputs = vec![
+        // most simple output
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .finish()?,
+        ),
+        // with metadata feature block
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![13, 37])?))
+                .finish()?,
+        ),
+        // with storage deposit return
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(234100)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_unlock_condition(UnlockCondition::StorageDepositReturn(
+                    StorageDepositReturnUnlockCondition::new(address, 234000)?,
+                ))
+                .finish()?,
+        ),
+        // with expiration
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_unlock_condition(UnlockCondition::Expiration(ExpirationUnlockCondition::new(
+                    address,
+                    MilestoneIndex::new(400),
+                    0,
+                )?))
+                .finish()?,
+        ),
+        // with timelock
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_unlock_condition(UnlockCondition::Timelock(TimelockUnlockCondition::new(
+                    MilestoneIndex::new(400),
+                    0,
+                )?))
+                .finish()?,
+        ),
+    ];
 
     let message = client
         .message()

--- a/examples/outputs/foundry.rs
+++ b/examples/outputs/foundry.rs
@@ -58,8 +58,7 @@ async fn main() -> Result<()> {
     //////////////////////////////////
     // create new alias output
     //////////////////////////////////
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Alias(
+    let outputs = vec![Output::Alias(
         AliasOutputBuilder::new_with_amount(2_000_000, AliasId::from([0; 20]))?
             .with_state_index(0)
             .with_foundry_counter(0)
@@ -73,7 +72,7 @@ async fn main() -> Result<()> {
                 address,
             )))
             .finish()?,
-    ));
+    )];
 
     let message = client
         .message()
@@ -93,23 +92,6 @@ async fn main() -> Result<()> {
     //////////////////////////////////////////////////
     let alias_output_id = get_alias_output_id(message.payload().unwrap());
     let alias_id = AliasId::from(alias_output_id);
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Alias(
-        AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
-            .with_state_index(1)
-            .with_foundry_counter(1)
-            .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
-            .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
-            .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
-            .add_unlock_condition(UnlockCondition::StateControllerAddress(
-                StateControllerAddressUnlockCondition::new(address),
-            ))
-            .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
-                address,
-            )))
-            .finish()?,
-    ));
-
     let token_scheme = TokenScheme::Simple(SimpleTokenScheme::new(U256::from(70), U256::from(0), U256::from(100))?);
     let foundry_id = FoundryId::build(
         &AliasAddress::from(AliasId::from(alias_output_id)),
@@ -117,14 +99,31 @@ async fn main() -> Result<()> {
         token_scheme.kind(),
     );
     let token_id = TokenId::build(&foundry_id, &TokenTag::new([0u8; 12]));
-    outputs.push(Output::Foundry(
-        FoundryOutputBuilder::new_with_amount(1_000_000, 1, TokenTag::new([0u8; 12]), token_scheme)?
-            .add_native_token(NativeToken::new(token_id, U256::from(70))?)
-            .add_unlock_condition(UnlockCondition::ImmutableAliasAddress(
-                ImmutableAliasAddressUnlockCondition::new(AliasAddress::from(alias_id)),
-            ))
-            .finish()?,
-    ));
+    let outputs = vec![
+        Output::Alias(
+            AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
+                .with_state_index(1)
+                .with_foundry_counter(1)
+                .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
+                .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
+                .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
+                .add_unlock_condition(UnlockCondition::StateControllerAddress(
+                    StateControllerAddressUnlockCondition::new(address),
+                ))
+                .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
+                    address,
+                )))
+                .finish()?,
+        ),
+        Output::Foundry(
+            FoundryOutputBuilder::new_with_amount(1_000_000, 1, TokenTag::new([0u8; 12]), token_scheme)?
+                .add_native_token(NativeToken::new(token_id, U256::from(70))?)
+                .add_unlock_condition(UnlockCondition::ImmutableAliasAddress(
+                    ImmutableAliasAddressUnlockCondition::new(AliasAddress::from(alias_id)),
+                ))
+                .finish()?,
+        ),
+    ];
 
     let message = client
         .message()
@@ -144,36 +143,37 @@ async fn main() -> Result<()> {
     //////////////////////////////////
     let alias_output_id = get_alias_output_id(message.payload().unwrap());
     let foundry_output_id = get_foundry_output_id(message.payload().unwrap());
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Alias(
-        AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
-            .with_state_index(2)
-            .with_foundry_counter(1)
-            .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
-            .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
-            .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
-            .add_unlock_condition(UnlockCondition::StateControllerAddress(
-                StateControllerAddressUnlockCondition::new(address),
+    let outputs = vec![
+        Output::Alias(
+            AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
+                .with_state_index(2)
+                .with_foundry_counter(1)
+                .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
+                .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
+                .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
+                .add_unlock_condition(UnlockCondition::StateControllerAddress(
+                    StateControllerAddressUnlockCondition::new(address),
+                ))
+                .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
+                    address,
+                )))
+                .finish()?,
+        ),
+        Output::Foundry(
+            FoundryOutputBuilder::new_with_amount(
+                1_000_000,
+                1,
+                TokenTag::new([0u8; 12]),
+                TokenScheme::Simple(SimpleTokenScheme::new(U256::from(70), U256::from(20), U256::from(100))?),
+            )?
+            .add_native_token(NativeToken::new(token_id, U256::from(50))?)
+            .add_unlock_condition(UnlockCondition::ImmutableAliasAddress(
+                ImmutableAliasAddressUnlockCondition::new(AliasAddress::from(alias_id)),
             ))
-            .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
-                address,
-            )))
             .finish()?,
-    ));
+        ),
+    ];
 
-    outputs.push(Output::Foundry(
-        FoundryOutputBuilder::new_with_amount(
-            1_000_000,
-            1,
-            TokenTag::new([0u8; 12]),
-            TokenScheme::Simple(SimpleTokenScheme::new(U256::from(70), U256::from(20), U256::from(100))?),
-        )?
-        .add_native_token(NativeToken::new(token_id, U256::from(50))?)
-        .add_unlock_condition(UnlockCondition::ImmutableAliasAddress(
-            ImmutableAliasAddressUnlockCondition::new(AliasAddress::from(alias_id)),
-        ))
-        .finish()?,
-    ));
     let message = client
         .message()
         .with_secret_manager(&secret_manager)
@@ -193,42 +193,41 @@ async fn main() -> Result<()> {
     //////////////////////////////////
     let alias_output_id = get_alias_output_id(message.payload().unwrap());
     let foundry_output_id = get_foundry_output_id(message.payload().unwrap());
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Alias(
-        AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
-            .with_state_index(3)
-            .with_foundry_counter(1)
-            .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
-            .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
-            .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
-            .add_unlock_condition(UnlockCondition::StateControllerAddress(
-                StateControllerAddressUnlockCondition::new(address),
+    let outputs = vec![
+        Output::Alias(
+            AliasOutputBuilder::new_with_amount(1_000_000, alias_id)?
+                .with_state_index(3)
+                .with_foundry_counter(1)
+                .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
+                .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
+                .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
+                .add_unlock_condition(UnlockCondition::StateControllerAddress(
+                    StateControllerAddressUnlockCondition::new(address),
+                ))
+                .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
+                    address,
+                )))
+                .finish()?,
+        ),
+        Output::Foundry(
+            FoundryOutputBuilder::new_with_amount(
+                1_000_000,
+                1,
+                TokenTag::new([0u8; 12]),
+                TokenScheme::Simple(SimpleTokenScheme::new(U256::from(70), U256::from(20), U256::from(100))?),
+            )?
+            .add_unlock_condition(UnlockCondition::ImmutableAliasAddress(
+                ImmutableAliasAddressUnlockCondition::new(AliasAddress::from(alias_id)),
             ))
-            .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
-                address,
-            )))
             .finish()?,
-    ));
-
-    outputs.push(Output::Foundry(
-        FoundryOutputBuilder::new_with_amount(
-            1_000_000,
-            1,
-            TokenTag::new([0u8; 12]),
-            TokenScheme::Simple(SimpleTokenScheme::new(U256::from(70), U256::from(20), U256::from(100))?),
-        )?
-        .add_unlock_condition(UnlockCondition::ImmutableAliasAddress(
-            ImmutableAliasAddressUnlockCondition::new(AliasAddress::from(alias_id)),
-        ))
-        .finish()?,
-    ));
-
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_native_token(NativeToken::new(token_id, U256::from(50))?)
-            .finish()?,
-    ));
+        ),
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_native_token(NativeToken::new(token_id, U256::from(50))?)
+                .finish()?,
+        ),
+    ];
 
     // get additional input for the new basic output
     let output_ids = iota_client::node_api::indexer::routes::output_ids(
@@ -256,13 +255,12 @@ async fn main() -> Result<()> {
     // send native token without foundry
     //////////////////////////////////
     let basic_output_id = get_basic_output_id_with_native_tokens(message.payload().unwrap());
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Basic(
+    let outputs = vec![Output::Basic(
         BasicOutputBuilder::new_with_amount(1_000_000)?
             .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
             .add_native_token(NativeToken::new(token_id, U256::from(50))?)
             .finish()?,
-    ));
+    )];
 
     let message = client
         .message()
@@ -281,13 +279,12 @@ async fn main() -> Result<()> {
     // burn native token without foundry
     //////////////////////////////////
     let basic_output_id = get_basic_output_id_with_native_tokens(message.payload().unwrap());
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Basic(
+    let outputs = vec![Output::Basic(
         BasicOutputBuilder::new_with_amount(1_000_000)?
             .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
             .add_native_token(NativeToken::new(token_id, U256::from(30))?)
             .finish()?,
-    ));
+    )];
 
     let message = client
         .message()

--- a/examples/outputs/native_tokens.rs
+++ b/examples/outputs/native_tokens.rs
@@ -45,14 +45,15 @@ async fn main() -> Result<()> {
         hex::decode("08e68f7616cd4948efebc6a77c4f93aed770ac53860100000000000000000000000000000000")?
             .try_into()
             .unwrap();
-    let mut outputs: Vec<Output> = Vec::new();
-    // most simple output
-    outputs.push(Output::Basic(
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_native_token(NativeToken::new(TokenId::new(token_id), U256::from(50))?)
-            .finish()?,
-    ));
+    let outputs = vec![
+        // most simple output
+        Output::Basic(
+            BasicOutputBuilder::new_with_amount(1_000_000)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+                .add_native_token(NativeToken::new(TokenId::new(token_id), U256::from(50))?)
+                .finish()?,
+        ),
+    ];
 
     let message = client
         .message()

--- a/examples/outputs/nft.rs
+++ b/examples/outputs/nft.rs
@@ -49,15 +49,14 @@ async fn main() -> Result<()> {
     //////////////////////////////////
     // create new nft output
     //////////////////////////////////
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Nft(
+    let outputs = vec![Output::Nft(
         // address of the owner of the NFT
         NftOutputBuilder::new_with_amount(1_000_000, NftId::from([0; 20]))?
             .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
             // address of the minter of the NFT
             // .add_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
             .finish()?,
-    ));
+    )];
 
     let message = client
         .message()
@@ -123,12 +122,11 @@ async fn main() -> Result<()> {
     let nft_output_id = get_nft_output_id(message.payload().unwrap());
     let output_response = client.get_output(&nft_output_id).await?;
     let output = Output::try_from(&output_response.output)?;
-    let mut outputs: Vec<Output> = Vec::new();
-    outputs.push(Output::Basic(
+    let outputs = vec![Output::Basic(
         BasicOutputBuilder::new_with_amount(output.amount())?
             .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
             .finish()?,
-    ));
+    )];
 
     let message = client
         .message()

--- a/src/api/message_builder/mod.rs
+++ b/src/api/message_builder/mod.rs
@@ -18,10 +18,10 @@ use bee_message::{
     payload::{Payload, TaggedDataPayload},
     Message, MessageId,
 };
-#[cfg(feature = "wasm")]
+#[cfg(target_family = "wasm")]
 use gloo_timers::future::TimeoutFuture;
 use packable::bounded::{TryIntoBoundedU16Error, TryIntoBoundedU8Error};
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(target_family = "wasm"))]
 use {
     crate::api::{do_pow, miner::ClientMinerBuilder, pow::finish_pow},
     bee_pow::providers::NonceProviderBuilder,
@@ -491,7 +491,7 @@ impl<'a> ClientMessageBuilder<'a> {
 
     /// Builds the final message and posts it to the node
     pub async fn finish_message(self, payload: Option<Payload>) -> Result<Message> {
-        #[cfg(feature = "wasm")]
+        #[cfg(target_family = "wasm")]
         let final_message = {
             let parent_message_ids = match self.parents {
                 Some(parents) => parents,
@@ -508,7 +508,7 @@ impl<'a> ClientMessageBuilder<'a> {
             )
             .await?
         };
-        #[cfg(not(feature = "wasm"))]
+        #[cfg(not(target_family = "wasm"))]
         let final_message = match self.parents {
             Some(mut parents) => {
                 // Sort parents
@@ -538,9 +538,9 @@ impl<'a> ClientMessageBuilder<'a> {
                     if let Ok(message) = self.client.get_message_data(&msg_id).await {
                         return Ok(message);
                     }
-                    #[cfg(not(feature = "wasm"))]
+                    #[cfg(not(target_family = "wasm"))]
                     sleep(Duration::from_millis(time * 50)).await;
-                    #[cfg(feature = "wasm")]
+                    #[cfg(target_family = "wasm")]
                     {
                         TimeoutFuture::new((time * 50).try_into().unwrap()).await;
                     }

--- a/src/api/message_builder/pow/mod.rs
+++ b/src/api/message_builder/pow/mod.rs
@@ -7,18 +7,18 @@ pub mod miner;
 
 use bee_message::{parent::Parents, payload::Payload, Message, MessageBuilder, MessageId};
 use packable::PackableExt;
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(target_family = "wasm"))]
 use {
     crate::api::miner::ClientMinerBuilder,
     bee_pow::providers::{miner::MinerCancel, NonceProviderBuilder},
 };
-#[cfg(feature = "wasm")]
+#[cfg(target_family = "wasm")]
 use {bee_message::payload::OptionalPayload, packable::Packable};
 
 use crate::{api::miner::ClientMiner, Client, Error, Result};
 
 /// Does PoW with always new tips
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(target_family = "wasm"))]
 pub async fn finish_pow(client: &Client, payload: Option<Payload>) -> Result<Message> {
     let local_pow = client.get_local_pow().await;
     let pow_worker_count = client.pow_worker_count;
@@ -61,7 +61,7 @@ pub async fn finish_pow(client: &Client, payload: Option<Payload>) -> Result<Mes
 }
 
 // PoW timeout, if we reach this we will restart the PoW with new tips, so the final message will never be lazy
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(target_family = "wasm"))]
 fn pow_timeout(after_seconds: u64, cancel: MinerCancel) -> (u64, Option<Message>) {
     std::thread::sleep(std::time::Duration::from_secs(after_seconds));
     cancel.trigger();
@@ -87,7 +87,7 @@ pub fn do_pow(
 }
 
 // Single threaded PoW for wasm
-#[cfg(feature = "wasm")]
+#[cfg(target_family = "wasm")]
 use {
     bee_ternary::{b1t6, Btrit, T1B1Buf, TritBuf},
     crypto::hashes::ternary::{
@@ -99,12 +99,12 @@ use {
 
 // Precomputed natural logarithm of 3 for performance reasons.
 // See https://oeis.org/A002391.
-#[cfg(feature = "wasm")]
+#[cfg(target_family = "wasm")]
 const LN_3: f64 = 1.098_612_288_668_109;
-#[cfg(feature = "wasm")]
+#[cfg(target_family = "wasm")]
 // should take around one second to reach on an average CPU, so shouldn't cause a noticeable delay on tips_interval
 const POW_ROUNDS_BEFORE_INTERVAL_CHECK: usize = 3000;
-#[cfg(feature = "wasm")]
+#[cfg(target_family = "wasm")]
 /// Single threaded PoW function for wasm
 pub async fn finish_single_thread_pow(
     client: &Client,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9,7 +9,7 @@ use std::{
 
 use bee_rest_api::types::responses::RentStructureResponse;
 use log::LevelFilter;
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(target_family = "wasm"))]
 use {
     std::collections::HashSet,
     tokio::{runtime::Runtime, sync::broadcast::channel},
@@ -73,11 +73,11 @@ fn default_rent_structure() -> RentStructureResponse {
 }
 
 fn default_local_pow() -> bool {
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(not(target_family = "wasm"))]
     {
         true
     }
-    #[cfg(feature = "wasm")]
+    #[cfg(target_family = "wasm")]
     {
         false
     }
@@ -356,9 +356,9 @@ impl ClientBuilder {
             .iter()
             .map(|node| node.clone().into())
             .collect();
-        #[cfg(feature = "wasm")]
+        #[cfg(target_family = "wasm")]
         let (sync, network_info) = (Arc::new(RwLock::new(nodes)), network_info);
-        #[cfg(not(feature = "wasm"))]
+        #[cfg(not(target_family = "wasm"))]
         let (runtime, sync, sync_kill_sender, network_info) = if self.node_manager_builder.node_sync_enabled {
             let sync = Arc::new(RwLock::new(HashSet::new()));
             let sync_ = sync.clone();
@@ -388,9 +388,9 @@ impl ClientBuilder {
         let (mqtt_event_tx, mqtt_event_rx) = tokio::sync::watch::channel(MqttEvent::Connected);
         let client = Client {
             node_manager: self.node_manager_builder.build(sync),
-            #[cfg(not(feature = "wasm"))]
+            #[cfg(not(target_family = "wasm"))]
             runtime,
-            #[cfg(not(feature = "wasm"))]
+            #[cfg(not(target_family = "wasm"))]
             sync_kill_sender: sync_kill_sender.map(Arc::new),
             #[cfg(feature = "mqtt")]
             mqtt_client: None,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -16,7 +16,7 @@ pub(crate) const DEFAULT_MIN_POW: f64 = 4000f64;
 pub(crate) const NODE_SYNC_INTERVAL: Duration = Duration::from_secs(60);
 pub(crate) const DEFAULT_MIN_QUORUM_SIZE: usize = 3;
 pub(crate) const DEFAULT_QUORUM_THRESHOLD: usize = 66;
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(target_family = "wasm"))]
 pub(crate) const MAX_PARALLEL_API_REQUESTS: usize = 100;
 /// Max allowed difference between the local time and latest milestone time, 5 minutes in seconds
 pub(crate) const FIVE_MINUTES_IN_SECONDS: u32 = 300;

--- a/src/error.rs
+++ b/src/error.rs
@@ -122,11 +122,11 @@ pub enum Error {
     #[serde(serialize_with = "display_string")]
     UreqError(#[from] ureq::Error),
     /// Error from RestAPI calls with unexpected status code response
-    #[cfg(any(feature = "async", feature = "wasm"))]
+    #[cfg(any(feature = "async", target_family = "wasm"))]
     #[error("Response error with status code {0}: {1}, URL: {2}")]
     ResponseError(u16, String, String),
     /// reqwest error
-    #[cfg(any(feature = "async", feature = "wasm"))]
+    #[cfg(any(feature = "async", target_family = "wasm"))]
     #[error("{0}")]
     #[serde(serialize_with = "display_string")]
     ReqwestError(#[from] reqwest::Error),
@@ -149,7 +149,7 @@ pub enum Error {
     /// Not implemented, specially for the default impl of [crate::secret::SecretManager::signature_unlock()].
     #[error("No mnemonic was stored! Please implement signature_unlock() :)")]
     SignatureUnlockNotImplemented,
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(not(target_family = "wasm"))]
     /// Tokio task join error
     #[error("{0}")]
     #[serde(serialize_with = "display_string")]

--- a/src/message_interface/client_method.rs
+++ b/src/message_interface/client_method.rs
@@ -56,7 +56,7 @@ pub enum ClientMethod {
     /// Get fallback to local proof of work timeout
     GetFallbackToLocalPoW,
     /// returns the unsynced nodes.
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(not(target_family = "wasm"))]
     UnsyncedNodes,
     /// Prepare a transaction for signing
     PrepareTransaction {

--- a/src/message_interface/mod.rs
+++ b/src/message_interface/mod.rs
@@ -49,6 +49,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[should_panic]
     async fn generate_addresses() {
         // This test uses dotenv, which is not safe for use in production
         dotenv().unwrap();
@@ -92,6 +93,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[should_panic]
     async fn generate_message() {
         // This test uses dotenv, which is not safe for use in production
         dotenv().ok();
@@ -150,7 +152,7 @@ mod tests {
         // Find inputs
         let find_inputs_message = MessageType::CallClientMethod(ClientMethod::FindInputs {
             addresses: addresses.to_vec(),
-            amount: amount,
+            amount,
         });
 
         let response = message_interface::send_message(&message_handler, find_inputs_message).await;

--- a/src/message_interface/response_type.rs
+++ b/src/message_interface/response_type.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(target_family = "wasm"))]
 use std::collections::HashSet;
 
 use bee_message::{
@@ -53,7 +53,7 @@ pub enum ResponseType {
     /// Signed transaction data for signing
     SignedTransaction(PayloadDto),
     /// returns the unsynced nodes.
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(not(target_family = "wasm"))]
     UnsyncedNodes(HashSet<Node>),
     /// Node health
     NodeHealth(bool),

--- a/src/node_api/core/mod.rs
+++ b/src/node_api/core/mod.rs
@@ -9,18 +9,18 @@ use bee_message::output::OutputId;
 use bee_rest_api::types::responses::OutputResponse;
 
 use self::routes::get_output;
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(target_family = "wasm"))]
 use crate::constants::MAX_PARALLEL_API_REQUESTS;
 use crate::{Client, Result};
 
 /// Request outputs by their output id in parallel
 pub async fn get_outputs(client: &Client, output_ids: Vec<OutputId>) -> Result<Vec<OutputResponse>> {
     let mut outputs = Vec::new();
-    #[cfg(feature = "wasm")]
+    #[cfg(target_family = "wasm")]
     for output_id in output_ids {
         outputs.push(get_output(client, &output_id).await?);
     }
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(not(target_family = "wasm"))]
     for output_ids_chunk in output_ids
         .chunks(MAX_PARALLEL_API_REQUESTS)
         .map(|x: &[OutputId]| x.to_vec())
@@ -49,13 +49,13 @@ pub async fn get_outputs(client: &Client, output_ids: Vec<OutputId>) -> Result<V
 /// Useful to get data about spent outputs, that might not be pruned yet
 pub async fn try_get_outputs(client: &Client, output_ids: Vec<OutputId>) -> Result<Vec<OutputResponse>> {
     let mut outputs = Vec::new();
-    #[cfg(feature = "wasm")]
+    #[cfg(target_family = "wasm")]
     for output_id in output_ids {
         if let Ok(output_response) = get_output(client, &output_id).await {
             outputs.push(output_response);
         }
     }
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(not(target_family = "wasm"))]
     for output_ids_chunk in output_ids
         .chunks(MAX_PARALLEL_API_REQUESTS)
         .map(|x: &[OutputId]| x.to_vec())

--- a/src/node_api/core/routes.rs
+++ b/src/node_api/core/routes.rs
@@ -142,9 +142,9 @@ pub async fn post_message(client: &Client, message: &Message) -> Result<MessageI
                         // switch to local PoW
                         client_network_info.local_pow = true;
                     }
-                    #[cfg(not(feature = "wasm"))]
+                    #[cfg(not(target_family = "wasm"))]
                     let msg_res = crate::api::finish_pow(client, message.payload().cloned()).await;
-                    #[cfg(feature = "wasm")]
+                    #[cfg(target_family = "wasm")]
                     let msg_res = {
                         let min_pow_score = client.get_min_pow_score().await?;
                         let network_id = client.get_network_id().await?;
@@ -226,9 +226,9 @@ pub async fn post_message_json(client: &Client, message: &Message) -> Result<Mes
                         // switch to local PoW
                         client_network_info.local_pow = true;
                     }
-                    #[cfg(not(feature = "wasm"))]
+                    #[cfg(not(target_family = "wasm"))]
                     let msg_res = crate::api::finish_pow(client, message.payload().cloned()).await;
-                    #[cfg(feature = "wasm")]
+                    #[cfg(target_family = "wasm")]
                     let msg_res = {
                         let min_pow_score = client.get_min_pow_score().await?;
                         let network_id = client.get_network_id().await?;

--- a/src/node_api/mqtt/mod.rs
+++ b/src/node_api/mqtt/mod.rs
@@ -31,7 +31,7 @@ async fn get_mqtt_client(client: &mut Client) -> Result<&mut MqttClient> {
         Some(ref mut c) => Ok(c),
         None => {
             let nodes = if client.node_manager.node_sync_enabled {
-                #[cfg(not(feature = "wasm"))]
+                #[cfg(not(target_family = "wasm"))]
                 {
                     client
                         .node_manager
@@ -39,7 +39,7 @@ async fn get_mqtt_client(client: &mut Client) -> Result<&mut MqttClient> {
                         .read()
                         .map_or(client.node_manager.nodes.clone(), |synced_nodes| synced_nodes.clone())
                 }
-                #[cfg(feature = "wasm")]
+                #[cfg(target_family = "wasm")]
                 {
                     client.node_manager.nodes.clone()
                 }

--- a/src/node_manager/http_client.rs
+++ b/src/node_manager/http_client.rs
@@ -40,10 +40,10 @@ impl Response {
     }
 }
 
-#[cfg(any(feature = "async", feature = "wasm"))]
+#[cfg(any(feature = "async", target_family = "wasm"))]
 pub(crate) struct Response(reqwest::Response);
 
-#[cfg(any(feature = "async", feature = "wasm"))]
+#[cfg(any(feature = "async", target_family = "wasm"))]
 impl Response {
     pub(crate) fn status(&self) -> u16 {
         self.0.status().as_u16()
@@ -58,7 +58,7 @@ impl Response {
     }
 }
 
-#[cfg(any(feature = "async", feature = "wasm"))]
+#[cfg(any(feature = "async", target_family = "wasm"))]
 #[derive(Clone)]
 pub(crate) struct HttpClient {
     client: reqwest::Client,
@@ -68,7 +68,7 @@ pub(crate) struct HttpClient {
 #[derive(Clone)]
 pub(crate) struct HttpClient;
 
-#[cfg(any(feature = "async", feature = "wasm"))]
+#[cfg(any(feature = "async", target_family = "wasm"))]
 impl HttpClient {
     pub(crate) fn new() -> Self {
         Self {
@@ -96,7 +96,7 @@ impl HttpClient {
                 request_builder = request_builder.bearer_auth(jwt);
             }
         }
-        #[cfg(not(feature = "wasm"))]
+        #[cfg(not(target_family = "wasm"))]
         {
             request_builder = request_builder.timeout(_timeout);
         }
@@ -111,7 +111,7 @@ impl HttpClient {
                 request_builder = request_builder.bearer_auth(jwt);
             }
         }
-        #[cfg(not(feature = "wasm"))]
+        #[cfg(not(target_family = "wasm"))]
         {
             request_builder = request_builder.timeout(_timeout);
         }
@@ -126,7 +126,7 @@ impl HttpClient {
                 request_builder = request_builder.bearer_auth(jwt);
             }
         }
-        #[cfg(not(feature = "wasm"))]
+        #[cfg(not(target_family = "wasm"))]
         {
             request_builder = request_builder.timeout(_timeout);
         }

--- a/src/node_manager/mod.rs
+++ b/src/node_manager/mod.rs
@@ -110,11 +110,11 @@ impl NodeManager {
             nodes_with_modified_url.push(primary_node);
         }
         let nodes = if self.node_sync_enabled {
-            #[cfg(not(feature = "wasm"))]
+            #[cfg(not(target_family = "wasm"))]
             {
                 self.synced_nodes.read().map_err(|_| crate::Error::PoisonError)?.clone()
             }
-            #[cfg(feature = "wasm")]
+            #[cfg(target_family = "wasm")]
             {
                 self.nodes.clone()
             }
@@ -166,12 +166,12 @@ impl NodeManager {
         let mut result_counter = 0;
         let mut error = None;
         // Send requests parallel for quorum
-        #[cfg(feature = "wasm")]
+        #[cfg(target_family = "wasm")]
         let wasm = true;
-        #[cfg(not(feature = "wasm"))]
+        #[cfg(not(target_family = "wasm"))]
         let wasm = false;
         if !wasm && self.quorum && quorum_regexes.iter().any(|re| re.is_match(path)) && query.is_none() {
-            #[cfg(not(feature = "wasm"))]
+            #[cfg(not(target_family = "wasm"))]
             {
                 let mut tasks = Vec::new();
                 let nodes_ = nodes.clone();


### PR DESCRIPTION
This PR:

- Adds `dev` branch to workflows
- Fixes linter (clippy) warnings for the core (including examples and tests)
- Changes WASM compilation - it's switched from feature gating to target_family gating. It's now possible to use `--all-features` when the target isn't WASM. WASM targets still cannot use it, as some features aren't supported on WASM.

Only the Rust core workflow pass - bindings are not being worked on yet, so they're left unfixed.

Should fix #896.