### PR TITLE
Add remainder to PreparedTransactionData

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ default = [ "async", "tls" ]
 sync = [ "ureq", "tokio", "futures" ]
 async = [ "reqwest", "futures", "tokio" ]
 mqtt = [ "rumqttc", "once_cell", "futures" ]
-ledger = [ "iota-ledger" ]
+ledger_nano = [ "iota-ledger" ]
 tls = [ "reqwest/rustls-tls", "ureq/tls" ]
 stronghold = [ "iota_stronghold", "riker", "crypto05" ]
 message_interface = [ "backtrace" ]
@@ -86,8 +86,8 @@ name = "10_mqtt"
 required-features = [ "mqtt" ]
 
 [[example]]
-name = "ledger"
-required-features = [ "ledger" ]
+name = "ledger_nano"
+required-features = [ "ledger_nano" ]
 
 [[example]]
 name = "stronghold"

--- a/bindings/java/native/src/classes/message.rs
+++ b/bindings/java/native/src/classes/message.rs
@@ -374,8 +374,8 @@ impl<'a> ClientMessageBuilder<'a> {
 
         let prepared = RustPreparedTransactionData {
             essence: prepared_transaction_data.essence.to_inner(),
-            input_signing_data_entries: prepared_transaction_data
-                .input_signing_data_entries
+            inputs_data: prepared_transaction_data
+                .inputs_data
                 .iter()
                 .map(|a| addres_into_rust_address_recorder(a.clone()))
                 .collect(),

--- a/bindings/java/native/src/classes/prepared.rs
+++ b/bindings/java/native/src/classes/prepared.rs
@@ -19,7 +19,7 @@ pub struct PreparedTransactionData {
     /// Transaction essence
     pub essence: Essence,
     /// Required address information for signing
-    pub input_signing_data_entries: Vec<InputSigningData>,
+    pub inputs_data: Vec<InputSigningData>,
 }
 
 impl PreparedTransactionData {
@@ -36,8 +36,8 @@ impl PreparedTransactionData {
         self.essence.clone()
     }
 
-    pub fn input_signing_data_entries(&self) -> Vec<InputSigningData> {
-        self.input_signing_data_entries.iter().cloned().collect()
+    pub fn inputs_data(&self) -> Vec<InputSigningData> {
+        self.inputs_data.iter().cloned().collect()
     }
 
     pub fn serialize(&self) -> Result<String> {
@@ -54,8 +54,8 @@ impl core::fmt::Display for PreparedTransactionData {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(
             f,
-            "essence={}, input_signing_data_entries=({:?})",
-            self.essence, self.input_signing_data_entries
+            "essence={}, inputs_data=({:?})",
+            self.essence, self.inputs_data
         )
     }
 }
@@ -70,8 +70,8 @@ impl From<RustPreparedTransactionData> for PreparedTransactionData {
     fn from(prepared: RustPreparedTransactionData) -> Self {
         Self {
             essence: prepared.essence.into(),
-            input_signing_data_entries: prepared
-                .input_signing_data_entries
+            inputs_data: prepared
+                .inputs_data
                 .iter()
                 .map(|rec| rec.into())
                 .collect(),

--- a/bindings/java/native/src/java_glue.rs.in
+++ b/bindings/java/native/src/java_glue.rs.in
@@ -1360,7 +1360,7 @@ foreign_class!(
         /// Transaction essence
         fn PreparedTransactionData::essence(&self) -> Essence;
         /// Required address information for signing
-        fn PreparedTransactionData::input_signing_data_entries(&self) -> Vec<InputSigningData>;
+        fn PreparedTransactionData::inputs_data(&self) -> Vec<InputSigningData>;
 
         /// Serializes the prepared data into a json string
         fn PreparedTransactionData::serialize(&self) -> Result<String>;

--- a/bindings/nodejs/examples/offline_signing/example_prepared_transaction.json
+++ b/bindings/nodejs/examples/offline_signing/example_prepared_transaction.json
@@ -39,7 +39,7 @@
             }
         ]
     },
-    "input_signing_data_entries": [
+    "inputs_data": [
         {
             "output": {
                 "type": "Basic",

--- a/bindings/wasm/examples/offline_signing/example_prepared_transaction.json
+++ b/bindings/wasm/examples/offline_signing/example_prepared_transaction.json
@@ -33,7 +33,7 @@
             "payload": null
         }
     },
-    "input_signing_data_entries": [
+    "inputs_data": [
         {
             "account_index": 0,
             "input": {

--- a/examples/ledger_nano.rs
+++ b/examples/ledger_nano.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! cargo run --example ledger --features=ledger --release
+//! cargo run --example ledger_nano --features=ledger_nano --release
 
 use iota_client::{
     secret::{ledger::LedgerSecretManager, SecretManager},

--- a/examples/ledger_nano.rs
+++ b/examples/ledger_nano.rs
@@ -4,7 +4,7 @@
 //! cargo run --example ledger_nano --features=ledger_nano --release
 
 use iota_client::{
-    secret::{ledger::LedgerSecretManager, SecretManager},
+    secret::{ledger_nano::LedgerSecretManager, SecretManager},
     Client, Result,
 };
 

--- a/examples/offline_signing/2_transaction_signing.rs
+++ b/examples/offline_signing/2_transaction_signing.rs
@@ -20,7 +20,7 @@ use iota_client::{
         payload::{transaction::TransactionPayload, Payload},
         unlock_block::UnlockBlocks,
     },
-    secret::{mnemonic::MnemonicSecretManager, SecretManageExt, SecretManager, SignMessageMetadata},
+    secret::{mnemonic::MnemonicSecretManager, SecretManageExt, SecretManager},
     Result,
 };
 
@@ -38,23 +38,13 @@ async fn main() -> Result<()> {
     let prepared_transaction = read_prepared_transaction_from_file(PREPARED_TRANSACTION_FILE_NAME)?;
 
     let mut input_addresses = Vec::new();
-    for input_signing_data in &prepared_transaction.input_signing_data_entries {
+    for input_signing_data in &prepared_transaction.inputs_data {
         let (_bech32_hrp, address) = Address::try_from_bech32(&input_signing_data.bech32_address)?;
         input_addresses.push(address);
     }
 
     // Signs prepared transaction offline.
-    let unlock_blocks = secret_manager
-        .sign_transaction_essence(
-            &prepared_transaction.essence,
-            &prepared_transaction.input_signing_data_entries,
-            // TODO set correct data
-            SignMessageMetadata {
-                remainder_value: 0,
-                remainder_deposit_address: None,
-            },
-        )
-        .await?;
+    let unlock_blocks = secret_manager.sign_transaction_essence(&prepared_transaction).await?;
     let unlock_blocks = UnlockBlocks::new(unlock_blocks)?;
     let signed_transaction = TransactionPayload::new(prepared_transaction.essence.clone(), unlock_blocks)?;
 

--- a/examples/offline_signing/2_transaction_signing.rs
+++ b/examples/offline_signing/2_transaction_signing.rs
@@ -20,7 +20,7 @@ use iota_client::{
         payload::{transaction::TransactionPayload, Payload},
         unlock_block::UnlockBlocks,
     },
-    secret::{mnemonic::MnemonicSecretManager, Network, SecretManageExt, SecretManager, SignMessageMetadata},
+    secret::{mnemonic::MnemonicSecretManager, SecretManageExt, SecretManager, SignMessageMetadata},
     Result,
 };
 
@@ -52,7 +52,6 @@ async fn main() -> Result<()> {
             SignMessageMetadata {
                 remainder_value: 0,
                 remainder_deposit_address: None,
-                network: Network::Testnet,
             },
         )
         .await?;

--- a/examples/offline_signing/3_send_message.rs
+++ b/examples/offline_signing/3_send_message.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
         let (local_time, milestone_index) = online_client.get_time_and_milestone_checked().await?;
 
         let conflict = verify_semantic(
-            &prepared_transaction.input_signing_data_entries,
+            &prepared_transaction.inputs_data,
             signed_transaction_payload,
             milestone_index,
             local_time,

--- a/src/api/address.rs
+++ b/src/api/address.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use crate::{
     api::types::{Bech32Addresses, RawAddresses},
     constants::{SHIMMER_COIN_TYPE, SHIMMER_TESTNET_BECH32_HRP},
-    secret::{GenerateAddressMetadata, Network, SecretManage, SecretManager},
+    secret::{GenerateAddressMetadata, SecretManage, SecretManager},
     Client, Result,
 };
 
@@ -54,10 +54,7 @@ impl<'a> GetAddressesBuilder<'a> {
             range: 0..super::ADDRESS_GAP_RANGE,
             internal: false,
             bech32_hrp: None,
-            metadata: GenerateAddressMetadata {
-                syncing: true,
-                network: Network::Testnet,
-            },
+            metadata: GenerateAddressMetadata { syncing: true },
         }
     }
 

--- a/src/api/message_builder/input_selection/manual.rs
+++ b/src/api/message_builder/input_selection/manual.rs
@@ -33,7 +33,7 @@ pub(crate) async fn get_custom_inputs(
     allow_burning: bool,
 ) -> Result<SelectedTransactionData> {
     log::debug!("[get_custom_inputs]");
-    let mut input_signing_data_entries = Vec::new();
+    let mut inputs_data = Vec::new();
 
     if let Some(inputs) = &message_builder.inputs {
         for input in inputs {
@@ -66,7 +66,7 @@ pub(crate) async fn get_custom_inputs(
                     }
                     None => (0, false),
                 };
-                input_signing_data_entries.push(InputSigningData {
+                inputs_data.push(InputSigningData {
                     output: Output::try_from(&output_response.output)?,
                     output_metadata: OutputMetadata::try_from(&output_response)?,
                     chain: Some(Chain::from_u32_hardened(vec![
@@ -82,7 +82,7 @@ pub(crate) async fn get_custom_inputs(
         }
     }
     let selected_transaction_data = try_select_inputs(
-        input_signing_data_entries,
+        inputs_data,
         message_builder.outputs.clone(),
         true,
         message_builder.custom_remainder_address,

--- a/src/api/message_builder/input_selection/remainder.rs
+++ b/src/api/message_builder/input_selection/remainder.rs
@@ -10,10 +10,14 @@ use bee_message::{
 };
 
 use crate::{
-    api::input_selection::{
-        get_accumulated_output_amounts, get_minted_and_melted_native_tokens, get_remainder_native_tokens,
-        minimum_storage_deposit, AccumulatedOutputAmounts,
+    api::{
+        input_selection::{
+            get_accumulated_output_amounts, get_minted_and_melted_native_tokens, get_remainder_native_tokens,
+            minimum_storage_deposit, AccumulatedOutputAmounts,
+        },
+        RemainderData,
     },
+    crypto::keys::slip10::Chain,
     secret::types::InputSigningData,
     Error, Result,
 };
@@ -21,18 +25,19 @@ use crate::{
 // Get a remainder with amount and native tokens if necessary, if no remainder_address is provided it will be selected
 // from the inputs, also validates the amounts
 pub(crate) async fn get_remainder_output<'a>(
-    inputs: impl Iterator<Item = &'a Output> + Clone,
+    inputs: impl Iterator<Item = &'a InputSigningData> + Clone,
     outputs: impl Iterator<Item = &'a Output> + Clone,
     remainder_address: Option<Address>,
     byte_cost_config: &ByteCostConfig,
     allow_burning: bool,
-) -> Result<Option<Output>> {
+) -> Result<Option<RemainderData>> {
     log::debug!("[get_remainder]");
-    let mut remainder_output = None;
-    let input_data = get_accumulated_output_amounts(std::iter::empty(), inputs.clone()).await?;
+    let mut remainder_data = None;
+    let input_outputs = inputs.clone().map(|i| &i.output);
+    let input_data = get_accumulated_output_amounts(std::iter::empty(), input_outputs.clone()).await?;
     let output_data = get_accumulated_output_amounts(std::iter::empty(), outputs.clone()).await?;
     // Get minted native tokens
-    let (minted_native_tokens, melted_native_tokens) = get_minted_and_melted_native_tokens(inputs.clone(), outputs)?;
+    let (minted_native_tokens, melted_native_tokens) = get_minted_and_melted_native_tokens(input_outputs, outputs)?;
 
     // check amount first
     if input_data.amount < output_data.amount {
@@ -52,8 +57,9 @@ pub(crate) async fn get_remainder_output<'a>(
     let native_token_remainder = get_remainder_native_tokens(&input_native_tokens, &output_native_tokens)?;
     // Output possible remaining tokens back to the original address
     if remainder_amount > 0 {
-        let remainder_addr = match remainder_address {
-            Some(a) => a,
+        let (remainder_addr, address_chain) = match remainder_address {
+            // For provided remainder addresses we can't get the Chain
+            Some(a) => (a, None),
             None => get_remainder_address(inputs)?,
         };
 
@@ -65,7 +71,11 @@ pub(crate) async fn get_remainder_output<'a>(
         let remainder = remainder_output_builder.finish_output()?;
         // Check if output has enough amount to cover the storage deposit
         remainder.verify_storage_deposit(byte_cost_config)?;
-        remainder_output.replace(remainder);
+        remainder_data.replace(RemainderData {
+            output: remainder,
+            chain: address_chain,
+            address: remainder_addr,
+        });
     } else {
         // if we have remaining native tokens, but no amount left, then we can't create this transaction unless we want
         // to burn them
@@ -74,27 +84,29 @@ pub(crate) async fn get_remainder_output<'a>(
         }
     }
 
-    Ok(remainder_output)
+    Ok(remainder_data)
 }
 
 // Get an Ed25519 address from the inputs as remainder address
 // We don't want to use nft or alias addresses as remainder address, because we might can't control them later
-pub(crate) fn get_remainder_address<'a>(inputs: impl Iterator<Item = &'a Output>) -> Result<Address> {
+pub(crate) fn get_remainder_address<'a>(
+    inputs: impl Iterator<Item = &'a InputSigningData>,
+) -> Result<(Address, Option<Chain>)> {
     // get address from an input, by default we only allow ed25519 addresses as remainder, because then we're sure that
     // the sender can access it
     let mut address = None;
     'outer: for input in inputs {
-        if let Some(unlock_conditions) = input.unlock_conditions() {
+        if let Some(unlock_conditions) = input.output.unlock_conditions() {
             for unlock_condition in unlock_conditions.iter() {
                 if let UnlockCondition::Address(address_unlock_condition) = unlock_condition {
-                    address.replace(address_unlock_condition.address());
+                    address.replace((*address_unlock_condition.address(), input.chain.clone()));
                     break 'outer;
                 }
             }
         }
     }
     match address {
-        Some(addr) => Ok(*addr),
+        Some(addr) => Ok(addr),
         None => Err(Error::MissingInputWithEd25519UnlockCondition),
     }
 }
@@ -120,7 +132,7 @@ pub(crate) fn get_additional_required_remainder_amount(
                 byte_cost_config,
                 &match remainder_address {
                     Some(a) => a,
-                    None => get_remainder_address(selected_inputs.iter().map(|i| &i.output))?,
+                    None => get_remainder_address(selected_inputs.iter())?.0,
                 },
                 &native_token_remainder,
             )?;

--- a/src/api/message_builder/input_selection/types.rs
+++ b/src/api/message_builder/input_selection/types.rs
@@ -5,7 +5,7 @@
 
 use bee_message::output::{NativeTokensBuilder, Output};
 
-use crate::api::message_builder::input_selection::InputSigningData;
+use crate::api::{message_builder::input_selection::InputSigningData, RemainderData};
 
 /// Transaction data with selected inputs, input data for signing and outputs, with remainder output if required
 #[derive(Debug, Clone)]
@@ -15,7 +15,7 @@ pub struct SelectedTransactionData {
     /// All outputs for the transaction, including remainder output if required
     pub outputs: Vec<Output>,
     /// Optional remainder output, also already parts of the outputs
-    pub remainder_output: Option<Output>,
+    pub remainder: Option<RemainderData>,
 }
 
 /// Required things from the to be created outputs

--- a/src/api/message_builder/transaction.rs
+++ b/src/api/message_builder/transaction.rs
@@ -21,7 +21,7 @@ use bee_message::{
 use crate::{
     api::{types::PreparedTransactionData, ClientMessageBuilder},
     bee_message::output::AliasId,
-    secret::{types::InputSigningData, Network, SecretManageExt, SignMessageMetadata},
+    secret::{types::InputSigningData, SecretManageExt, SignMessageMetadata},
     Error, Result,
 };
 
@@ -119,10 +119,6 @@ pub async fn sign_transaction(
             SignMessageMetadata {
                 remainder_value: 0,
                 remainder_deposit_address: None,
-                network: match message_builder.client.get_network_id().await? {
-                    1454675179895816119 => Network::Mainnet,
-                    _ => Network::Testnet,
-                },
             },
         )
         .await?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -180,31 +180,31 @@ pub enum Error {
     #[error("No input with matching ed25519 unlock condition provided")]
     MissingInputWithEd25519UnlockCondition,
     /// Ledger transport error
-    #[cfg(feature = "ledger")]
+    #[cfg(feature = "ledger_nano")]
     #[error("ledger transport error")]
     LedgerMiscError,
     /// Dongle Locked
-    #[cfg(feature = "ledger")]
+    #[cfg(feature = "ledger_nano")]
     #[error("ledger locked")]
     LedgerDongleLocked,
     /// Denied by User
-    #[cfg(feature = "ledger")]
+    #[cfg(feature = "ledger_nano")]
     #[error("denied by user")]
     LedgerDeniedByUser,
     /// Ledger Device not found
-    #[cfg(feature = "ledger")]
+    #[cfg(feature = "ledger_nano")]
     #[error("ledger device not found")]
     LedgerDeviceNotFound,
     /// Ledger Essence Too Large
-    #[cfg(feature = "ledger")]
+    #[cfg(feature = "ledger_nano")]
     #[error("ledger essence too large")]
     LedgerEssenceTooLarge,
     /// Ledger transport error
-    #[cfg(feature = "ledger")]
+    #[cfg(feature = "ledger_nano")]
     #[error("ledger app compiled for testnet but used with mainnet or vice versa")]
     LedgerNetMismatch,
     /// Wrong ledger seed error
-    #[cfg(feature = "ledger")]
+    #[cfg(feature = "ledger_nano")]
     #[error("ledger mnemonic is mismatched")]
     LedgerMnemonicMismatch,
     /// Riker system error during Stronghold initialization
@@ -243,7 +243,7 @@ pub enum Error {
 // LedgerDeviceNotFound: No usable Ledger device was found
 // LedgerMiscError: Everything else.
 // LedgerEssenceTooLarge: Essence with bip32 input indices need more space then the internal buffer is big
-#[cfg(feature = "ledger")]
+#[cfg(feature = "ledger_nano")]
 impl From<iota_ledger::api::errors::APIError> for Error {
     fn from(error: iota_ledger::api::errors::APIError) -> Self {
         log::info!("ledger error: {}", error);

--- a/src/message_interface/mod.rs
+++ b/src/message_interface/mod.rs
@@ -45,7 +45,7 @@ mod tests {
     use crate::{
         api::GetAddressesBuilderOptions as GenerateAddressesOptions,
         message_interface::{self, ClientMethod, MessageType, ResponseType},
-        secret::{types::Network, GenerateAddressMetadata, SecretManagerDto},
+        secret::{GenerateAddressMetadata, SecretManagerDto},
     };
 
     #[tokio::test]
@@ -71,10 +71,7 @@ mod tests {
             range: Some(std::ops::Range { start: 0, end: 10 }),
             internal: None,
             bech32_hrp: Some("atoi".to_string()),
-            metadata: Some(GenerateAddressMetadata {
-                syncing: false,
-                network: Network::Testnet,
-            }),
+            metadata: Some(GenerateAddressMetadata { syncing: false }),
         };
         let message = MessageType::CallClientMethod(ClientMethod::GenerateAddresses {
             secret_manager: serde_json::from_str::<SecretManagerDto>(&secret_manager).unwrap(),
@@ -124,10 +121,7 @@ mod tests {
             range: Some(std::ops::Range { start: 0, end: 10 }),
             internal: None,
             bech32_hrp: Some("atoi".to_string()),
-            metadata: Some(GenerateAddressMetadata {
-                syncing: false,
-                network: Network::Testnet,
-            }),
+            metadata: Some(GenerateAddressMetadata { syncing: false }),
         };
 
         let generate_addresses_message = MessageType::CallClientMethod(ClientMethod::GenerateAddresses {

--- a/src/secret/mnemonic.rs
+++ b/src/secret/mnemonic.rs
@@ -16,14 +16,8 @@ use crypto::{
     keys::slip10::{Chain, Curve, Seed},
 };
 
-use super::{
-    default_sign_transaction_essence, types::InputSigningData, GenerateAddressMetadata, SecretManage, SecretManageExt,
-};
-use crate::{
-    constants::HD_WALLET_TYPE,
-    secret::{PreparedTransactionData, RemainderData},
-    Client, Result,
-};
+use super::{types::InputSigningData, GenerateAddressMetadata, SecretManage};
+use crate::{constants::HD_WALLET_TYPE, secret::RemainderData, Client, Result};
 
 /// Secret manager that uses only a mnemonic.
 ///
@@ -89,16 +83,6 @@ impl SecretManage for MnemonicSecretManager {
         Ok(UnlockBlock::Signature(SignatureUnlockBlock::new(Signature::Ed25519(
             Ed25519Signature::new(public_key, signature),
         ))))
-    }
-}
-
-#[async_trait]
-impl SecretManageExt for MnemonicSecretManager {
-    async fn sign_transaction_essence(
-        &self,
-        prepared_transaction_data: &PreparedTransactionData,
-    ) -> crate::Result<Vec<UnlockBlock>> {
-        default_sign_transaction_essence(self, prepared_transaction_data).await
     }
 }
 

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -217,7 +217,7 @@ impl SecretManage for SecretManager {
                     .await
             }
             #[cfg(feature = "ledger_nano")]
-            SecretManager::LedgerNano(secret_manager) | SecretManager::LedgerNanoSimulator(secret_manager)=> {
+            SecretManager::LedgerNano(secret_manager) | SecretManager::LedgerNanoSimulator(secret_manager) => {
                 secret_manager
                     .generate_addresses(coin_type, account_index, address_indexes, internal, metadata)
                     .await

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -79,73 +79,6 @@ pub trait SecretManageExt {
     ) -> crate::Result<Vec<UnlockBlock>>;
 }
 
-// Shared implementation for MnemonicSecretManager and StrongholdSecretManager
-pub(crate) async fn default_sign_transaction_essence<'a>(
-    secret_manager: &dyn SecretManage,
-    prepared_transaction_data: &PreparedTransactionData,
-) -> crate::Result<Vec<UnlockBlock>> {
-    // The hashed_essence gets signed
-    let hashed_essence = prepared_transaction_data.essence.hash();
-    let mut unlock_blocks = Vec::new();
-    let mut unlock_block_indexes = HashMap::<Address, usize>::new();
-
-    for (current_block_index, input) in prepared_transaction_data.inputs_data.iter().enumerate() {
-        // Get the address that is required to unlock the input
-        let (_, input_address) = Address::try_from_bech32(&input.bech32_address)?;
-
-        // Check if we already added an [UnlockBlock] for this address
-        match unlock_block_indexes.get(&input_address) {
-            // If we already have an [UnlockBlock] for this address, add a [UnlockBlock] based on the address type
-            Some(block_index) => match input_address {
-                Address::Alias(_alias) => {
-                    unlock_blocks.push(UnlockBlock::Alias(AliasUnlockBlock::new(*block_index as u16)?))
-                }
-                Address::Ed25519(_ed25519) => {
-                    unlock_blocks.push(UnlockBlock::Reference(ReferenceUnlockBlock::new(*block_index as u16)?))
-                }
-                Address::Nft(_nft) => unlock_blocks.push(UnlockBlock::Nft(NftUnlockBlock::new(*block_index as u16)?)),
-            },
-            None => {
-                // We can only sign ed25519 addresses and unlock_block_indexes needs to contain the alias or nft
-                // address already at this point, because the reference index needs to be lower
-                // than the current block index
-                if input_address.kind() != Ed25519Address::KIND {
-                    return Err(crate::Error::MissingInputWithEd25519UnlockCondition);
-                }
-
-                let unlock_block = secret_manager
-                    .signature_unlock(input, &hashed_essence, &prepared_transaction_data.remainder)
-                    .await?;
-                unlock_blocks.push(unlock_block);
-
-                // Add the ed25519 address to the unlock_block_indexes, so it gets referenced if further inputs have
-                // the same address in their unlock condition
-                unlock_block_indexes.insert(input_address, current_block_index);
-            }
-        }
-
-        // When we have an alias or Nft output, we will add their alias or nft address to unlock_block_indexes,
-        // because they can be used to unlock outputs via [UnlockBlock::Alias] or [UnlockBlock::Nft],
-        // that have the corresponding alias or nft address in their unlock condition
-        match &input.output {
-            Output::Alias(alias_output) => unlock_block_indexes.insert(
-                Address::Alias(AliasAddress::new(
-                    alias_output.alias_id().or_from_output_id(input.output_id()?),
-                )),
-                current_block_index,
-            ),
-            Output::Nft(nft_output) => unlock_block_indexes.insert(
-                Address::Nft(NftAddress::new(
-                    nft_output.nft_id().or_from_output_id(input.output_id()?),
-                )),
-                current_block_index,
-            ),
-            _ => None,
-        };
-    }
-    Ok(unlock_blocks)
-}
-
 /// Supported secret managers
 
 // Boxes make this type clumsy to use.
@@ -284,13 +217,7 @@ impl SecretManage for SecretManager {
                     .await
             }
             #[cfg(feature = "ledger_nano")]
-            SecretManager::LedgerNano(secret_manager) => {
-                secret_manager
-                    .generate_addresses(coin_type, account_index, address_indexes, internal, metadata)
-                    .await
-            }
-            #[cfg(feature = "ledger_nano")]
-            SecretManager::LedgerNanoSimulator(secret_manager) => {
+            SecretManager::LedgerNano(secret_manager) | SecretManager::LedgerNanoSimulator(secret_manager)=> {
                 secret_manager
                     .generate_addresses(coin_type, account_index, address_indexes, internal, metadata)
                     .await
@@ -315,11 +242,7 @@ impl SecretManage for SecretManager {
                 secret_manager.signature_unlock(input, essence_hash, metadata).await
             }
             #[cfg(feature = "ledger_nano")]
-            SecretManager::LedgerNano(secret_manager) => {
-                secret_manager.signature_unlock(input, essence_hash, metadata).await
-            }
-            #[cfg(feature = "ledger_nano")]
-            SecretManager::LedgerNanoSimulator(secret_manager) => {
+            SecretManager::LedgerNano(secret_manager) | SecretManager::LedgerNanoSimulator(secret_manager) => {
                 secret_manager.signature_unlock(input, essence_hash, metadata).await
             }
             SecretManager::Mnemonic(secret_manager) => {
@@ -337,20 +260,83 @@ impl SecretManageExt for SecretManager {
     ) -> crate::Result<Vec<UnlockBlock>> {
         match self {
             #[cfg(feature = "stronghold")]
-            SecretManager::Stronghold(secret_manager) => {
-                secret_manager.sign_transaction_essence(prepared_transaction_data).await
-            }
+            SecretManager::Stronghold(_) => self.default_sign_transaction_essence(prepared_transaction_data).await,
             #[cfg(feature = "ledger_nano")]
-            SecretManager::LedgerNano(secret_manager) => {
+            SecretManager::LedgerNano(secret_manager) | SecretManager::LedgerNanoSimulator(secret_manager) => {
                 secret_manager.sign_transaction_essence(prepared_transaction_data).await
             }
-            #[cfg(feature = "ledger_nano")]
-            SecretManager::LedgerNanoSimulator(secret_manager) => {
-                secret_manager.sign_transaction_essence(prepared_transaction_data).await
-            }
-            SecretManager::Mnemonic(secret_manager) => {
-                secret_manager.sign_transaction_essence(prepared_transaction_data).await
-            }
+            SecretManager::Mnemonic(_) => self.default_sign_transaction_essence(prepared_transaction_data).await,
         }
+    }
+}
+
+impl SecretManager {
+    // Shared implementation for MnemonicSecretManager and StrongholdSecretManager
+    async fn default_sign_transaction_essence<'a>(
+        &self,
+        prepared_transaction_data: &PreparedTransactionData,
+    ) -> crate::Result<Vec<UnlockBlock>> {
+        // The hashed_essence gets signed
+        let hashed_essence = prepared_transaction_data.essence.hash();
+        let mut unlock_blocks = Vec::new();
+        let mut unlock_block_indexes = HashMap::<Address, usize>::new();
+
+        for (current_block_index, input) in prepared_transaction_data.inputs_data.iter().enumerate() {
+            // Get the address that is required to unlock the input
+            let (_, input_address) = Address::try_from_bech32(&input.bech32_address)?;
+
+            // Check if we already added an [UnlockBlock] for this address
+            match unlock_block_indexes.get(&input_address) {
+                // If we already have an [UnlockBlock] for this address, add a [UnlockBlock] based on the address type
+                Some(block_index) => match input_address {
+                    Address::Alias(_alias) => {
+                        unlock_blocks.push(UnlockBlock::Alias(AliasUnlockBlock::new(*block_index as u16)?))
+                    }
+                    Address::Ed25519(_ed25519) => {
+                        unlock_blocks.push(UnlockBlock::Reference(ReferenceUnlockBlock::new(*block_index as u16)?))
+                    }
+                    Address::Nft(_nft) => {
+                        unlock_blocks.push(UnlockBlock::Nft(NftUnlockBlock::new(*block_index as u16)?))
+                    }
+                },
+                None => {
+                    // We can only sign ed25519 addresses and unlock_block_indexes needs to contain the alias or nft
+                    // address already at this point, because the reference index needs to be lower
+                    // than the current block index
+                    if input_address.kind() != Ed25519Address::KIND {
+                        return Err(crate::Error::MissingInputWithEd25519UnlockCondition);
+                    }
+
+                    let unlock_block = self
+                        .signature_unlock(input, &hashed_essence, &prepared_transaction_data.remainder)
+                        .await?;
+                    unlock_blocks.push(unlock_block);
+
+                    // Add the ed25519 address to the unlock_block_indexes, so it gets referenced if further inputs have
+                    // the same address in their unlock condition
+                    unlock_block_indexes.insert(input_address, current_block_index);
+                }
+            }
+
+            // When we have an alias or Nft output, we will add their alias or nft address to unlock_block_indexes,
+            // because they can be used to unlock outputs via [UnlockBlock::Alias] or [UnlockBlock::Nft],
+            // that have the corresponding alias or nft address in their unlock condition
+            match &input.output {
+                Output::Alias(alias_output) => unlock_block_indexes.insert(
+                    Address::Alias(AliasAddress::new(
+                        alias_output.alias_id().or_from_output_id(input.output_id()?),
+                    )),
+                    current_block_index,
+                ),
+                Output::Nft(nft_output) => unlock_block_indexes.insert(
+                    Address::Nft(NftAddress::new(
+                        nft_output.nft_id().or_from_output_id(input.output_id()?),
+                    )),
+                    current_block_index,
+                ),
+                _ => None,
+            };
+        }
+        Ok(unlock_blocks)
     }
 }

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -3,8 +3,8 @@
 
 //! Secret manager module enabling address generation and transaction essence signing.
 
-#[cfg(feature = "ledger")]
-pub mod ledger;
+#[cfg(feature = "ledger_nano")]
+pub mod ledger_nano;
 /// Module for signing with a mnemonic or seed
 pub mod mnemonic;
 /// Module for signing with a Stronghold vault
@@ -24,10 +24,10 @@ use bee_message::{
     payload::transaction::TransactionEssence,
     unlock_block::{AliasUnlockBlock, NftUnlockBlock, ReferenceUnlockBlock, UnlockBlock},
 };
-pub use types::{GenerateAddressMetadata, LedgerStatus, Network, SignMessageMetadata};
+pub use types::{GenerateAddressMetadata, LedgerStatus, SignMessageMetadata};
 
-#[cfg(feature = "ledger")]
-use self::ledger::LedgerSecretManager;
+#[cfg(feature = "ledger_nano")]
+use self::ledger_nano::LedgerSecretManager;
 use self::mnemonic::MnemonicSecretManager;
 #[cfg(feature = "stronghold")]
 use self::stronghold::StrongholdSecretManager;
@@ -79,78 +79,73 @@ pub trait SecretManageExt {
     ) -> crate::Result<Vec<UnlockBlock>>;
 }
 
-#[async_trait]
-impl<S> SecretManageExt for S
-where
-    S: SecretManage,
-{
-    async fn sign_transaction_essence<'a>(
-        &self,
-        essence: &TransactionEssence,
-        inputs: &[InputSigningData],
-        metadata: SignMessageMetadata<'a>,
-    ) -> crate::Result<Vec<UnlockBlock>> {
-        // The hashed_essence gets signed
-        let hashed_essence = essence.hash();
-        let mut unlock_blocks = Vec::new();
-        let mut unlock_block_indexes = HashMap::<Address, usize>::new();
+// Shared implementation for MnemonicSecretManager and StrongholdSecretManager
+pub(crate) async fn default_sign_transaction_essence<'a>(
+    secret_manager: &dyn SecretManage,
+    essence: &TransactionEssence,
+    inputs: &[InputSigningData],
+    metadata: SignMessageMetadata<'a>,
+) -> crate::Result<Vec<UnlockBlock>> {
+    // The hashed_essence gets signed
+    let hashed_essence = essence.hash();
+    let mut unlock_blocks = Vec::new();
+    let mut unlock_block_indexes = HashMap::<Address, usize>::new();
 
-        for (current_block_index, input) in inputs.iter().enumerate() {
-            // Get the address that is required to unlock the input
-            let (_, input_address) = Address::try_from_bech32(&input.bech32_address)?;
+    for (current_block_index, input) in inputs.iter().enumerate() {
+        // Get the address that is required to unlock the input
+        let (_, input_address) = Address::try_from_bech32(&input.bech32_address)?;
 
-            // Check if we already added an [UnlockBlock] for this address
-            match unlock_block_indexes.get(&input_address) {
-                // If we already have an [UnlockBlock] for this address, add a [UnlockBlock] based on the address type
-                Some(block_index) => match input_address {
-                    Address::Alias(_alias) => {
-                        unlock_blocks.push(UnlockBlock::Alias(AliasUnlockBlock::new(*block_index as u16)?))
-                    }
-                    Address::Ed25519(_ed25519) => {
-                        unlock_blocks.push(UnlockBlock::Reference(ReferenceUnlockBlock::new(*block_index as u16)?))
-                    }
-                    Address::Nft(_nft) => {
-                        unlock_blocks.push(UnlockBlock::Nft(NftUnlockBlock::new(*block_index as u16)?))
-                    }
-                },
-                None => {
-                    // We can only sign ed25519 addresses and unlock_block_indexes needs to contain the alias or nft
-                    // address already at this point, because the reference index needs to be lower
-                    // than the current block index
-                    if input_address.kind() != Ed25519Address::KIND {
-                        return Err(crate::Error::MissingInputWithEd25519UnlockCondition);
-                    }
-
-                    let unlock_block = self.signature_unlock(input, &hashed_essence, &metadata).await?;
-                    unlock_blocks.push(unlock_block);
-
-                    // Add the ed25519 address to the unlock_block_indexes, so it gets referenced if further inputs have
-                    // the same address in their unlock condition
-                    unlock_block_indexes.insert(input_address, current_block_index);
+        // Check if we already added an [UnlockBlock] for this address
+        match unlock_block_indexes.get(&input_address) {
+            // If we already have an [UnlockBlock] for this address, add a [UnlockBlock] based on the address type
+            Some(block_index) => match input_address {
+                Address::Alias(_alias) => {
+                    unlock_blocks.push(UnlockBlock::Alias(AliasUnlockBlock::new(*block_index as u16)?))
                 }
-            }
+                Address::Ed25519(_ed25519) => {
+                    unlock_blocks.push(UnlockBlock::Reference(ReferenceUnlockBlock::new(*block_index as u16)?))
+                }
+                Address::Nft(_nft) => unlock_blocks.push(UnlockBlock::Nft(NftUnlockBlock::new(*block_index as u16)?)),
+            },
+            None => {
+                // We can only sign ed25519 addresses and unlock_block_indexes needs to contain the alias or nft
+                // address already at this point, because the reference index needs to be lower
+                // than the current block index
+                if input_address.kind() != Ed25519Address::KIND {
+                    return Err(crate::Error::MissingInputWithEd25519UnlockCondition);
+                }
 
-            // When we have an alias or Nft output, we will add their alias or nft address to unlock_block_indexes,
-            // because they can be used to unlock outputs via [UnlockBlock::Alias] or [UnlockBlock::Nft],
-            // that have the corresponding alias or nft address in their unlock condition
-            match &input.output {
-                Output::Alias(alias_output) => unlock_block_indexes.insert(
-                    Address::Alias(AliasAddress::new(
-                        alias_output.alias_id().or_from_output_id(input.output_id()?),
-                    )),
-                    current_block_index,
-                ),
-                Output::Nft(nft_output) => unlock_block_indexes.insert(
-                    Address::Nft(NftAddress::new(
-                        nft_output.nft_id().or_from_output_id(input.output_id()?),
-                    )),
-                    current_block_index,
-                ),
-                _ => None,
-            };
+                let unlock_block = secret_manager
+                    .signature_unlock(input, &hashed_essence, &metadata)
+                    .await?;
+                unlock_blocks.push(unlock_block);
+
+                // Add the ed25519 address to the unlock_block_indexes, so it gets referenced if further inputs have
+                // the same address in their unlock condition
+                unlock_block_indexes.insert(input_address, current_block_index);
+            }
         }
-        Ok(unlock_blocks)
+
+        // When we have an alias or Nft output, we will add their alias or nft address to unlock_block_indexes,
+        // because they can be used to unlock outputs via [UnlockBlock::Alias] or [UnlockBlock::Nft],
+        // that have the corresponding alias or nft address in their unlock condition
+        match &input.output {
+            Output::Alias(alias_output) => unlock_block_indexes.insert(
+                Address::Alias(AliasAddress::new(
+                    alias_output.alias_id().or_from_output_id(input.output_id()?),
+                )),
+                current_block_index,
+            ),
+            Output::Nft(nft_output) => unlock_block_indexes.insert(
+                Address::Nft(NftAddress::new(
+                    nft_output.nft_id().or_from_output_id(input.output_id()?),
+                )),
+                current_block_index,
+            ),
+            _ => None,
+        };
     }
+    Ok(unlock_blocks)
 }
 
 /// Supported secret managers
@@ -165,13 +160,13 @@ pub enum SecretManager {
     Stronghold(StrongholdSecretManager),
 
     /// Secret manager that uses a Ledger hardware wallet.
-    #[cfg(feature = "ledger")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ledger")))]
+    #[cfg(feature = "ledger_nano")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ledger_nano")))]
     LedgerNano(LedgerSecretManager),
 
     /// Secret manager that uses a Ledger Speculos simulator.
-    #[cfg(feature = "ledger")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ledger")))]
+    #[cfg(feature = "ledger_nano")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ledger_nano")))]
     LedgerNanoSimulator(LedgerSecretManager),
 
     /// Secret manager that uses only a mnemonic.
@@ -183,9 +178,9 @@ impl std::fmt::Debug for SecretManager {
         match self {
             #[cfg(feature = "stronghold")]
             Self::Stronghold(_) => f.debug_tuple("Stronghold").field(&"...").finish(),
-            #[cfg(feature = "ledger")]
+            #[cfg(feature = "ledger_nano")]
             Self::LedgerNano(_) => f.debug_tuple("LedgerNano").field(&"...").finish(),
-            #[cfg(feature = "ledger")]
+            #[cfg(feature = "ledger_nano")]
             Self::LedgerNanoSimulator(_) => f.debug_tuple("LedgerNanoSimulator").field(&"...").finish(),
             Self::Mnemonic(_) => f.debug_tuple("Mnemonic").field(&"...").finish(),
         }
@@ -208,10 +203,10 @@ pub enum SecretManagerDto {
     #[cfg_attr(docsrs, doc(cfg(feature = "stronghold")))]
     Stronghold(StrongholdDto),
     /// Ledger Device
-    #[cfg(feature = "ledger")]
+    #[cfg(feature = "ledger_nano")]
     LedgerNano,
     /// Ledger Speculos Simulator
-    #[cfg(feature = "ledger")]
+    #[cfg(feature = "ledger_nano")]
     LedgerNanoSimulator,
     /// Mnemonic
     Mnemonic(String),
@@ -236,10 +231,10 @@ impl TryFrom<&SecretManagerDto> for SecretManager {
                 Self::Stronghold(builder.build())
             }
 
-            #[cfg(feature = "ledger")]
+            #[cfg(feature = "ledger_nano")]
             SecretManagerDto::LedgerNano => Self::LedgerNano(LedgerSecretManager::new(false)),
 
-            #[cfg(feature = "ledger")]
+            #[cfg(feature = "ledger_nano")]
             SecretManagerDto::LedgerNanoSimulator => Self::LedgerNanoSimulator(LedgerSecretManager::new(true)),
 
             SecretManagerDto::Mnemonic(mnemonic) => Self::Mnemonic(MnemonicSecretManager::try_from_mnemonic(mnemonic)?),
@@ -259,10 +254,10 @@ impl From<&SecretManager> for SecretManagerDto {
                     .map(|s| s.clone().into_os_string().to_string_lossy().into()),
             }),
 
-            #[cfg(feature = "ledger")]
+            #[cfg(feature = "ledger_nano")]
             SecretManager::LedgerNano(_) => Self::LedgerNano,
 
-            #[cfg(feature = "ledger")]
+            #[cfg(feature = "ledger_nano")]
             SecretManager::LedgerNanoSimulator(_) => Self::LedgerNanoSimulator,
 
             // `MnemonicSecretManager(Seed)` doesn't have Debug or Display implemented and in the current use cases of
@@ -290,13 +285,13 @@ impl SecretManage for SecretManager {
                     .generate_addresses(coin_type, account_index, address_indexes, internal, metadata)
                     .await
             }
-            #[cfg(feature = "ledger")]
+            #[cfg(feature = "ledger_nano")]
             SecretManager::LedgerNano(secret_manager) => {
                 secret_manager
                     .generate_addresses(coin_type, account_index, address_indexes, internal, metadata)
                     .await
             }
-            #[cfg(feature = "ledger")]
+            #[cfg(feature = "ledger_nano")]
             SecretManager::LedgerNanoSimulator(secret_manager) => {
                 secret_manager
                     .generate_addresses(coin_type, account_index, address_indexes, internal, metadata)
@@ -321,16 +316,44 @@ impl SecretManage for SecretManager {
             SecretManager::Stronghold(secret_manager) => {
                 secret_manager.signature_unlock(input, essence_hash, metadata).await
             }
-            #[cfg(feature = "ledger")]
+            #[cfg(feature = "ledger_nano")]
             SecretManager::LedgerNano(secret_manager) => {
                 secret_manager.signature_unlock(input, essence_hash, metadata).await
             }
-            #[cfg(feature = "ledger")]
+            #[cfg(feature = "ledger_nano")]
             SecretManager::LedgerNanoSimulator(secret_manager) => {
                 secret_manager.signature_unlock(input, essence_hash, metadata).await
             }
             SecretManager::Mnemonic(secret_manager) => {
                 secret_manager.signature_unlock(input, essence_hash, metadata).await
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl SecretManageExt for SecretManager {
+    async fn sign_transaction_essence<'a>(
+        &self,
+        essence: &TransactionEssence,
+        inputs: &[InputSigningData],
+        metadata: SignMessageMetadata<'a>,
+    ) -> crate::Result<Vec<UnlockBlock>> {
+        match self {
+            #[cfg(feature = "stronghold")]
+            SecretManager::Stronghold(secret_manager) => {
+                secret_manager.sign_transaction_essence(essence, inputs, metadata).await
+            }
+            #[cfg(feature = "ledger_nano")]
+            SecretManager::LedgerNano(secret_manager) => {
+                secret_manager.sign_transaction_essence(essence, inputs, metadata).await
+            }
+            #[cfg(feature = "ledger_nano")]
+            SecretManager::LedgerNanoSimulator(secret_manager) => {
+                secret_manager.sign_transaction_essence(essence, inputs, metadata).await
+            }
+            SecretManager::Mnemonic(secret_manager) => {
+                secret_manager.sign_transaction_essence(essence, inputs, metadata).await
             }
         }
     }

--- a/src/secret/types.rs
+++ b/src/secret/types.rs
@@ -34,9 +34,6 @@ pub struct SignMessageMetadata<'a> {
     pub remainder_value: u64,
     /// The transfer's deposit address for the remainder value if any.
     pub remainder_deposit_address: Option<&'a AccountAddress>,
-    /// The network which is used so the correct BIP32 path is used for the ledger. Debug mode starts with 44'/1' and
-    /// in mainnet-mode it's 44'/4218'
-    pub network: Network,
 }
 
 /// An account address.
@@ -59,18 +56,6 @@ pub struct GenerateAddressMetadata {
     /// This means that the account might not be saved.
     /// If it is false, the prompt will be displayed on ledger devices.
     pub syncing: bool,
-    /// The network which is used so the correct BIP32 path is used for the ledger. Debug mode starts with 44'/1' and
-    /// in mainnet-mode it's 44'/4218'
-    pub network: Network,
-}
-
-/// Network enum for ledger metadata
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum Network {
-    /// Mainnet
-    Mainnet,
-    /// Testnet
-    Testnet,
 }
 
 /// The Ledger device status.

--- a/src/secret/types.rs
+++ b/src/secret/types.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 
 use bee_message::{
     address::Address,
-    output::{Output, OutputId},
+    output::{dto::OutputDto, Output, OutputId},
     payload::transaction::TransactionId,
     MessageId,
 };
@@ -27,20 +27,10 @@ pub struct StrongholdDto {
     #[serde(rename = "snapshotPath")]
     pub snapshot_path: Option<String>,
 }
-
-/// Metadata provided to [SecretManager::signature_unlock()](super::SecretManager::signature_unlock()).
-pub struct SignMessageMetadata<'a> {
-    /// The transfer's remainder value.
-    pub remainder_value: u64,
-    /// The transfer's deposit address for the remainder value if any.
-    pub remainder_deposit_address: Option<&'a AccountAddress>,
-}
-
 /// An account address.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccountAddress {
     /// The address.
-    // todo: should we also use an address wrapper like in wallet.rs or the bech32 representation?
     pub address: Address,
     /// The address key index.
     #[serde(rename = "keyIndex")]
@@ -166,5 +156,44 @@ impl PartialEq for InputSigningData {
     fn eq(&self, other: &Self) -> bool {
         self.output_metadata.transaction_id == other.output_metadata.transaction_id
             && self.output_metadata.output_index == other.output_metadata.output_index
+    }
+}
+
+/// Dto for data for transaction inputs for signing and ordering of unlock blocks
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InputSigningDataDto {
+    /// The output
+    pub output: OutputDto,
+    /// The output metadata
+    #[serde(rename = "outputMetadata")]
+    pub output_metadata: OutputMetadata,
+    /// The chain derived from seed, only for ed25519 addresses
+    pub chain: Option<Chain>,
+    /// The bech32 encoded address, required because of alias outputs where we have multiple possible unlock
+    /// conditions, because we otherwise don't know which one we need
+    #[serde(rename = "bech32Address")]
+    pub bech32_address: String,
+}
+
+impl TryFrom<&InputSigningDataDto> for InputSigningData {
+    type Error = Error;
+
+    fn try_from(input: &InputSigningDataDto) -> Result<Self> {
+        Ok(Self {
+            output: Output::try_from(&input.output)?,
+            output_metadata: input.output_metadata.clone(),
+            chain: input.chain.clone(),
+            bech32_address: input.bech32_address.clone(),
+        })
+    }
+}
+impl From<&InputSigningData> for InputSigningDataDto {
+    fn from(input: &InputSigningData) -> Self {
+        Self {
+            output: OutputDto::from(&input.output),
+            output_metadata: input.output_metadata.clone(),
+            chain: input.chain.clone(),
+            bech32_address: input.bech32_address.clone(),
+        }
     }
 }

--- a/src/stronghold/secret.rs
+++ b/src/stronghold/secret.rs
@@ -20,11 +20,8 @@ use super::{
     StrongholdAdapter,
 };
 use crate::{
-    api::{PreparedTransactionData, RemainderData},
-    secret::{
-        default_sign_transaction_essence, types::InputSigningData, GenerateAddressMetadata, SecretManage,
-        SecretManageExt,
-    },
+    api::RemainderData,
+    secret::{types::InputSigningData, GenerateAddressMetadata, SecretManage},
     Result,
 };
 
@@ -130,16 +127,6 @@ impl SecretManage for StrongholdAdapter {
         )));
 
         Ok(unlock_block)
-    }
-}
-
-#[async_trait]
-impl SecretManageExt for StrongholdAdapter {
-    async fn sign_transaction_essence(
-        &self,
-        prepared_transaction_data: &PreparedTransactionData,
-    ) -> crate::Result<Vec<UnlockBlock>> {
-        default_sign_transaction_essence(self, prepared_transaction_data).await
     }
 }
 

--- a/src/stronghold/secret.rs
+++ b/src/stronghold/secret.rs
@@ -8,7 +8,6 @@ use std::ops::Range;
 use async_trait::async_trait;
 use bee_message::{
     address::{Address, Ed25519Address},
-    payload::transaction::TransactionEssence,
     signature::{Ed25519Signature, Signature},
     unlock_block::{SignatureUnlockBlock, UnlockBlock},
 };
@@ -21,9 +20,10 @@ use super::{
     StrongholdAdapter,
 };
 use crate::{
+    api::{PreparedTransactionData, RemainderData},
     secret::{
         default_sign_transaction_essence, types::InputSigningData, GenerateAddressMetadata, SecretManage,
-        SecretManageExt, SignMessageMetadata,
+        SecretManageExt,
     },
     Result,
 };
@@ -82,11 +82,11 @@ impl SecretManage for StrongholdAdapter {
         Ok(addresses)
     }
 
-    async fn signature_unlock<'a>(
+    async fn signature_unlock(
         &self,
         input: &InputSigningData,
         essence_hash: &[u8; 32],
-        _: &SignMessageMetadata<'a>,
+        _: &Option<RemainderData>,
     ) -> Result<UnlockBlock> {
         // Stronghold arguments.
         let seed_location = SLIP10DeriveInput::Seed(Location::Generic {
@@ -135,13 +135,11 @@ impl SecretManage for StrongholdAdapter {
 
 #[async_trait]
 impl SecretManageExt for StrongholdAdapter {
-    async fn sign_transaction_essence<'a>(
+    async fn sign_transaction_essence(
         &self,
-        essence: &TransactionEssence,
-        inputs: &[InputSigningData],
-        metadata: SignMessageMetadata<'a>,
+        prepared_transaction_data: &PreparedTransactionData,
     ) -> crate::Result<Vec<UnlockBlock>> {
-        default_sign_transaction_essence(self, essence, inputs, metadata).await
+        default_sign_transaction_essence(self, prepared_transaction_data).await
     }
 }
 


### PR DESCRIPTION
# Description of change

Add remainder to PreparedTransactionData so we know which output is the remainder output by looking only on that
Required for offline signing support

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
