### PR TITLE
Remove useless client method forwards

### DIFF
--- a/examples/custom_inputs.rs
+++ b/examples/custom_inputs.rs
@@ -42,11 +42,9 @@ async fn main() -> Result<()> {
     );
     tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
-    let output_ids = iota_client::node_api::indexer::routes::output_ids(
-        &client,
-        vec![QueryParameter::Address(addresses[0].clone())],
-    )
-    .await?;
+    let output_ids = client
+        .output_ids(vec![QueryParameter::Address(addresses[0].clone())])
+        .await?;
     println!("{:?}", output_ids);
 
     let message = client

--- a/examples/custom_remainder_address.rs
+++ b/examples/custom_remainder_address.rs
@@ -52,11 +52,9 @@ async fn main() -> Result<()> {
     );
     tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
-    let output_ids = iota_client::node_api::indexer::routes::output_ids(
-        &client,
-        vec![QueryParameter::Address(sender_address.clone())],
-    )
-    .await?;
+    let output_ids = client
+        .output_ids(vec![QueryParameter::Address(sender_address.clone())])
+        .await?;
     println!("{:?}", output_ids);
 
     let message = client

--- a/examples/indexer.rs
+++ b/examples/indexer.rs
@@ -41,14 +41,12 @@ async fn main() -> Result<()> {
         .await?
     );
 
-    let output_ids = iota_client::node_api::indexer::routes::output_ids(
-        &client,
-        vec![QueryParameter::Address(address.to_bech32("atoi"))],
-    )
-    .await?;
+    let output_ids = client
+        .output_ids(vec![QueryParameter::Address(address.to_bech32("atoi"))])
+        .await?;
     println!("output ids {:?}", output_ids);
 
-    let outputs = iota_client::node_api::core::get_outputs(&client, output_ids).await?;
+    let outputs = client.get_outputs(output_ids).await?;
 
     println!("outputs {:?}", outputs);
     Ok(())

--- a/examples/outputs/all.rs
+++ b/examples/outputs/all.rs
@@ -226,11 +226,9 @@ async fn main() -> Result<()> {
     ];
 
     // get additional input for the new basic output
-    let output_ids = iota_client::node_api::indexer::routes::output_ids(
-        &client,
-        vec![QueryParameter::Address(address.to_bech32("rms"))],
-    )
-    .await?;
+    let output_ids = client
+        .output_ids(vec![QueryParameter::Address(address.to_bech32("rms"))])
+        .await?;
 
     let message = client
         .message()

--- a/examples/outputs/foundry.rs
+++ b/examples/outputs/foundry.rs
@@ -58,21 +58,19 @@ async fn main() -> Result<()> {
     //////////////////////////////////
     // create new alias output
     //////////////////////////////////
-    let outputs = vec![
-        AliasOutputBuilder::new_with_amount(2_000_000, AliasId::null())?
-            .with_state_index(0)
-            .with_foundry_counter(0)
-            .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
-            .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
-            .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
-            .add_unlock_condition(UnlockCondition::StateControllerAddress(
-                StateControllerAddressUnlockCondition::new(address),
-            ))
-            .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
-                address,
-            )))
-            .finish_output()?,
-    ];
+    let outputs = vec![AliasOutputBuilder::new_with_amount(2_000_000, AliasId::null())?
+        .with_state_index(0)
+        .with_foundry_counter(0)
+        .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
+        .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
+        .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
+        .add_unlock_condition(UnlockCondition::StateControllerAddress(
+            StateControllerAddressUnlockCondition::new(address),
+        ))
+        .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
+            address,
+        )))
+        .finish_output()?];
 
     let message = client
         .message()
@@ -216,11 +214,9 @@ async fn main() -> Result<()> {
     ];
 
     // get additional input for the new basic output
-    let output_ids = iota_client::node_api::indexer::routes::output_ids(
-        &client,
-        vec![QueryParameter::Address(address.to_bech32("atoi"))],
-    )
-    .await?;
+    let output_ids = client
+        .output_ids(vec![QueryParameter::Address(address.to_bech32("atoi"))])
+        .await?;
 
     let message = client
         .message()
@@ -241,12 +237,10 @@ async fn main() -> Result<()> {
     // send native token without foundry
     //////////////////////////////////
     let basic_output_id = get_basic_output_id_with_native_tokens(message.payload().unwrap());
-    let outputs = vec![
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_native_token(NativeToken::new(token_id, U256::from(50))?)
-            .finish_output()?,
-    ];
+    let outputs = vec![BasicOutputBuilder::new_with_amount(1_000_000)?
+        .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+        .add_native_token(NativeToken::new(token_id, U256::from(50))?)
+        .finish_output()?];
 
     let message = client
         .message()
@@ -265,12 +259,10 @@ async fn main() -> Result<()> {
     // burn native token without foundry
     //////////////////////////////////
     let basic_output_id = get_basic_output_id_with_native_tokens(message.payload().unwrap());
-    let outputs = vec![
-        BasicOutputBuilder::new_with_amount(1_000_000)?
-            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-            .add_native_token(NativeToken::new(token_id, U256::from(30))?)
-            .finish_output()?,
-    ];
+    let outputs = vec![BasicOutputBuilder::new_with_amount(1_000_000)?
+        .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+        .add_native_token(NativeToken::new(token_id, U256::from(30))?)
+        .finish_output()?];
 
     let message = client
         .message()

--- a/examples/outputs/foundry.rs
+++ b/examples/outputs/foundry.rs
@@ -58,19 +58,21 @@ async fn main() -> Result<()> {
     //////////////////////////////////
     // create new alias output
     //////////////////////////////////
-    let outputs = vec![AliasOutputBuilder::new_with_amount(2_000_000, AliasId::null())?
-        .with_state_index(0)
-        .with_foundry_counter(0)
-        .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
-        .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
-        .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
-        .add_unlock_condition(UnlockCondition::StateControllerAddress(
-            StateControllerAddressUnlockCondition::new(address),
-        ))
-        .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
-            address,
-        )))
-        .finish_output()?];
+    let outputs = vec![
+        AliasOutputBuilder::new_with_amount(2_000_000, AliasId::null())?
+            .with_state_index(0)
+            .with_foundry_counter(0)
+            .add_feature_block(FeatureBlock::Sender(SenderFeatureBlock::new(address)))
+            .add_feature_block(FeatureBlock::Metadata(MetadataFeatureBlock::new(vec![1, 2, 3])?))
+            .add_immutable_feature_block(FeatureBlock::Issuer(IssuerFeatureBlock::new(address)))
+            .add_unlock_condition(UnlockCondition::StateControllerAddress(
+                StateControllerAddressUnlockCondition::new(address),
+            ))
+            .add_unlock_condition(UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(
+                address,
+            )))
+            .finish_output()?,
+    ];
 
     let message = client
         .message()
@@ -237,10 +239,12 @@ async fn main() -> Result<()> {
     // send native token without foundry
     //////////////////////////////////
     let basic_output_id = get_basic_output_id_with_native_tokens(message.payload().unwrap());
-    let outputs = vec![BasicOutputBuilder::new_with_amount(1_000_000)?
-        .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-        .add_native_token(NativeToken::new(token_id, U256::from(50))?)
-        .finish_output()?];
+    let outputs = vec![
+        BasicOutputBuilder::new_with_amount(1_000_000)?
+            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+            .add_native_token(NativeToken::new(token_id, U256::from(50))?)
+            .finish_output()?,
+    ];
 
     let message = client
         .message()
@@ -259,10 +263,12 @@ async fn main() -> Result<()> {
     // burn native token without foundry
     //////////////////////////////////
     let basic_output_id = get_basic_output_id_with_native_tokens(message.payload().unwrap());
-    let outputs = vec![BasicOutputBuilder::new_with_amount(1_000_000)?
-        .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
-        .add_native_token(NativeToken::new(token_id, U256::from(30))?)
-        .finish_output()?];
+    let outputs = vec![
+        BasicOutputBuilder::new_with_amount(1_000_000)?
+            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))
+            .add_native_token(NativeToken::new(token_id, U256::from(30))?)
+            .finish_output()?,
+    ];
 
     let message = client
         .message()

