### PR TITLE
Stronghold Improvements: Timeout and Unloading

### DIFF
--- a/examples/stronghold.rs
+++ b/examples/stronghold.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
     let mut stronghold_secret_manager = StrongholdSecretManager::builder()
         .password("some_hopefully_secure_password")
         .snapshot_path(PathBuf::from("test.stronghold"))
-        .build();
+        .try_build()?;
 
     // This example uses dotenv, which is not safe for use in production
     dotenv().ok();

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,7 +144,7 @@ pub enum Error {
     /// Output Error
     #[error("Output error: {0}")]
     OutputError(&'static str),
-    /// Not implemented, specially for the default impl of [crate::secret::SecretManager::signature_unlock()].
+    /// Not implemented, specially for the default impl of [crate::secret::SecretManage::signature_unlock()].
     #[error("No mnemonic was stored! Please implement signature_unlock() :)")]
     SignatureUnlockNotImplemented,
     #[cfg(not(target_family = "wasm"))]

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -15,9 +15,9 @@ pub mod stronghold;
 /// Signing related types
 pub mod types;
 
+use std::{collections::HashMap, ops::Range, str::FromStr};
 #[cfg(feature = "stronghold")]
-use std::path::PathBuf;
-use std::{collections::HashMap, ops::Range, str::FromStr, time::Duration};
+use std::{path::PathBuf, time::Duration};
 
 use async_trait::async_trait;
 use bee_block::{

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -17,7 +17,7 @@ pub mod types;
 
 #[cfg(feature = "stronghold")]
 use std::path::PathBuf;
-use std::{collections::HashMap, ops::Range, str::FromStr};
+use std::{collections::HashMap, ops::Range, str::FromStr, time::Duration};
 
 use async_trait::async_trait;
 use bee_block::{
@@ -165,6 +165,10 @@ impl TryFrom<&SecretManagerDto> for SecretManager {
                     builder = builder.password(password);
                 }
 
+                if let Some(timeout) = &stronghold_dto.timeout {
+                    builder = builder.timeout(Duration::from_secs(*timeout));
+                }
+
                 if let Some(snapshot_path) = &stronghold_dto.snapshot_path {
                     builder = builder.snapshot_path(PathBuf::from(snapshot_path));
                 }
@@ -191,6 +195,7 @@ impl From<&SecretManager> for SecretManagerDto {
             #[cfg(feature = "stronghold")]
             SecretManager::Stronghold(stronghold_dto) => Self::Stronghold(StrongholdDto {
                 password: None,
+                timeout: stronghold_dto.get_timeout().map(|duration| duration.as_secs()),
                 snapshot_path: stronghold_dto
                     .snapshot_path
                     .as_ref()

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -173,7 +173,7 @@ impl TryFrom<&SecretManagerDto> for SecretManager {
                     builder = builder.snapshot_path(PathBuf::from(snapshot_path));
                 }
 
-                Self::Stronghold(builder.build())
+                Self::Stronghold(builder.try_build()?)
             }
 
             #[cfg(feature = "ledger_nano")]

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -193,10 +193,10 @@ impl From<&SecretManager> for SecretManagerDto {
     fn from(value: &SecretManager) -> Self {
         match value {
             #[cfg(feature = "stronghold")]
-            SecretManager::Stronghold(stronghold_dto) => Self::Stronghold(StrongholdDto {
+            SecretManager::Stronghold(stronghold_adapter) => Self::Stronghold(StrongholdDto {
                 password: None,
-                timeout: stronghold_dto.get_timeout().map(|duration| duration.as_secs()),
-                snapshot_path: stronghold_dto
+                timeout: stronghold_adapter.get_timeout().map(|duration| duration.as_secs()),
+                snapshot_path: stronghold_adapter
                     .snapshot_path
                     .as_ref()
                     .map(|s| s.clone().into_os_string().to_string_lossy().into()),

--- a/src/secret/types.rs
+++ b/src/secret/types.rs
@@ -25,6 +25,8 @@ use crate::{Error, Result};
 pub struct StrongholdDto {
     /// The Stronghold password
     pub password: Option<String>,
+    /// The timeout for auto key clearing, in seconds
+    pub timeout: Option<u64>,
     /// The path for the Stronghold file
     #[serde(rename = "snapshotPath")]
     pub snapshot_path: Option<String>,

--- a/src/stronghold/db.rs
+++ b/src/stronghold/db.rs
@@ -108,7 +108,7 @@ mod tests {
         use super::StrongholdAdapter;
         use crate::db::DatabaseProvider;
 
-        let mut stronghold = StrongholdAdapter::builder().password("drowssap").build();
+        let mut stronghold = StrongholdAdapter::builder().password("drowssap").try_build().unwrap();
 
         assert!(matches!(stronghold.get(b"test-0").await, Ok(None)));
         assert!(matches!(stronghold.get(b"test-1").await, Ok(None)));

--- a/src/stronghold/db.rs
+++ b/src/stronghold/db.rs
@@ -31,7 +31,7 @@ impl DatabaseProvider for StrongholdAdapter {
         }
 
         let location = location_from_key(k);
-        let (data, status) = self.stronghold.read_from_store(location).await;
+        let (data, status) = self.stronghold.lock().await.read_from_store(location).await;
 
         // XXX: this theoretically indicates a non-existent key, but what about other errors?
         if let ResultMessage::Error(err) = status {
@@ -69,7 +69,12 @@ impl DatabaseProvider for StrongholdAdapter {
         };
 
         let location = location_from_key(k);
-        let status = self.stronghold.write_to_store(location, encrypted_value, None).await;
+        let status = self
+            .stronghold
+            .lock()
+            .await
+            .write_to_store(location, encrypted_value, None)
+            .await;
 
         if let ResultMessage::Error(err) = status {
             return Err(Error::StrongholdProcedureError(err));
@@ -87,7 +92,7 @@ impl DatabaseProvider for StrongholdAdapter {
         let old_value = self.get(k).await?;
 
         let location = location_from_key(k);
-        let status = self.stronghold.delete_from_store(location).await;
+        let status = self.stronghold.lock().await.delete_from_store(location).await;
 
         if let ResultMessage::Error(err) = status {
             return Err(Error::StrongholdProcedureError(err));

--- a/src/stronghold/mod.rs
+++ b/src/stronghold/mod.rs
@@ -8,13 +8,13 @@
 //! - Smart-card-like secret vault
 //! - Generic key-value, encrypted database
 //!
-//! [`StrongholdAdapter`] respectively implements [`DatabaseProvider`] and [`SecretManager`] for the above purposes
-//! using Stronghold. Type aliases [`StrongholdDatabaseProvider`] and [`StrongholdSecretManager`] are also provided if
-//! one wants to have a more consistent naming when using any of the feature sets.
+//! [`StrongholdAdapter`] respectively implements [`DatabaseProvider`] and [`SecretManage`] for the above purposes
+//! using Stronghold. Type aliases `StrongholdDatabaseProvider` and `StrongholdSecretManager` are also provided if one
+//! wants to have a more consistent naming when using any of the feature sets.
 //!
 //! Use [`builder()`] to construct a [`StrongholdAdapter`] with customized parameters; see documentation of methods of
 //! [`StrongholdAdapterBuilder`] for details. Alternatively, invoking [`new()`] (or using [`Default::default()`])
-//! creates a [`StrongholdAdapter`] with default parameters. The default [`StrongholdAdapter`]:
+//! creates a [`StrongholdAdapter`] with default parameters. However, the default [`StrongholdAdapter`]:
 //!
 //! - is not initialized with a password
 //! - is without a password clearing timeout
@@ -27,28 +27,30 @@
 //! - Without a password clearing timeout, the derived key would be stored in the memory for as long as possible, and
 //!   could be used as an attack vector.
 //! - Without a snapshot path configured, all operations would be _transient_ (i.e. all data would be lost when
-//!   [`StrongholdAdapter`] is dropped).
+//!   [`StrongholdAdapter`] is dropped, or the cached key has been cleared).
 //!
-//! These configurations can also be set later using [`set_password()`], [`set_snapshot_path()`], etc.
+//! They can also be set later using [`set_password()`], [`set_timeout()`], etc.
 //!
-//! Stronghold is memory-based, so it's not required to use a snapshot file on the disk. Without a snapshot path set
-//! (via [`StrongholdAdapterBuilder::snapshot_path()`] or [`StrongholdAdapter::set_snapshot_path()`]),
-//! [`StrongholdAdapter`] will run purely in memory. If a snapshot path is set, then [`StrongholdAdapter`] would lazily
-//! load the file on _the first call_ that performs some actions on Stronghold. Subsequent actions are still performed
-//! in memory. If the snapshot file doesn't exist, these function calls will all fail. To load or store the Stronghold
-//! state from or to a Stronghold snapshot on disk, remember to call [`read_stronghold_snapshot()`] or
-//! [`write_stronghold_snapshot()`]; the latter can be used to create a snapshot file after creating a
-//! [`StrongholdAdapter`] with a non-existent snapshot path.
+//! With [`set_timeout()`], an automatic task can be spawned in the background to purge the key from memory using
+//! [zeroize] after the `timeout` duration. It's used to reduce the attack vector. When the key is cleared from the
+//! memory, Stronghold will be unloaded from the memory too. If no `snapshot_path` has been set at this point, then
+//! secrets stored in Stronghold will be dropped and lost.
+//!
+//! Nevertheless, Stronghold is memory-based, so it's not required to use a snapshot file on the disk. Without a
+//! snapshot path set, [`StrongholdAdapter`] will run purely in memory. If a snapshot path is set, then
+//! [`StrongholdAdapter`] would lazily load the file on _the first call_ that performs some actions on Stronghold.
+//! Subsequent actions are still performed in memory. If the snapshot file doesn't exist, these function calls will all
+//! fail. To proactively load or store the Stronghold state from or to a Stronghold snapshot on disk, use
+//! [`read_stronghold_snapshot()`] or [`write_stronghold_snapshot()`]. The latter can be used to create a snapshot file
+//! after creating a [`StrongholdAdapter`] with a non-existent snapshot path.
 //!
 //! [Stronghold]: iota_stronghold
 //! [`DatabaseProvider`]: crate::db::DatabaseProvider
-//! [`SecretManager`]: crate::secret::SecretManager
-//! [`StrongholdDatabaseProvider`]: crate::db::StrongholdDatabaseProvider
-//! [`StrongholdSecretmanager`]: crate::signing::StrongholdSecretmanager
+//! [`SecretManage`]: crate::secret::SecretManage
 //! [`builder()`]: self::StrongholdAdapter::builder()
 //! [`new()`]: self::StrongholdAdapter::new()
 //! [`set_password()`]: self::StrongholdAdapter::set_password()
-//! [`set_snapshot_path()`]: self::StrongholdAdapter::set_snapshot_path()
+//! [`set_timeout()`]: self::StrongholdAdapter::set_timeout()
 //! [`read_stronghold_snapshot()`]: self::StrongholdAdapter::read_stronghold_snapshot()
 //! [`write_stronghold_snapshot()`]: self::StrongholdAdapter::write_stronghold_snapshot()
 
@@ -76,7 +78,7 @@ use crate::{Error, Result};
 #[builder(pattern = "owned", build_fn(skip))]
 pub struct StrongholdAdapter {
     /// A stronghold instance.
-    stronghold: Stronghold,
+    stronghold: Arc<Mutex<Stronghold>>,
 
     /// A key to open the Stronghold vault.
     ///
@@ -116,12 +118,16 @@ pub struct StrongholdAdapter {
 impl Default for StrongholdAdapter {
     fn default() -> Self {
         // XXX: we unwrap here.
-        let system = ActorSystem::new().map_err(|err| err.to_string()).unwrap();
+        let system = ActorSystem::new().unwrap();
         let client_path = PRIVATE_DATA_CLIENT_PATH.to_vec();
         let options = Vec::new();
 
         Self {
-            stronghold: Stronghold::init_stronghold_system(system, client_path, options),
+            stronghold: Arc::new(Mutex::new(Stronghold::init_stronghold_system(
+                system,
+                client_path,
+                options,
+            ))),
             key: Arc::new(Mutex::new(None)),
             timeout: None,
             timeout_task: Arc::new(Mutex::new(None)),
@@ -162,57 +168,61 @@ impl StrongholdAdapterBuilder {
         if let (Some(key), Some(Some(timeout))) = (&self.key, self.timeout) {
             let timeout_task = Arc::new(Mutex::new(None));
 
+            // Stronghold isn't optional, so we must initialize one here if it hasn't been supplied.
+            let stronghold = self.stronghold.unwrap_or_else(|| {
+                // XXX: we unwrap here.
+                let system = ActorSystem::new().unwrap();
+                let client_path = PRIVATE_DATA_CLIENT_PATH.to_vec();
+                let options = Vec::new();
+
+                Arc::new(Mutex::new(Stronghold::init_stronghold_system(
+                    system,
+                    client_path,
+                    options,
+                )))
+            });
+
             // The key clearing task, with the data it owns.
-            let key = key.clone();
             let task_self = timeout_task.clone();
+            let stronghold_cloned = stronghold.clone();
+            let key = key.clone();
 
             // To keep this function synchronous (`fn`), we spawn a task that spawns the key clearing task here. It'll
             // however panic when this function is not in a Tokio runtime context (usually in an `async fn`), albeit it
             // itself is a `fn`. There is also a small delay from the return of this function to the task actually being
             // spawned and set in the `struct`.
             tokio::spawn(async move {
-                *task_self.lock().await = Some(tokio::spawn(task_key_clear(task_self.clone(), key, timeout)));
+                *task_self.lock().await = Some(tokio::spawn(task_key_clear(
+                    task_self.clone(),
+                    stronghold_cloned,
+                    key,
+                    timeout,
+                )));
             });
 
-            // Keep the handle in the builder; the code below checks this.
+            // Keep Stronghold and the task handle in the builder; the code below checks this.
+            self.stronghold = Some(stronghold);
             self.timeout_task = Some(timeout_task);
         }
 
-        // Create the adapter per configuration and return it.
-        //
-        // False positive: we don't throw `None`s back!
-        #[allow(clippy::question_mark)]
+        // Create the adapter as per configuration and return it.
         StrongholdAdapter {
-            stronghold: if let Some(stronghold) = self.stronghold {
-                stronghold
-            } else {
+            stronghold: self.stronghold.unwrap_or_else(|| {
                 // XXX: we unwrap here.
-                let system = ActorSystem::new().map_err(|err| err.to_string()).unwrap();
+                let system = ActorSystem::new().unwrap();
                 let client_path = PRIVATE_DATA_CLIENT_PATH.to_vec();
                 let options = Vec::new();
 
-                Stronghold::init_stronghold_system(system, client_path, options)
-            },
-            key: if let Some(key) = self.key {
-                key
-            } else {
-                Arc::new(Mutex::new(None))
-            },
-            timeout: if let Some(timeout) = self.timeout {
-                timeout
-            } else {
-                None
-            },
-            timeout_task: if let Some(timeout_task) = self.timeout_task {
-                timeout_task
-            } else {
-                Arc::new(Mutex::new(None))
-            },
-            snapshot_path: if let Some(snapshot_path) = self.snapshot_path {
-                snapshot_path
-            } else {
-                None
-            },
+                Arc::new(Mutex::new(Stronghold::init_stronghold_system(
+                    system,
+                    client_path,
+                    options,
+                )))
+            }),
+            key: self.key.unwrap_or_else(|| Arc::new(Mutex::new(None))),
+            timeout: self.timeout.unwrap_or(None),
+            timeout_task: self.timeout_task.unwrap_or_else(|| Arc::new(Mutex::new(None))),
+            snapshot_path: self.snapshot_path.unwrap_or(None),
             snapshot_loaded: false,
         }
     }
@@ -249,10 +259,11 @@ impl StrongholdAdapter {
             }
 
             // The key clearing task, with the data it owns.
-            let key = self.key.clone();
             let task_self = self.timeout_task.clone();
+            let stronghold = self.stronghold.clone();
+            let key = self.key.clone();
 
-            *self.timeout_task.lock().await = Some(tokio::spawn(task_key_clear(task_self, key, timeout)));
+            *self.timeout_task.lock().await = Some(tokio::spawn(task_key_clear(task_self, stronghold, key, timeout)));
         }
     }
 
@@ -295,10 +306,11 @@ impl StrongholdAdapter {
         // If a new timeout is set and the key is still in the memory, spawn a new task; otherwise we do nothing.
         if let (Some(_), Some(timeout)) = (self.key.lock().await.as_ref(), self.timeout) {
             // The key clearing task, with the data it owns.
-            let key = self.key.clone();
             let task_self = self.timeout_task.clone();
+            let stronghold = self.stronghold.clone();
+            let key = self.key.clone();
 
-            *self.timeout_task.lock().await = Some(tokio::spawn(task_key_clear(task_self, key, timeout)));
+            *self.timeout_task.lock().await = Some(tokio::spawn(task_key_clear(task_self, stronghold, key, timeout)));
         }
     }
 
@@ -331,6 +343,8 @@ impl StrongholdAdapter {
 
         match self
             .stronghold
+            .lock()
+            .await
             .read_snapshot(
                 PRIVATE_DATA_CLIENT_PATH.to_vec(),
                 None,
@@ -351,7 +365,9 @@ impl StrongholdAdapter {
 
     /// Persist Stronghold to a snapshot at `snapshot_path`.
     ///
-    /// It doesn't unload the snapshot.
+    /// It doesn't unload the snapshot; see also [`unload_stronghold_snapshot()`].
+    ///
+    /// [`unload_stronghold_snapshot()`]: Self::unload_stronghold_snapshot()
     pub async fn write_stronghold_snapshot(&mut self) -> Result<()> {
         // The key and the snapshot path need to be supplied first.
         let locked_key = self.key.lock().await;
@@ -376,6 +392,8 @@ impl StrongholdAdapter {
 
         match self
             .stronghold
+            .lock()
+            .await
             .write_all_to_snapshot(
                 &**key,
                 Some(STRONGHOLD_FILENAME.to_string()),
@@ -387,11 +405,39 @@ impl StrongholdAdapter {
             ResultMessage::Error(err) => Err(crate::Error::StrongholdProcedureError(err)),
         }
     }
+
+    /// Unload Stronghold from memory.
+    ///
+    /// This first writes Stronghold snapshot to disk, then kills Stronghold. All secrets will be purged from the
+    /// memory, so if secrets aren't written to disk (for example, no snapshot path has been provided, i.e. running
+    /// Stronghold purely in memory) then secrets stored in Stronghold will be lost.
+    ///
+    /// To further prevent Stronghold methods to be invoked without valid key, this method will be invoked every time
+    /// the cached key is cleared from the memory. In other words, if a `timeout` is set and a `snapshot_path` is not
+    /// set for a [`StrongholdAdapter`], then after `timeout` Stronghold will be purged. See the [module-level
+    /// documentation](self) for more details.
+    pub async fn unload_stronghold_snapshot(&mut self) -> Result<()> {
+        // Flush Stronghold.
+        self.write_stronghold_snapshot().await?;
+
+        // Kill Stronghold.
+        match self
+            .stronghold
+            .lock()
+            .await
+            .kill_stronghold(PRIVATE_DATA_CLIENT_PATH.to_vec(), false)
+            .await
+        {
+            ResultMessage::Ok(_) => Ok(()),
+            ResultMessage::Error(err) => Err(crate::Error::StrongholdProcedureError(err)),
+        }
+    }
 }
 
 /// The asynchronous key clearing task purging `key` after `timeout` spent in Tokio.
 async fn task_key_clear(
     task_self: Arc<Mutex<Option<JoinHandle<()>>>>,
+    stronghold: Arc<Mutex<Stronghold>>,
     key: Arc<Mutex<Option<Zeroizing<Vec<u8>>>>>,
     timeout: Duration,
 ) {
@@ -401,6 +447,13 @@ async fn task_key_clear(
     if let Some(mut key) = key.lock().await.take() {
         key.zeroize();
     }
+
+    debug!("StrongholdAdapter is killing Stronghold");
+    stronghold
+        .lock()
+        .await
+        .kill_stronghold(PRIVATE_DATA_CLIENT_PATH.to_vec(), false)
+        .await;
 
     // Take self, but do nothing (we're exiting anyways).
     task_self.lock().await.take();

--- a/src/stronghold/mod.rs
+++ b/src/stronghold/mod.rs
@@ -430,7 +430,11 @@ impl StrongholdAdapter {
         {
             ResultMessage::Ok(_) => Ok(()),
             ResultMessage::Error(err) => Err(crate::Error::StrongholdProcedureError(err)),
-        }
+        }?;
+
+        self.snapshot_loaded = false;
+
+        Ok(())
     }
 }
 

--- a/src/stronghold/mod.rs
+++ b/src/stronghold/mod.rs
@@ -63,7 +63,7 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use derive_builder::Builder;
 use iota_stronghold::{ResultMessage, Stronghold};
-use log::debug;
+use log::{debug, warn};
 use riker::actors::ActorSystem;
 use tokio::{sync::Mutex, task::JoinHandle};
 use zeroize::{Zeroize, Zeroizing};
@@ -279,6 +279,11 @@ impl StrongholdAdapter {
         // Purge the key, setting it to None then.
         if let Some(mut key) = self.key.lock().await.take() {
             key.zeroize();
+        }
+
+        // Unload Stronghold, but we can't do much about the errors.
+        if let Err(err) = self.unload_stronghold_snapshot().await {
+            warn!("failed to unload Stronghold while clearing the key: {err}");
         }
     }
 

--- a/src/stronghold/mod.rs
+++ b/src/stronghold/mod.rs
@@ -276,14 +276,14 @@ impl StrongholdAdapter {
             timeout_task.abort();
         }
 
+        // Unload Stronghold first, but we can't do much about the errors.
+        if let Err(err) = self.unload_stronghold_snapshot().await {
+            warn!("failed to unload Stronghold while clearing the key: {err}");
+        }
+
         // Purge the key, setting it to None then.
         if let Some(mut key) = self.key.lock().await.take() {
             key.zeroize();
-        }
-
-        // Unload Stronghold, but we can't do much about the errors.
-        if let Err(err) = self.unload_stronghold_snapshot().await {
-            warn!("failed to unload Stronghold while clearing the key: {err}");
         }
     }
 

--- a/src/stronghold/mod.rs
+++ b/src/stronghold/mod.rs
@@ -481,7 +481,7 @@ mod tests {
         assert!(matches!(*client.timeout_task.lock().await, Some(_)));
 
         // After the timeout, the key should be purged.
-        tokio::time::sleep(Duration::from_millis(110)).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
         assert!(matches!(*client.key.lock().await, None));
         assert_eq!(client.get_timeout(), Some(timeout));
         assert!(matches!(*client.timeout_task.lock().await, None));

--- a/src/stronghold/secret.rs
+++ b/src/stronghold/secret.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! The [SecretManager] implementation for [StrongholdAdapter].
+//! The [SecretManage] implementation for [StrongholdAdapter].
 
 use std::ops::Range;
 
@@ -151,6 +151,8 @@ impl StrongholdAdapter {
     ) -> Result<()> {
         match self
             .stronghold
+            .lock()
+            .await
             .runtime_exec(Procedure::BIP39Recover {
                 mnemonic,
                 passphrase,
@@ -188,6 +190,8 @@ impl StrongholdAdapter {
     ) -> Result<()> {
         match self
             .stronghold
+            .lock()
+            .await
             .runtime_exec(Procedure::SLIP10Derive {
                 chain,
                 input,
@@ -220,6 +224,8 @@ impl StrongholdAdapter {
     async fn ed25519_public_key(&self, private_key: Location) -> Result<[u8; 32]> {
         match self
             .stronghold
+            .lock()
+            .await
             .runtime_exec(Procedure::Ed25519PublicKey { private_key })
             .await
         {
@@ -245,6 +251,8 @@ impl StrongholdAdapter {
     async fn ed25519_sign(&self, private_key: Location, msg: &[u8]) -> Result<[u8; 64]> {
         match self
             .stronghold
+            .lock()
+            .await
             .runtime_exec(Procedure::Ed25519Sign {
                 private_key,
                 msg: msg.to_vec(),
@@ -294,7 +302,7 @@ impl StrongholdAdapter {
 
         // If the snapshot has successfully been loaded, then we need to check if there has been a
         // mnemonic stored in Stronghold or not to prevent overwriting it.
-        if self.snapshot_loaded && self.stronghold.record_exists(output.clone()).await {
+        if self.snapshot_loaded && self.stronghold.lock().await.record_exists(output.clone()).await {
             return Err(crate::Error::StrongholdMnemonicAlreadyStored);
         }
 

--- a/src/stronghold/secret.rs
+++ b/src/stronghold/secret.rs
@@ -22,7 +22,7 @@ use super::{
 use crate::{
     api::RemainderData,
     secret::{types::InputSigningData, GenerateAddressMetadata, SecretManage},
-    Result,
+    Error, Result,
 };
 
 #[async_trait]
@@ -35,6 +35,15 @@ impl SecretManage for StrongholdAdapter {
         internal: bool,
         _metadata: GenerateAddressMetadata,
     ) -> Result<Vec<Address>> {
+        // Prevent the method from being invoked when the key has been cleared from the memory. Do note that Stronghold
+        // only asks for a key for reading / writing a snapshot, so without our cached key this method is invocable, but
+        // it doesn't make sense when it comes to our user (signing transactions / generating addresses without a key).
+        // Thus, we put an extra guard here to prevent this methods from being invoked when our cached key has
+        // been cleared.
+        if !self.is_key_available().await {
+            return Err(Error::StrongholdKeyCleared);
+        }
+
         // Stronghold arguments.
         let seed_location = SLIP10DeriveInput::Seed(Location::Generic {
             vault_path: SECRET_VAULT_PATH.to_vec(),
@@ -85,6 +94,15 @@ impl SecretManage for StrongholdAdapter {
         essence_hash: &[u8; 32],
         _: &Option<RemainderData>,
     ) -> Result<Unlock> {
+        // Prevent the method from being invoked when the key has been cleared from the memory. Do note that Stronghold
+        // only asks for a key for reading / writing a snapshot, so without our cached key this method is invocable, but
+        // it doesn't make sense when it comes to our user (signing transactions / generating addresses without a key).
+        // Thus, we put an extra guard here to prevent this methods from being invoked when our cached key has
+        // been cleared.
+        if !self.is_key_available().await {
+            return Err(Error::StrongholdKeyCleared);
+        }
+
         // Stronghold arguments.
         let seed_location = SLIP10DeriveInput::Seed(Location::Generic {
             vault_path: SECRET_VAULT_PATH.to_vec(),

--- a/src/stronghold/secret.rs
+++ b/src/stronghold/secret.rs
@@ -337,7 +337,8 @@ mod tests {
         let mut stronghold_adapter = StrongholdAdapter::builder()
             .snapshot_path(stronghold_path.clone())
             .password("drowssap")
-            .build();
+            .try_build()
+            .unwrap();
 
         stronghold_adapter.store_mnemonic(mnemonic).await.unwrap();
 

--- a/src/stronghold/secret.rs
+++ b/src/stronghold/secret.rs
@@ -35,15 +35,6 @@ impl SecretManage for StrongholdAdapter {
         internal: bool,
         _metadata: GenerateAddressMetadata,
     ) -> Result<Vec<Address>> {
-        // Prevent the method from being invoked when the key has been cleared from the memory. Do note that Stronghold
-        // only asks for a key for reading / writing a snapshot, so without our cached key this method is invocable, but
-        // it doesn't make sense when it comes to our user (signing transactions / generating addresses without a key).
-        // Thus, we put an extra guard here to prevent this methods from being invoked when our cached key has
-        // been cleared.
-        if !self.is_key_available().await {
-            return Err(Error::StrongholdKeyCleared);
-        }
-
         // Stronghold arguments.
         let seed_location = SLIP10DeriveInput::Seed(Location::Generic {
             vault_path: SECRET_VAULT_PATH.to_vec(),

--- a/tests/addresses.rs
+++ b/tests/addresses.rs
@@ -194,7 +194,8 @@ async fn address_generation() {
         let mut stronghold_secret_manager = StrongholdSecretManager::builder()
             .password("some_hopefully_secure_password")
             .snapshot_path(PathBuf::from(stronghold_filename.to_string()))
-            .build();
+            .try_build()
+            .unwrap();
 
         stronghold_secret_manager
             .store_mnemonic(address.mnemonic.to_string())

--- a/tests/addresses.rs
+++ b/tests/addresses.rs
@@ -270,6 +270,7 @@ async fn address_generation() {
             let stronghold_filename = format!("{}.stronghold", address.bech32_address);
             let secret_manager_dto = StrongholdDto {
                 password: Some("some_hopefully_secure_password".to_string()),
+                timeout: None,
                 snapshot_path: Some(stronghold_filename.clone()),
             };
             let message_type = MessageType::CallClientMethod(ClientMethod::StoreMnemonic {


### PR DESCRIPTION
This PR adds timeout related methods to `StrongholdAdapter`. `get_timeout()` and `set_timeout()` are added to view and change the key clearing timeout. The task will be automatically spawned in `set_timeout()` if a new timeout is provided and key is still in the memory. `restart_key_timeout()` is also added as a shortcut of refreshing the count down by setting the same timeout again.

Fix #996.