### PR TITLE
Create dir before writing stronghold snapshot if it doesn't exist

### DIFF
--- a/src/stronghold/mod.rs
+++ b/src/stronghold/mod.rs
@@ -324,6 +324,12 @@ impl StrongholdAdapter {
             return Err(Error::StrongholdSnapshotPathMissing);
         };
 
+        if let Some(parent) = snapshot_path.parent() {
+            if !parent.is_dir() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+
         match self
             .stronghold
             .write_all_to_snapshot(

--- a/src/stronghold/mod.rs
+++ b/src/stronghold/mod.rs
@@ -324,6 +324,7 @@ impl StrongholdAdapter {
             return Err(Error::StrongholdSnapshotPathMissing);
         };
 
+        // Check if directory in path exists, if not create it
         if let Some(parent) = snapshot_path.parent() {
             if !parent.is_dir() {
                 std::fs::create_dir_all(parent)?;

--- a/tests/secret_manager.rs
+++ b/tests/secret_manager.rs
@@ -27,8 +27,7 @@ async fn mnemonic_secret_manager_dto() -> Result<()> {
 #[cfg(feature = "stronghold")]
 #[tokio::test]
 async fn stronghold_secret_manager_dto() -> Result<()> {
-    let dto =
-        r#"{"Stronghold": {"password": "some_hopefully_secure_password", "snapshotPath": "test/test.stronghold"}}"#;
+    let dto = r#"{"Stronghold": {"password": "some_hopefully_secure_password", "snapshotPath": "snapshot_test_dir/test.stronghold"}}"#;
     let mnemonic = String::from(
         "acoustic trophy damage hint search taste love bicycle foster cradle brown govern endless depend situate athlete pudding blame question genius transfer van random vast",
     );
@@ -63,6 +62,6 @@ async fn stronghold_secret_manager_dto() -> Result<()> {
     }
 
     // Remove garbage after test, but don't care about the result
-    std::fs::remove_file("test/test.stronghold").unwrap_or(());
+    std::fs::remove_dir_all("snapshot_test_dir").unwrap_or(());
     Ok(())
 }

--- a/tests/secret_manager.rs
+++ b/tests/secret_manager.rs
@@ -27,7 +27,8 @@ async fn mnemonic_secret_manager_dto() -> Result<()> {
 #[cfg(feature = "stronghold")]
 #[tokio::test]
 async fn stronghold_secret_manager_dto() -> Result<()> {
-    let dto = r#"{"Stronghold": {"password": "some_hopefully_secure_password", "snapshotPath": "test.stronghold"}}"#;
+    let dto =
+        r#"{"Stronghold": {"password": "some_hopefully_secure_password", "snapshotPath": "test/test.stronghold"}}"#;
     let mnemonic = String::from(
         "acoustic trophy damage hint search taste love bicycle foster cradle brown govern endless depend situate athlete pudding blame question genius transfer van random vast",
     );
@@ -62,6 +63,6 @@ async fn stronghold_secret_manager_dto() -> Result<()> {
     }
 
     // Remove garbage after test, but don't care about the result
-    std::fs::remove_file("test.stronghold").unwrap_or(());
+    std::fs::remove_file("test/test.stronghold").unwrap_or(());
     Ok(())
 }


### PR DESCRIPTION
# Description of change

Adds a check in `write_stronghold_snapshot()` to see if directory in snapshot_path exists, if it doesn't create it.

## Links to any relevant issues

Fixes issue #975

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Modify `stronghold_secret_manager_dto` test to verify that stronghold doesn't panic if directory in path doesn't exist

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