--- a/src/api/message_builder/input_selection/automatic.rs
+++ b/src/api/message_builder/input_selection/automatic.rs
@@ -80,18 +80,17 @@ pub(crate) async fn get_inputs(
         // For each address, get the address outputs
         let mut address_index = gap_index;
         for (index, (str_address, internal)) in public_and_internal_addresses.iter().enumerate() {
-            let output_ids = crate::node_api::indexer::routes::output_ids(
-                message_builder.client,
-                vec![
+            let output_ids = message_builder
+                .client
+                .output_ids(vec![
                     QueryParameter::Address(str_address.to_string()),
                     QueryParameter::HasExpirationCondition(false),
                     QueryParameter::HasTimelockCondition(false),
                     QueryParameter::HasStorageDepositReturnCondition(false),
-                ],
-            )
-            .await?;
+                ])
+                .await?;
 
-            let address_outputs = crate::node_api::core::get_outputs(message_builder.client, output_ids).await?;
+            let address_outputs = message_builder.client.get_outputs(output_ids).await?;
 
             // If there are more than 20 (ADDRESS_GAP_RANGE) consecutive empty addresses, then we stop
             // looking up the addresses belonging to the seed. Note that we don't
@@ -227,18 +226,18 @@ async fn get_inputs_for_sender_and_issuer(
             .await?;
             // if we didn't return with an error, then the address was found
 
-            let output_ids = crate::node_api::indexer::routes::output_ids(
-                message_builder.client,
-                vec![
+            let output_ids = message_builder
+                .client
+                .output_ids(vec![
                     QueryParameter::Address(Address::Ed25519(*address).to_bech32(&bech32_hrp)),
                     QueryParameter::HasExpirationCondition(false),
                     QueryParameter::HasTimelockCondition(false),
                     QueryParameter::HasStorageDepositReturnCondition(false),
-                ],
-            )
-            .await?;
+                ])
+                .await?;
 
-            let address_outputs = crate::node_api::core::get_outputs(message_builder.client, output_ids).await?;
+            let address_outputs = message_builder.client.get_outputs(output_ids).await?;
+
             match address_outputs.first() {
                 Some(output_response) => {
                     required_ed25519_inputs.push(InputSigningData {

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,10 +14,9 @@ use std::{
 use bee_message::{
     address::Address,
     input::{Input, UtxoInput, INPUT_COUNT_MAX},
-    output::{AliasId, ByteCostConfig, ByteCostConfigBuilder, FoundryId, NftId, OutputId},
+    output::{ByteCostConfig, ByteCostConfigBuilder, OutputId},
     parent::Parents,
     payload::{
-        milestone::MilestoneId,
         transaction::{TransactionEssence, TransactionId},
         Payload, TaggedDataPayload,
     },
@@ -25,11 +24,8 @@ use bee_message::{
 };
 use bee_pow::providers::NonceProviderBuilder;
 use bee_rest_api::types::{
-    dtos::{LedgerInclusionStateDto, PeerDto, ReceiptDto},
-    responses::{
-        InfoResponse as NodeInfo, MessageMetadataResponse, MilestoneResponse, OutputResponse, TreasuryResponse,
-        UtxoChangesResponse as MilestoneUTXOChanges,
-    },
+    dtos::LedgerInclusionStateDto,
+    responses::{InfoResponse as NodeInfo, OutputResponse},
 };
 use crypto::keys::slip10::Seed;
 #[cfg(target_family = "wasm")]
@@ -453,172 +449,18 @@ impl Client {
         Ok(resp)
     }
 
-    /// Returns the node information together with the url of the used node
-    /// GET /api/v2/info endpoint
-    pub async fn get_info(&self) -> Result<NodeInfoWrapper> {
-        crate::node_api::core::routes::get_info(self).await
-    }
-
-    /// GET /api/v2/peers endpoint
-    pub async fn get_peers(&self) -> Result<Vec<PeerDto>> {
-        crate::node_api::core::routes::get_peers(self).await
-    }
-
-    /// GET /api/v2/tips endpoint
-    pub async fn get_tips(&self) -> Result<Vec<MessageId>> {
-        crate::node_api::core::routes::get_tips(self).await
-    }
-
-    /// POST /api/v2/messages endpoint
-    pub async fn post_message(&self, message: &Message) -> Result<MessageId> {
-        crate::node_api::core::routes::post_message(self, message).await
-    }
-
-    /// POST JSON to /api/v2/messages endpoint
-    pub async fn post_message_json(&self, message: &Message) -> Result<MessageId> {
-        crate::node_api::core::routes::post_message_json(self, message).await
-    }
-
-    /// GET /api/v2/messages/{messageID} endpoint
-    /// Consume the builder and find a message by its identifer. This method returns the given message object.
-    pub async fn get_message_data(&self, message_id: &MessageId) -> Result<Message> {
-        crate::node_api::core::routes::data(self, message_id).await
-    }
-
-    /// GET /api/v2/messages/{messageID}/metadata endpoint
-    /// Consume the builder and find a message by its identifer. This method returns the given message metadata.
-    pub async fn get_message_metadata(&self, message_id: &MessageId) -> Result<MessageMetadataResponse> {
-        crate::node_api::core::routes::metadata(self, message_id).await
-    }
-
-    /// GET /api/v2/messages/{messageID}/raw endpoint
-    /// Consume the builder and find a message by its identifer. This method returns the given message raw data.
-    pub async fn get_message_raw(&self, message_id: &MessageId) -> Result<String> {
-        crate::node_api::core::routes::raw(self, message_id).await
-    }
-
-    /// GET /api/v2/messages/{messageID}/children endpoint
-    /// Consume the builder and returns the list of message IDs that reference a message by its identifier.
-    pub async fn get_message_children(&self, message_id: &MessageId) -> Result<Box<[MessageId]>> {
-        crate::node_api::core::routes::children(self, message_id).await
-    }
-
-    /// GET /api/v2/outputs/{outputId} endpoint
-    /// Find an output by its transaction_id and corresponding output_index.
-    pub async fn get_output(&self, output_id: &OutputId) -> Result<OutputResponse> {
-        crate::node_api::core::routes::get_output(self, output_id).await
-    }
-
     /// GET /api/plugins/indexer/v1/outputs/basic{query} endpoint
     pub fn get_address(&self) -> GetAddressBuilder<'_> {
         GetAddressBuilder::new(self)
-    }
-
-    /// GET /api/v2/milestones/{milestoneId} endpoint
-    /// Get the milestone by the given milestone id.
-    pub async fn get_milestone_by_milestone_id(&self, milestone_id: MilestoneId) -> Result<MilestoneResponse> {
-        crate::node_api::core::routes::get_milestone_by_milestone_id(self, milestone_id).await
-    }
-
-    /// GET /api/v2/milestones/by-index/{milestoneIndex} endpoint
-    /// Get the milestone by the given index.
-    pub async fn get_milestone_by_milestone_index(&self, index: u32) -> Result<MilestoneResponse> {
-        crate::node_api::core::routes::get_milestone_by_milestone_index(self, index).await
-    }
-
-    /// GET /api/v2/milestones/{milestoneId}/utxo-changes endpoint
-    /// Get the milestone by the given milestone id.
-    pub async fn get_utxo_changes_by_milestone_id(&self, milestone_id: MilestoneId) -> Result<MilestoneUTXOChanges> {
-        crate::node_api::core::routes::get_utxo_changes_by_milestone_id(self, milestone_id).await
-    }
-
-    /// GET /api/v2/milestones/by-index/{milestoneIndex}/utxo-changes endpoint
-    /// Get the milestone by the given index.
-    pub async fn get_utxo_changes_by_milestone_index(&self, index: u32) -> Result<MilestoneUTXOChanges> {
-        crate::node_api::core::routes::get_utxo_changes_by_milestone_index(self, index).await
-    }
-
-    /// GET /api/v2/receipts endpoint
-    /// Get all receipts.
-    pub async fn get_receipts(&self) -> Result<Vec<ReceiptDto>> {
-        crate::node_api::core::routes::get_receipts(self).await
-    }
-
-    /// GET /api/v2/receipts/{migratedAt} endpoint
-    /// Get the receipts by the given milestone index.
-    pub async fn get_receipts_migrated_at(&self, milestone_index: u32) -> Result<Vec<ReceiptDto>> {
-        crate::node_api::core::routes::get_receipts_migrated_at(self, milestone_index).await
-    }
-
-    /// GET /api/v2/treasury endpoint
-    /// Get the treasury output.
-    pub async fn get_treasury(&self) -> Result<TreasuryResponse> {
-        crate::node_api::core::routes::get_treasury(self).await
-    }
-
-    /// GET /api/v2/transactions/{transactionId}/included-message
-    /// Returns the included message of the transaction.
-    pub async fn get_included_message(&self, transaction_id: &TransactionId) -> Result<Message> {
-        crate::node_api::core::routes::get_included_message(self, transaction_id).await
-    }
-
-    //////////////////////////////////////////////////////////////////////
-    // Node indexer API
-    //////////////////////////////////////////////////////////////////////
-
-    /// api/plugins/indexer/v1/outputs/basic
-    pub async fn output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
-        crate::node_api::indexer::routes::output_ids(self, query_parameters).await
-    }
-
-    /// api/plugins/indexer/v1/outputs/alias
-    pub async fn aliases_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
-        crate::node_api::indexer::routes::aliases_output_ids(self, query_parameters).await
-    }
-
-    /// api/plugins/indexer/v1/outputs/alias/{AliasId}
-    pub async fn alias_output_id(&self, alias_id: AliasId) -> Result<OutputId> {
-        crate::node_api::indexer::routes::alias_output_id(self, alias_id).await
-    }
-
-    /// api/plugins/indexer/v1/outputs/nft
-    pub async fn nfts_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
-        crate::node_api::indexer::routes::nfts_output_ids(self, query_parameters).await
-    }
-
-    /// api/plugins/indexer/v1/outputs/nft/{NftId}
-    pub async fn nft_output_id(&self, nft_id: NftId) -> Result<OutputId> {
-        crate::node_api::indexer::routes::nft_output_id(self, nft_id).await
-    }
-
-    /// api/plugins/indexer/v1/outputs/foundry
-    pub async fn foundries_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
-        crate::node_api::indexer::routes::foundries_output_ids(self, query_parameters).await
-    }
-
-    /// api/plugins/indexer/v1/outputs/foundry/{FoundryID}
-    pub async fn foundry_output_id(&self, foundry_id: FoundryId) -> Result<OutputId> {
-        crate::node_api::indexer::routes::foundry_output_id(self, foundry_id).await
     }
 
     //////////////////////////////////////////////////////////////////////
     // High level API
     //////////////////////////////////////////////////////////////////////
 
-    /// Get OutputResponse from provided OutputIds (requests are sent in parallel)
-    pub async fn get_outputs(&self, output_ids: Vec<OutputId>) -> Result<Vec<OutputResponse>> {
-        crate::node_api::core::get_outputs(self, output_ids).await
-    }
-
-    /// Try to get OutputResponse from provided OutputIds (requests are sent in parallel and errors are ignored, can be
-    /// useful for spent outputs)
-    pub async fn try_get_outputs(&self, output_ids: Vec<OutputId>) -> Result<Vec<OutputResponse>> {
-        crate::node_api::core::try_get_outputs(self, output_ids).await
-    }
-
     /// Get the inputs of a transaction for the given transaction id.
     pub async fn inputs_from_transaction_id(&self, transaction_id: &TransactionId) -> Result<Vec<OutputResponse>> {
-        let message = crate::node_api::core::routes::get_included_message(self, transaction_id).await?;
+        let message = self.get_included_message(transaction_id).await?;
 
         let inputs = match message.payload() {
             Some(Payload::Transaction(t)) => match t.essence() {
@@ -639,7 +481,7 @@ impl Client {
             })
             .collect();
 
-        crate::node_api::core::get_outputs(self, input_ids).await
+        self.get_outputs(input_ids).await
     }
 
     /// A generic send function for easily sending transaction or tagged data messages.
@@ -830,7 +672,7 @@ impl Client {
     /// Find all outputs based on the requests criteria. This method will try to query multiple nodes if
     /// the request amount exceeds individual node limit.
     pub async fn find_outputs(&self, output_ids: &[OutputId], addresses: &[String]) -> Result<Vec<OutputResponse>> {
-        let mut output_metadata = crate::node_api::core::get_outputs(self, output_ids.to_vec()).await?;
+        let mut output_metadata = self.get_outputs(output_ids.to_vec()).await?;
 
         // Use `get_address()` API to get the address outputs first,
         // then collect the `UtxoInput` in the HashSet.

--- a/src/node_api/core/mod.rs
+++ b/src/node_api/core/mod.rs
@@ -8,77 +8,78 @@ pub mod routes;
 use bee_message::output::OutputId;
 use bee_rest_api::types::responses::OutputResponse;
 
-use self::routes::get_output;
 #[cfg(not(target_family = "wasm"))]
 use crate::constants::MAX_PARALLEL_API_REQUESTS;
 use crate::{Client, Result};
 
-/// Request outputs by their output id in parallel
-pub async fn get_outputs(client: &Client, output_ids: Vec<OutputId>) -> Result<Vec<OutputResponse>> {
-    let mut outputs = Vec::new();
-    #[cfg(target_family = "wasm")]
-    for output_id in output_ids {
-        outputs.push(get_output(client, &output_id).await?);
-    }
-    #[cfg(not(target_family = "wasm"))]
-    for output_ids_chunk in output_ids
-        .chunks(MAX_PARALLEL_API_REQUESTS)
-        .map(|x: &[OutputId]| x.to_vec())
-    {
-        let mut tasks = Vec::new();
-        for output_id in output_ids_chunk {
-            let client_ = client.clone();
+impl Client {
+    /// Request outputs by their output id in parallel
+    pub async fn get_outputs(&self, output_ids: Vec<OutputId>) -> Result<Vec<OutputResponse>> {
+        let mut outputs = Vec::new();
+        #[cfg(target_family = "wasm")]
+        for output_id in output_ids {
+            outputs.push(client.get_output(&output_id).await?);
+        }
+        #[cfg(not(target_family = "wasm"))]
+        for output_ids_chunk in output_ids
+            .chunks(MAX_PARALLEL_API_REQUESTS)
+            .map(|x: &[OutputId]| x.to_vec())
+        {
+            let mut tasks = Vec::new();
+            for output_id in output_ids_chunk {
+                let client_ = self.clone();
 
-            tasks.push(async move {
-                tokio::spawn(async move {
-                    let output_response = get_output(&client_, &output_id).await?;
-                    crate::Result::Ok(output_response)
-                })
-                .await
-            });
+                tasks.push(async move {
+                    tokio::spawn(async move {
+                        let output_response = client_.get_output(&output_id).await?;
+                        crate::Result::Ok(output_response)
+                    })
+                    .await
+                });
+            }
+            for res in futures::future::try_join_all(tasks).await? {
+                let output_response = res?;
+                outputs.push(output_response);
+            }
         }
-        for res in futures::future::try_join_all(tasks).await? {
-            let output_response = res?;
-            outputs.push(output_response);
-        }
+        Ok(outputs)
     }
-    Ok(outputs)
-}
 
-/// Request outputs by their output id in parallel, ignores failed requests
-/// Useful to get data about spent outputs, that might not be pruned yet
-pub async fn try_get_outputs(client: &Client, output_ids: Vec<OutputId>) -> Result<Vec<OutputResponse>> {
-    let mut outputs = Vec::new();
-    #[cfg(target_family = "wasm")]
-    for output_id in output_ids {
-        if let Ok(output_response) = get_output(client, &output_id).await {
-            outputs.push(output_response);
+    /// Request outputs by their output id in parallel, ignores failed requests
+    /// Useful to get data about spent outputs, that might not be pruned yet
+    pub async fn try_get_outputs(&self, output_ids: Vec<OutputId>) -> Result<Vec<OutputResponse>> {
+        let mut outputs = Vec::new();
+        #[cfg(target_family = "wasm")]
+        for output_id in output_ids {
+            if let Ok(output_response) = get_output(client, &output_id).await {
+                outputs.push(output_response);
+            }
         }
-    }
-    #[cfg(not(target_family = "wasm"))]
-    for output_ids_chunk in output_ids
-        .chunks(MAX_PARALLEL_API_REQUESTS)
-        .map(|x: &[OutputId]| x.to_vec())
-    {
-        let mut tasks = Vec::new();
-        for output_id in output_ids_chunk {
-            let client_ = client.clone();
+        #[cfg(not(target_family = "wasm"))]
+        for output_ids_chunk in output_ids
+            .chunks(MAX_PARALLEL_API_REQUESTS)
+            .map(|x: &[OutputId]| x.to_vec())
+        {
+            let mut tasks = Vec::new();
+            for output_id in output_ids_chunk {
+                let client_ = self.clone();
 
-            tasks.push(async move {
-                tokio::spawn(async move {
-                    // Ignore possible errors
-                    if let Ok(output_response) = get_output(&client_, &output_id).await {
-                        Some(output_response)
-                    } else {
-                        None
-                    }
-                })
-                .await
-            });
+                tasks.push(async move {
+                    tokio::spawn(async move {
+                        // Ignore possible errors
+                        if let Ok(output_response) = client_.get_output(&output_id).await {
+                            Some(output_response)
+                        } else {
+                            None
+                        }
+                    })
+                    .await
+                });
+            }
+            for output_response in (futures::future::try_join_all(tasks).await?).into_iter().flatten() {
+                outputs.push(output_response);
+            }
         }
-        for output_response in (futures::future::try_join_all(tasks).await?).into_iter().flatten() {
-            outputs.push(output_response);
-        }
+        Ok(outputs)
     }
-    Ok(outputs)
 }

--- a/src/node_api/core/routes.rs
+++ b/src/node_api/core/routes.rs
@@ -23,397 +23,361 @@ use crate::{constants::DEFAULT_API_TIMEOUT, Client, Error, NodeInfoWrapper, Resu
 
 // https://github.com/gohornet/hornet/blob/stardust-utxo/plugins/restapi/v2/plugin.go
 
-/// Returns general information about the node.
-/// GET /api/v2/info endpoint
-pub async fn get_info(client: &Client) -> Result<NodeInfoWrapper> {
-    let path = "api/v2/info";
+impl Client {
+    /// Returns general information about the node.
+    /// GET /api/v2/info endpoint
+    pub async fn get_info(&self) -> Result<NodeInfoWrapper> {
+        let path = "api/v2/info";
 
-    let resp: NodeInfoWrapper = client
-        .node_manager
-        .get_request(path, None, client.get_timeout())
-        .await?;
+        let resp = self.node_manager.get_request(path, None, self.get_timeout()).await?;
 
-    Ok(resp)
-}
-
-/// Returns non-lazy tips.
-/// GET /api/v2/tips endpoint
-pub async fn get_tips(client: &Client) -> Result<Vec<MessageId>> {
-    let path = "api/v2/tips";
-
-    let resp: TipsResponse = client
-        .node_manager
-        .get_request(path, None, client.get_timeout())
-        .await?;
-
-    let mut tips = Vec::new();
-    for message_id in resp.tip_message_ids {
-        tips.push(MessageId::from_str(&message_id)?);
+        Ok(resp)
     }
-    Ok(tips)
-}
 
-/// Consume the builder and find a message by its MessageId. This method returns the given message object.
-/// GET /api/v2/messages/{MessageId} endpoint
-pub async fn data(client: &Client, message_id: &MessageId) -> Result<Message> {
-    let path = &format!("api/v2/messages/{}", message_id);
+    /// Returns non-lazy tips.
+    /// GET /api/v2/tips endpoint
+    pub async fn get_tips(&self) -> Result<Vec<MessageId>> {
+        let path = "api/v2/tips";
 
-    let resp: MessageResponse = client
-        .node_manager
-        .get_request(path, None, client.get_timeout())
-        .await?;
+        let resp: TipsResponse = self.node_manager.get_request(path, None, self.get_timeout()).await?;
 
-    Ok(Message::try_from(&resp.0)?)
-}
-
-/// Returns the metadata of a message.
-/// GET /api/v2/messages/{MessageId}/metadata endpoint
-pub async fn metadata(client: &Client, message_id: &MessageId) -> Result<MessageMetadataResponse> {
-    let path = &format!("api/v2/messages/{}/metadata", message_id);
-
-    let resp: MessageMetadataResponse = client
-        .node_manager
-        .get_request(path, None, client.get_timeout())
-        .await?;
-
-    Ok(resp)
-}
-
-/// Consume the builder and find a message by its MessageId. This method returns the given message raw data.
-/// GET /api/v2/messages/{MessageId}/raw endpoint
-pub async fn raw(client: &Client, message_id: &MessageId) -> Result<String> {
-    let path = &format!("api/v2/messages/{}/raw", message_id);
-    let resp = client
-        .node_manager
-        .get_request_text(path, None, client.get_timeout())
-        .await?;
-
-    Ok(resp)
-}
-
-/// GET /api/v2/messages/{messageID}/children endpoint
-/// Consume the builder and returns the list of message IDs that reference a message by its identifier.
-pub async fn children(client: &Client, message_id: &MessageId) -> Result<Box<[MessageId]>> {
-    let path = &format!("api/v2/messages/{}/children", message_id);
-
-    let resp: MessageChildrenResponse = client
-        .node_manager
-        .get_request(path, None, client.get_timeout())
-        .await?;
-
-    resp.children_message_ids
-        .iter()
-        .map(|s| {
-            let mut message_id = [0u8; 32];
-            hex::decode_to_slice(s, &mut message_id)?;
-            Ok(MessageId::from(message_id))
-        })
-        .collect::<Result<Box<[MessageId]>>>()
-}
-
-/// Returns the MessageId of the submitted message.
-/// POST /api/v2/messages endpoint
-pub async fn post_message(client: &Client, message: &Message) -> Result<MessageId> {
-    let path = "api/v2/messages";
-    let local_pow = client.get_local_pow().await;
-    let timeout = if local_pow {
-        client.get_timeout()
-    } else {
-        client.get_remote_pow_timeout()
-    };
-
-    // fallback to local PoW if remote PoW fails
-    let resp: SubmitMessageResponse = match client
-        .node_manager
-        .post_request_bytes(path, timeout, &message.pack_to_vec(), local_pow)
-        .await
-    {
-        Ok(res) => res,
-        Err(e) => {
-            if let Error::NodeError(e) = e {
-                let fallback_to_local_pow = client.get_fallback_to_local_pow().await;
-                // hornet and bee return different error messages
-                if (e == *"No available nodes with remote PoW"
-                    || e.contains("proof of work is not enabled")
-                    || e.contains("`PoW` not enabled"))
-                    && fallback_to_local_pow
-                {
-                    // Without this we get:within `impl Future<Output = [async output]>`, the trait `Send` is not
-                    // implemented for `std::sync::RwLockWriteGuard<'_, NetworkInfo>`
-                    {
-                        let mut client_network_info =
-                            client.network_info.write().map_err(|_| crate::Error::PoisonError)?;
-                        // switch to local PoW
-                        client_network_info.local_pow = true;
-                    }
-                    #[cfg(not(target_family = "wasm"))]
-                    let msg_res = crate::api::finish_pow(client, message.payload().cloned()).await;
-                    #[cfg(target_family = "wasm")]
-                    let msg_res = {
-                        let min_pow_score = client.get_min_pow_score().await?;
-                        let network_id = client.get_network_id().await?;
-                        crate::api::finish_single_thread_pow(
-                            client,
-                            network_id,
-                            None,
-                            message.payload().cloned(),
-                            min_pow_score,
-                        )
-                        .await
-                    };
-                    let message_with_local_pow = match msg_res {
-                        Ok(msg) => {
-                            // reset local PoW state
-                            let mut client_network_info =
-                                client.network_info.write().map_err(|_| crate::Error::PoisonError)?;
-                            client_network_info.local_pow = false;
-                            msg
-                        }
-                        Err(e) => {
-                            // reset local PoW state
-                            let mut client_network_info =
-                                client.network_info.write().map_err(|_| crate::Error::PoisonError)?;
-                            client_network_info.local_pow = false;
-                            return Err(e);
-                        }
-                    };
-                    client
-                        .node_manager
-                        .post_request_bytes(path, timeout, &message_with_local_pow.pack_to_vec(), true)
-                        .await?
-                } else {
-                    return Err(Error::NodeError(e));
-                }
-            } else {
-                return Err(e);
-            }
+        let mut tips = Vec::new();
+        for message_id in resp.tip_message_ids {
+            tips.push(MessageId::from_str(&message_id)?);
         }
-    };
 
-    Ok(MessageId::from_str(&resp.message_id)?)
-}
+        Ok(tips)
+    }
 
-/// Returns the MessageId of the submitted message.
-/// POST JSON to /api/v2/messages endpoint
-pub async fn post_message_json(client: &Client, message: &Message) -> Result<MessageId> {
-    let path = "api/v2/messages";
-    let local_pow = client.get_local_pow().await;
-    let timeout = if local_pow {
-        client.get_timeout()
-    } else {
-        client.get_remote_pow_timeout()
-    };
-    let message_dto = MessageDto::from(message);
-    // println!("{}", hex::encode(message.pack_to_vec()));
-    // println!("{}", serde_json::to_string(&message_dto)?);
-    // fallback to local PoW if remote PoW fails
-    let resp: SubmitMessageResponse = match client
-        .node_manager
-        .post_request_json(path, timeout, serde_json::to_value(message_dto)?, local_pow)
-        .await
-    {
-        Ok(res) => res,
-        Err(e) => {
-            if let Error::NodeError(e) = e {
-                let fallback_to_local_pow = client.get_fallback_to_local_pow().await;
-                // hornet and bee return different error messages
-                if (e == *"No available nodes with remote PoW"
-                    || e.contains("proof of work is not enabled")
-                    || e.contains("`PoW` not enabled"))
-                    && fallback_to_local_pow
-                {
-                    // Without this we get:within `impl Future<Output = [async output]>`, the trait `Send` is not
-                    // implemented for `std::sync::RwLockWriteGuard<'_, NetworkInfo>`
+    /// Consume the builder and find a message by its MessageId. This method returns the given message object.
+    /// GET /api/v2/messages/{MessageId} endpoint
+    pub async fn get_message_data(&self, message_id: &MessageId) -> Result<Message> {
+        let path = &format!("api/v2/messages/{}", message_id);
+
+        let resp: MessageResponse = self.node_manager.get_request(path, None, self.get_timeout()).await?;
+
+        Ok(Message::try_from(&resp.0)?)
+    }
+
+    /// Returns the metadata of a message.
+    /// GET /api/v2/messages/{MessageId}/metadata endpoint
+    pub async fn get_message_metadata(&self, message_id: &MessageId) -> Result<MessageMetadataResponse> {
+        let path = &format!("api/v2/messages/{}/metadata", message_id);
+
+        let resp: MessageMetadataResponse = self.node_manager.get_request(path, None, self.get_timeout()).await?;
+
+        Ok(resp)
+    }
+
+    /// Consume the builder and find a message by its MessageId. This method returns the given message raw data.
+    /// GET /api/v2/messages/{MessageId}/raw endpoint
+    pub async fn get_message_raw(&self, message_id: &MessageId) -> Result<String> {
+        let path = &format!("api/v2/messages/{}/raw", message_id);
+        let resp = self
+            .node_manager
+            .get_request_text(path, None, self.get_timeout())
+            .await?;
+
+        Ok(resp)
+    }
+
+    /// GET /api/v2/messages/{messageID}/children endpoint
+    /// Consume the builder and returns the list of message IDs that reference a message by its identifier.
+    pub async fn get_message_children(&self, message_id: &MessageId) -> Result<Box<[MessageId]>> {
+        let path = &format!("api/v2/messages/{}/children", message_id);
+
+        let resp: MessageChildrenResponse = self.node_manager.get_request(path, None, self.get_timeout()).await?;
+
+        resp.children_message_ids
+            .iter()
+            .map(|s| {
+                let mut message_id = [0u8; 32];
+                hex::decode_to_slice(s, &mut message_id)?;
+                Ok(MessageId::from(message_id))
+            })
+            .collect::<Result<Box<[MessageId]>>>()
+    }
+
+    /// Returns the MessageId of the submitted message.
+    /// POST /api/v2/messages endpoint
+    pub async fn post_message(&self, message: &Message) -> Result<MessageId> {
+        let path = "api/v2/messages";
+        let local_pow = self.get_local_pow().await;
+        let timeout = if local_pow {
+            self.get_timeout()
+        } else {
+            self.get_remote_pow_timeout()
+        };
+
+        // fallback to local PoW if remote PoW fails
+        let resp: SubmitMessageResponse = match self
+            .node_manager
+            .post_request_bytes(path, timeout, &message.pack_to_vec(), local_pow)
+            .await
+        {
+            Ok(res) => res,
+            Err(e) => {
+                if let Error::NodeError(e) = e {
+                    let fallback_to_local_pow = self.get_fallback_to_local_pow().await;
+                    // hornet and bee return different error messages
+                    if (e == *"No available nodes with remote PoW"
+                        || e.contains("proof of work is not enabled")
+                        || e.contains("`PoW` not enabled"))
+                        && fallback_to_local_pow
                     {
-                        let mut client_network_info =
-                            client.network_info.write().map_err(|_| crate::Error::PoisonError)?;
-                        // switch to local PoW
-                        client_network_info.local_pow = true;
+                        // Without this we get:within `impl Future<Output = [async output]>`, the trait `Send` is not
+                        // implemented for `std::sync::RwLockWriteGuard<'_, NetworkInfo>`
+                        {
+                            let mut client_network_info =
+                                self.network_info.write().map_err(|_| crate::Error::PoisonError)?;
+                            // switch to local PoW
+                            client_network_info.local_pow = true;
+                        }
+                        #[cfg(not(target_family = "wasm"))]
+                        let msg_res = crate::api::finish_pow(self, message.payload().cloned()).await;
+                        #[cfg(target_family = "wasm")]
+                        let msg_res = {
+                            let min_pow_score = self.get_min_pow_score().await?;
+                            let network_id = self.get_network_id().await?;
+                            crate::api::finish_single_thread_pow(
+                                client,
+                                network_id,
+                                None,
+                                message.payload().cloned(),
+                                min_pow_score,
+                            )
+                            .await
+                        };
+                        let message_with_local_pow = match msg_res {
+                            Ok(msg) => {
+                                // reset local PoW state
+                                let mut client_network_info =
+                                    self.network_info.write().map_err(|_| crate::Error::PoisonError)?;
+                                client_network_info.local_pow = false;
+                                msg
+                            }
+                            Err(e) => {
+                                // reset local PoW state
+                                let mut client_network_info =
+                                    self.network_info.write().map_err(|_| crate::Error::PoisonError)?;
+                                client_network_info.local_pow = false;
+                                return Err(e);
+                            }
+                        };
+                        self.node_manager
+                            .post_request_bytes(path, timeout, &message_with_local_pow.pack_to_vec(), true)
+                            .await?
+                    } else {
+                        return Err(Error::NodeError(e));
                     }
-                    #[cfg(not(target_family = "wasm"))]
-                    let msg_res = crate::api::finish_pow(client, message.payload().cloned()).await;
-                    #[cfg(target_family = "wasm")]
-                    let msg_res = {
-                        let min_pow_score = client.get_min_pow_score().await?;
-                        let network_id = client.get_network_id().await?;
-                        crate::api::finish_single_thread_pow(
-                            client,
-                            network_id,
-                            None,
-                            message.payload().cloned(),
-                            min_pow_score,
-                        )
-                        .await
-                    };
-                    let message_with_local_pow = match msg_res {
-                        Ok(msg) => {
-                            // reset local PoW state
-                            let mut client_network_info =
-                                client.network_info.write().map_err(|_| crate::Error::PoisonError)?;
-                            client_network_info.local_pow = false;
-                            msg
-                        }
-                        Err(e) => {
-                            // reset local PoW state
-                            let mut client_network_info =
-                                client.network_info.write().map_err(|_| crate::Error::PoisonError)?;
-                            client_network_info.local_pow = false;
-                            return Err(e);
-                        }
-                    };
-                    let message_dto = MessageDto::from(&message_with_local_pow);
-
-                    client
-                        .node_manager
-                        .post_request_json(path, timeout, serde_json::to_value(message_dto)?, true)
-                        .await?
                 } else {
-                    return Err(Error::NodeError(e));
+                    return Err(e);
                 }
-            } else {
-                return Err(e);
             }
-        }
-    };
-    Ok(MessageId::from_str(&resp.message_id)?)
+        };
+
+        Ok(MessageId::from_str(&resp.message_id)?)
+    }
+
+    /// Returns the MessageId of the submitted message.
+    /// POST JSON to /api/v2/messages endpoint
+    pub async fn post_message_json(&self, message: &Message) -> Result<MessageId> {
+        let path = "api/v2/messages";
+        let local_pow = self.get_local_pow().await;
+        let timeout = if local_pow {
+            self.get_timeout()
+        } else {
+            self.get_remote_pow_timeout()
+        };
+        let message_dto = MessageDto::from(message);
+        // println!("{}", hex::encode(message.pack_to_vec()));
+        // println!("{}", serde_json::to_string(&message_dto)?);
+        // fallback to local PoW if remote PoW fails
+        let resp: SubmitMessageResponse = match self
+            .node_manager
+            .post_request_json(path, timeout, serde_json::to_value(message_dto)?, local_pow)
+            .await
+        {
+            Ok(res) => res,
+            Err(e) => {
+                if let Error::NodeError(e) = e {
+                    let fallback_to_local_pow = self.get_fallback_to_local_pow().await;
+                    // hornet and bee return different error messages
+                    if (e == *"No available nodes with remote PoW"
+                        || e.contains("proof of work is not enabled")
+                        || e.contains("`PoW` not enabled"))
+                        && fallback_to_local_pow
+                    {
+                        // Without this we get:within `impl Future<Output = [async output]>`, the trait `Send` is not
+                        // implemented for `std::sync::RwLockWriteGuard<'_, NetworkInfo>`
+                        {
+                            let mut client_network_info =
+                                self.network_info.write().map_err(|_| crate::Error::PoisonError)?;
+                            // switch to local PoW
+                            client_network_info.local_pow = true;
+                        }
+                        #[cfg(not(target_family = "wasm"))]
+                        let msg_res = crate::api::finish_pow(self, message.payload().cloned()).await;
+                        #[cfg(target_family = "wasm")]
+                        let msg_res = {
+                            let min_pow_score = self.get_min_pow_score().await?;
+                            let network_id = self.get_network_id().await?;
+                            crate::api::finish_single_thread_pow(
+                                client,
+                                network_id,
+                                None,
+                                message.payload().cloned(),
+                                min_pow_score,
+                            )
+                            .await
+                        };
+                        let message_with_local_pow = match msg_res {
+                            Ok(msg) => {
+                                // reset local PoW state
+                                let mut client_network_info =
+                                    self.network_info.write().map_err(|_| crate::Error::PoisonError)?;
+                                client_network_info.local_pow = false;
+                                msg
+                            }
+                            Err(e) => {
+                                // reset local PoW state
+                                let mut client_network_info =
+                                    self.network_info.write().map_err(|_| crate::Error::PoisonError)?;
+                                client_network_info.local_pow = false;
+                                return Err(e);
+                            }
+                        };
+                        let message_dto = MessageDto::from(&message_with_local_pow);
+
+                        self.node_manager
+                            .post_request_json(path, timeout, serde_json::to_value(message_dto)?, true)
+                            .await?
+                    } else {
+                        return Err(Error::NodeError(e));
+                    }
+                } else {
+                    return Err(e);
+                }
+            }
+        };
+
+        Ok(MessageId::from_str(&resp.message_id)?)
+    }
+
+    /// Returns the message that was included in the ledger for a given TransactionId
+    /// GET /api/v2/transactions/{transactionId}/included-message
+    pub async fn get_included_message(&self, transaction_id: &TransactionId) -> Result<Message> {
+        let path = &format!("api/v2/transactions/{}/included-message", transaction_id);
+
+        let resp: MessageResponse = self.node_manager.get_request(path, None, self.get_timeout()).await?;
+
+        Ok(Message::try_from(&resp.0)?)
+    }
+
+    /// Get the milestone by the given milestone id.
+    /// GET /api/v2/milestones/{milestoneId} endpoint
+    pub async fn get_milestone_by_milestone_id(&self, milestone_id: MilestoneId) -> Result<MilestoneResponse> {
+        let path = &format!("api/v2/milestones/{}", milestone_id);
+
+        let resp: MilestoneResponse = self.node_manager.get_request(path, None, self.get_timeout()).await?;
+
+        Ok(resp)
+    }
+
+    /// Get the milestone by the given milestone index.
+    /// GET /api/v2/milestones/{index} endpoint
+    pub async fn get_milestone_by_milestone_index(&self, index: u32) -> Result<MilestoneResponse> {
+        let path = &format!("api/v2/milestones/by-index/{}", index);
+
+        let resp: MilestoneResponse = self.node_manager.get_request(path, None, self.get_timeout()).await?;
+
+        Ok(resp)
+    }
+
+    /// Gets all UTXO changes of a milestone by its milestone id
+    /// GET /api/v2/milestones/{milestoneId}/utxo-changes endpoint
+    pub async fn get_utxo_changes_by_milestone_id(&self, milestone_id: MilestoneId) -> Result<UtxoChangesResponse> {
+        let path = &format!("api/v2/milestones/{}/utxo-changes", milestone_id);
+
+        let resp: UtxoChangesResponse = self.node_manager.get_request(path, None, self.get_timeout()).await?;
+
+        Ok(resp)
+    }
+
+    /// Gets all UTXO changes of a milestone by its milestone index
+    /// GET /api/v2/milestones/by-index/{index}/utxo-changes endpoint
+    pub async fn get_utxo_changes_by_milestone_index(&self, index: u32) -> Result<UtxoChangesResponse> {
+        let path = &format!("api/v2/milestones/by-index/{}/utxo-changes", index);
+
+        let resp: UtxoChangesResponse = self.node_manager.get_request(path, None, self.get_timeout()).await?;
+
+        Ok(resp)
+    }
+
+    /// Find an output by its OutputId (TransactionId + output_index).
+    /// GET /api/v2/outputs/{outputId} endpoint
+    pub async fn get_output(&self, output_id: &OutputId) -> Result<OutputResponse> {
+        let path = &format!("api/v2/outputs/{}", output_id);
+
+        let resp: OutputResponse = self.node_manager.get_request(path, None, self.get_timeout()).await?;
+
+        Ok(resp)
+    }
+
+    /// Get the current treasury output.
+    /// GET /api/v2/treasury endpoint
+    pub async fn get_treasury(&self) -> Result<TreasuryResponse> {
+        let path = "api/v2/treasury";
+
+        let resp: TreasuryResponse = self.node_manager.get_request(path, None, DEFAULT_API_TIMEOUT).await?;
+
+        Ok(resp)
+    }
+
+    /// Get all stored receipts.
+    /// GET /api/v2/receipts endpoint
+    pub async fn get_receipts(&self) -> Result<Vec<ReceiptDto>> {
+        let path = &"api/v2/receipts";
+
+        let resp: ReceiptsResponse = self.node_manager.get_request(path, None, DEFAULT_API_TIMEOUT).await?;
+
+        Ok(resp.receipts)
+    }
+
+    /// Get the receipts by the given milestone index.
+    /// GET /api/v2/receipts/{migratedAt} endpoint
+    pub async fn get_receipts_migrated_at(&self, milestone_index: u32) -> Result<Vec<ReceiptDto>> {
+        let path = &format!("api/v2/receipts/{}", milestone_index);
+
+        let resp: ReceiptsResponse = self.node_manager.get_request(path, None, DEFAULT_API_TIMEOUT).await?;
+
+        Ok(resp.receipts)
+    }
+
+    // // RoutePeer is the route for getting peers by their peerID.
+    // // GET returns the peer
+    // // DELETE deletes the peer.
+    // RoutePeer = "/peers/:" + restapipkg.ParameterPeerID
+
+    // // RoutePeers is the route for getting all peers of the node.
+    // // GET returns a list of all peers.
+    // // POST adds a new peer.
+    // RoutePeers = "/peers"
+
+    /// GET /api/v2/peers endpoint
+    pub async fn get_peers(&self) -> Result<Vec<PeerDto>> {
+        let path = "api/v2/peers";
+
+        let resp: PeersResponse = self.node_manager.get_request(path, None, self.get_timeout()).await?;
+
+        Ok(resp.0)
+    }
+
+    // // RouteControlDatabasePrune is the control route to manually prune the database.
+    // // POST prunes the database.
+    // RouteControlDatabasePrune = "/control/database/prune"
+
+    // // RouteControlSnapshotsCreate is the control route to manually create a snapshot files.
+    // // POST creates a snapshot (full, delta or both).
+    // RouteControlSnapshotsCreate = "/control/snapshots/create"
 }
-
-/// Returns the message that was included in the ledger for a given TransactionId
-/// GET /api/v2/transactions/{transactionId}/included-message
-pub async fn get_included_message(client: &Client, transaction_id: &TransactionId) -> Result<Message> {
-    let path = &format!("api/v2/transactions/{}/included-message", transaction_id);
-
-    let resp: MessageResponse = client
-        .node_manager
-        .get_request(path, None, client.get_timeout())
-        .await?;
-    Ok(Message::try_from(&resp.0)?)
-}
-
-/// Get the milestone by the given milestone id.
-/// GET /api/v2/milestones/{milestoneId} endpoint
-pub async fn get_milestone_by_milestone_id(client: &Client, milestone_id: MilestoneId) -> Result<MilestoneResponse> {
-    let path = &format!("api/v2/milestones/{}", milestone_id);
-
-    let resp: MilestoneResponse = client
-        .node_manager
-        .get_request(path, None, client.get_timeout())
-        .await?;
-
-    Ok(resp)
-}
-
-/// Get the milestone by the given milestone index.
-/// GET /api/v2/milestones/{index} endpoint
-pub async fn get_milestone_by_milestone_index(client: &Client, index: u32) -> Result<MilestoneResponse> {
-    let path = &format!("api/v2/milestones/by-index/{}", index);
-
-    let resp: MilestoneResponse = client
-        .node_manager
-        .get_request(path, None, client.get_timeout())
-        .await?;
-
-    Ok(resp)
-}
-
-/// Gets all UTXO changes of a milestone by its milestone id
-/// GET /api/v2/milestones/{milestoneId}/utxo-changes endpoint
-pub async fn get_utxo_changes_by_milestone_id(
-    client: &Client,
-    milestone_id: MilestoneId,
-) -> Result<UtxoChangesResponse> {
-    let path = &format!("api/v2/milestones/{}/utxo-changes", milestone_id);
-
-    let resp: UtxoChangesResponse = client
-        .node_manager
-        .get_request(path, None, client.get_timeout())
-        .await?;
-
-    Ok(resp)
-}
-
-/// Gets all UTXO changes of a milestone by its milestone index
-/// GET /api/v2/milestones/by-index/{index}/utxo-changes endpoint
-pub async fn get_utxo_changes_by_milestone_index(client: &Client, index: u32) -> Result<UtxoChangesResponse> {
-    let path = &format!("api/v2/milestones/by-index/{}/utxo-changes", index);
-
-    let resp: UtxoChangesResponse = client
-        .node_manager
-        .get_request(path, None, client.get_timeout())
-        .await?;
-
-    Ok(resp)
-}
-
-/// Find an output by its OutputId (TransactionId + output_index).
-/// GET /api/v2/outputs/{outputId} endpoint
-pub async fn get_output(client: &Client, output_id: &OutputId) -> Result<OutputResponse> {
-    let path = &format!("api/v2/outputs/{}", output_id);
-
-    let resp: OutputResponse = client
-        .node_manager
-        .get_request(path, None, client.get_timeout())
-        .await?;
-
-    Ok(resp)
-}
-
-/// Get the current treasury output.
-/// GET /api/v2/treasury endpoint
-pub async fn get_treasury(client: &Client) -> Result<TreasuryResponse> {
-    let path = "api/v2/treasury";
-
-    let resp: TreasuryResponse = client.node_manager.get_request(path, None, DEFAULT_API_TIMEOUT).await?;
-
-    Ok(resp)
-}
-
-/// Get all stored receipts.
-/// GET /api/v2/receipts endpoint
-pub async fn get_receipts(client: &Client) -> Result<Vec<ReceiptDto>> {
-    let path = &"api/v2/receipts";
-
-    let resp: ReceiptsResponse = client.node_manager.get_request(path, None, DEFAULT_API_TIMEOUT).await?;
-
-    Ok(resp.receipts)
-}
-
-/// Get the receipts by the given milestone index.
-/// GET /api/v2/receipts/{migratedAt} endpoint
-pub async fn get_receipts_migrated_at(client: &Client, milestone_index: u32) -> Result<Vec<ReceiptDto>> {
-    let path = &format!("api/v2/receipts/{}", milestone_index);
-
-    let resp: ReceiptsResponse = client.node_manager.get_request(path, None, DEFAULT_API_TIMEOUT).await?;
-
-    Ok(resp.receipts)
-}
-
-// // RoutePeer is the route for getting peers by their peerID.
-// // GET returns the peer
-// // DELETE deletes the peer.
-// RoutePeer = "/peers/:" + restapipkg.ParameterPeerID
-
-// // RoutePeers is the route for getting all peers of the node.
-// // GET returns a list of all peers.
-// // POST adds a new peer.
-// RoutePeers = "/peers"
-
-/// GET /api/v2/peers endpoint
-pub async fn get_peers(client: &Client) -> Result<Vec<PeerDto>> {
-    let path = "api/v2/peers";
-
-    let resp: PeersResponse = client
-        .node_manager
-        .get_request(path, None, client.get_timeout())
-        .await?;
-
-    Ok(resp.0)
-}
-
-// // RouteControlDatabasePrune is the control route to manually prune the database.
-// // POST prunes the database.
-// RouteControlDatabasePrune = "/control/database/prune"
-
-// // RouteControlSnapshotsCreate is the control route to manually create a snapshot files.
-// // POST creates a snapshot (full, delta or both).
-// RouteControlSnapshotsCreate = "/control/snapshots/create"

--- a/src/node_api/high_level/address.rs
+++ b/src/node_api/high_level/address.rs
@@ -34,19 +34,17 @@ impl<'a> GetAddressBuilder<'a> {
     /// Consume the builder and get the IOTA and native tokens balance of a given Bech32 encoded address, ignoring
     /// outputs with additional unlock conditions.
     pub async fn balance(self, address: &str) -> Result<AddressBalance> {
-        let output_ids = crate::node_api::indexer::routes::output_ids(
-            self.client,
-            vec![
+        let output_ids = self
+            .client
+            .output_ids(vec![
                 QueryParameter::Address(address.to_string()),
                 QueryParameter::HasExpirationCondition(false),
                 QueryParameter::HasTimelockCondition(false),
                 QueryParameter::HasStorageDepositReturnCondition(false),
-            ],
-        )
-        .await?;
+            ])
+            .await?;
 
-        let outputs_responses: Vec<OutputResponse> =
-            crate::node_api::core::get_outputs(self.client, output_ids).await?;
+        let outputs_responses = self.client.get_outputs(output_ids).await?;
 
         let mut total_balance = 0;
         let mut native_tokens_builder = NativeTokensBuilder::new();
@@ -78,8 +76,8 @@ impl<'a> GetAddressBuilder<'a> {
 
     /// Get outputs
     pub async fn outputs(self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputResponse>> {
-        let output_ids = crate::node_api::indexer::routes::output_ids(self.client, query_parameters).await?;
+        let output_ids = self.client.output_ids(query_parameters).await?;
 
-        crate::node_api::core::get_outputs(self.client, output_ids).await
+        self.client.get_outputs(output_ids).await
     }
 }

--- a/src/node_api/indexer/routes.rs
+++ b/src/node_api/indexer/routes.rs
@@ -4,91 +4,93 @@
 //! IOTA node indexer routes
 use bee_message::output::{AliasId, FoundryId, NftId, OutputId};
 
-use crate::{
-    node_api::indexer::{get_output_ids_with_pagination, query_parameters::QueryParameter},
-    Client, Result,
-};
+use crate::{node_api::indexer::query_parameters::QueryParameter, Client, Result};
 
 // hornet: https://github.com/gohornet/hornet/blob/develop/plugins/indexer/routes.go
 
-/// Get outputs filtered by the given parameters.
-/// GET with query parameter returns all outputIDs that fit these filter criteria.
-/// Query parameters: "address", "hasStorageDepositReturnCondition", "storageReturnAddress", "hasExpirationCondition",
-///                 "expiresBefore", "expiresAfter", "expiresBeforeMilestone", "expiresAfterMilestone",
-///                 "hasTimelockCondition", "timelockedBefore", "timelockedAfter", "timelockedBeforeMilestone",
-///                 "timelockedAfterMilestone", "sender", "tag", "createdBefore", "createdAfter"
-/// Returns an empty Vec if no results are found.
-/// api/plugins/indexer/v1/outputs/basic
-pub async fn output_ids(client: &Client, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
-    let route = "api/plugins/indexer/v1/outputs/basic";
+impl Client {
+    /// Get outputs filtered by the given parameters.
+    /// GET with query parameter returns all outputIDs that fit these filter criteria.
+    /// Query parameters: "address", "hasStorageDepositReturnCondition", "storageReturnAddress", "hasExpirationCondition",
+    ///                 "expiresBefore", "expiresAfter", "expiresBeforeMilestone", "expiresAfterMilestone",
+    ///                 "hasTimelockCondition", "timelockedBefore", "timelockedAfter", "timelockedBeforeMilestone",
+    ///                 "timelockedAfterMilestone", "sender", "tag", "createdBefore", "createdAfter"
+    /// Returns an empty Vec if no results are found.
+    /// api/plugins/indexer/v1/outputs/basic
+    pub async fn output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
+        let route = "api/plugins/indexer/v1/outputs/basic";
 
-    get_output_ids_with_pagination(client, route, query_parameters).await
-}
+        self.get_output_ids_with_pagination(route, query_parameters).await
+    }
 
-/// Get aliases filtered by the given parameters.
-/// GET with query parameter returns all outputIDs that fit these filter criteria.
-/// Query parameters: "stateController", "governor", "issuer", "sender", "createdBefore", "createdAfter"
-/// Returns an empty list if no results are found.
-/// api/plugins/indexer/v1/outputs/alias
-pub async fn aliases_output_ids(client: &Client, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
-    let route = "api/plugins/indexer/v1/outputs/alias";
+    /// Get aliases filtered by the given parameters.
+    /// GET with query parameter returns all outputIDs that fit these filter criteria.
+    /// Query parameters: "stateController", "governor", "issuer", "sender", "createdBefore", "createdAfter"
+    /// Returns an empty list if no results are found.
+    /// api/plugins/indexer/v1/outputs/alias
+    pub async fn aliases_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
+        let route = "api/plugins/indexer/v1/outputs/alias";
 
-    get_output_ids_with_pagination(client, route, query_parameters).await
-}
+        self.get_output_ids_with_pagination(route, query_parameters).await
+    }
 
-/// Get aliases by their aliasID.
-/// api/plugins/indexer/v1/outputs/alias/:{AliasId}
-pub async fn alias_output_id(client: &Client, alias_id: AliasId) -> Result<OutputId> {
-    let route = format!("api/plugins/indexer/v1/outputs/alias/{alias_id}");
+    /// Get aliases by their aliasID.
+    /// api/plugins/indexer/v1/outputs/alias/:{AliasId}
+    pub async fn alias_output_id(&self, alias_id: AliasId) -> Result<OutputId> {
+        let route = format!("api/plugins/indexer/v1/outputs/alias/{alias_id}");
 
-    Ok(*(get_output_ids_with_pagination(client, &route, Vec::new())
-        .await?
-        .first()
-        .ok_or_else(|| crate::Error::NodeError("No output id for alias".to_string()))?))
-}
+        Ok(*(self
+            .get_output_ids_with_pagination(&route, Vec::new())
+            .await?
+            .first()
+            .ok_or_else(|| crate::Error::NodeError("No output id for alias".to_string()))?))
+    }
 
-/// Get NFT filtered by the given parameters.
-/// Query parameters: "address", "hasStorageDepositReturnCondition", "storageReturnAddress", "hasExpirationCondition",
-///                 "expiresBefore", "expiresAfter", "expiresBeforeMilestone", "expiresAfterMilestone",
-///                 "hasTimelockCondition", "timelockedBefore", "timelockedAfter", "timelockedBeforeMilestone",
-///                 "timelockedAfterMilestone", "issuer", "sender", "tag", "createdBefore", "createdAfter"
-/// Returns an empty list if no results are found.
-/// api/plugins/indexer/v1/outputs/nft
-pub async fn nfts_output_ids(client: &Client, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
-    let route = "api/plugins/indexer/v1/outputs/nft";
+    /// Get NFT filtered by the given parameters.
+    /// Query parameters: "address", "hasStorageDepositReturnCondition", "storageReturnAddress", "hasExpirationCondition",
+    ///                 "expiresBefore", "expiresAfter", "expiresBeforeMilestone", "expiresAfterMilestone",
+    ///                 "hasTimelockCondition", "timelockedBefore", "timelockedAfter", "timelockedBeforeMilestone",
+    ///                 "timelockedAfterMilestone", "issuer", "sender", "tag", "createdBefore", "createdAfter"
+    /// Returns an empty list if no results are found.
+    /// api/plugins/indexer/v1/outputs/nft
+    pub async fn nfts_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
+        let route = "api/plugins/indexer/v1/outputs/nft";
 
-    get_output_ids_with_pagination(client, route, query_parameters).await
-}
+        self.get_output_ids_with_pagination(route, query_parameters).await
+    }
 
-/// Get NFT by their nftID.
-/// api/plugins/indexer/v1/outputs/nft/:{NftId}
-pub async fn nft_output_id(client: &Client, nft_id: NftId) -> Result<OutputId> {
-    let route = format!("api/plugins/indexer/v1/outputs/nft/{nft_id}");
+    /// Get NFT by their nftID.
+    /// api/plugins/indexer/v1/outputs/nft/:{NftId}
+    pub async fn nft_output_id(&self, nft_id: NftId) -> Result<OutputId> {
+        let route = format!("api/plugins/indexer/v1/outputs/nft/{nft_id}");
 
-    Ok(*(get_output_ids_with_pagination(client, &route, Vec::new())
-        .await?
-        .first()
-        .ok_or_else(|| crate::Error::NodeError("No output id for nft".to_string()))?))
-}
+        Ok(*(self
+            .get_output_ids_with_pagination(&route, Vec::new())
+            .await?
+            .first()
+            .ok_or_else(|| crate::Error::NodeError("No output id for nft".to_string()))?))
+    }
 
-/// Get foundries filtered by the given parameters.
-/// GET with query parameter returns all outputIDs that fit these filter criteria.
-/// Query parameters: "address", "createdBefore", "createdAfter"
-/// Returns an empty list if no results are found.
-/// api/plugins/indexer/v1/outputs/foundry
-pub async fn foundries_output_ids(client: &Client, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
-    let route = "api/plugins/indexer/v1/outputs/foundry";
+    /// Get foundries filtered by the given parameters.
+    /// GET with query parameter returns all outputIDs that fit these filter criteria.
+    /// Query parameters: "address", "createdBefore", "createdAfter"
+    /// Returns an empty list if no results are found.
+    /// api/plugins/indexer/v1/outputs/foundry
+    pub async fn foundries_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
+        let route = "api/plugins/indexer/v1/outputs/foundry";
 
-    get_output_ids_with_pagination(client, route, query_parameters).await
-}
+        self.get_output_ids_with_pagination(route, query_parameters).await
+    }
 
-/// Get foundries by their foundryID.
-/// api/plugins/indexer/v1/outputs/foundry/:{FoundryID}
-pub async fn foundry_output_id(client: &Client, foundry_id: FoundryId) -> Result<OutputId> {
-    let route = format!("api/plugins/indexer/v1/outputs/foundry/{foundry_id}");
+    /// Get foundries by their foundryID.
+    /// api/plugins/indexer/v1/outputs/foundry/:{FoundryID}
+    pub async fn foundry_output_id(&self, foundry_id: FoundryId) -> Result<OutputId> {
+        let route = format!("api/plugins/indexer/v1/outputs/foundry/{foundry_id}");
 
-    Ok(*(get_output_ids_with_pagination(client, &route, Vec::new())
-        .await?
-        .first()
-        .ok_or_else(|| crate::Error::NodeError("No output id for foundry".to_string()))?))
+        Ok(*(self
+            .get_output_ids_with_pagination(&route, Vec::new())
+            .await?
+            .first()
+            .ok_or_else(|| crate::Error::NodeError("No output id for foundry".to_string()))?))
+    }
 }

--- a/src/node_api/indexer/routes.rs
+++ b/src/node_api/indexer/routes.rs
@@ -11,11 +11,11 @@ use crate::{node_api::indexer::query_parameters::QueryParameter, Client, Result}
 impl Client {
     /// Get outputs filtered by the given parameters.
     /// GET with query parameter returns all outputIDs that fit these filter criteria.
-    /// Query parameters: "address", "hasStorageDepositReturnCondition", "storageReturnAddress", "hasExpirationCondition",
-    ///                 "expiresBefore", "expiresAfter", "expiresBeforeMilestone", "expiresAfterMilestone",
-    ///                 "hasTimelockCondition", "timelockedBefore", "timelockedAfter", "timelockedBeforeMilestone",
-    ///                 "timelockedAfterMilestone", "sender", "tag", "createdBefore", "createdAfter"
-    /// Returns an empty Vec if no results are found.
+    /// Query parameters: "address", "hasStorageDepositReturnCondition", "storageReturnAddress",
+    /// "hasExpirationCondition",                 "expiresBefore", "expiresAfter", "expiresBeforeMilestone",
+    /// "expiresAfterMilestone",                 "hasTimelockCondition", "timelockedBefore", "timelockedAfter",
+    /// "timelockedBeforeMilestone",                 "timelockedAfterMilestone", "sender", "tag", "createdBefore",
+    /// "createdAfter" Returns an empty Vec if no results are found.
     /// api/plugins/indexer/v1/outputs/basic
     pub async fn output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
         let route = "api/plugins/indexer/v1/outputs/basic";
@@ -47,11 +47,11 @@ impl Client {
     }
 
     /// Get NFT filtered by the given parameters.
-    /// Query parameters: "address", "hasStorageDepositReturnCondition", "storageReturnAddress", "hasExpirationCondition",
-    ///                 "expiresBefore", "expiresAfter", "expiresBeforeMilestone", "expiresAfterMilestone",
-    ///                 "hasTimelockCondition", "timelockedBefore", "timelockedAfter", "timelockedBeforeMilestone",
-    ///                 "timelockedAfterMilestone", "issuer", "sender", "tag", "createdBefore", "createdAfter"
-    /// Returns an empty list if no results are found.
+    /// Query parameters: "address", "hasStorageDepositReturnCondition", "storageReturnAddress",
+    /// "hasExpirationCondition",                 "expiresBefore", "expiresAfter", "expiresBeforeMilestone",
+    /// "expiresAfterMilestone",                 "hasTimelockCondition", "timelockedBefore", "timelockedAfter",
+    /// "timelockedBeforeMilestone",                 "timelockedAfterMilestone", "issuer", "sender", "tag",
+    /// "createdBefore", "createdAfter" Returns an empty list if no results are found.
     /// api/plugins/indexer/v1/outputs/nft
     pub async fn nfts_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
         let route = "api/plugins/indexer/v1/outputs/nft";


### PR DESCRIPTION
First part of a big overall refactoring/cleaning.
Removes the client forwarding methods for less maintenance and allowing a more natural/expected API.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
