### PR TITLE
Add and use SignedTransactionData for offline signing

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -4,7 +4,13 @@
 use bee_message::{
     address::{dto::AddressDto, Address},
     output::{dto::OutputDto, Output},
-    payload::transaction::{dto::TransactionEssenceDto, TransactionEssence},
+    payload::{
+        transaction::{
+            dto::{TransactionEssenceDto, TransactionPayloadDto},
+            TransactionEssence,
+        },
+        TransactionPayload,
+    },
     DtoError,
 };
 
@@ -23,6 +29,96 @@ pub struct PreparedTransactionData {
     pub inputs_data: Vec<InputSigningData>,
     /// Optional remainder output information
     pub remainder: Option<RemainderData>,
+}
+
+/// PreparedTransactionData Dto
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreparedTransactionDataDto {
+    /// Transaction essence
+    pub essence: TransactionEssenceDto,
+    /// Required address information for signing
+    #[serde(rename = "inputsData")]
+    pub inputs_data: Vec<InputSigningDataDto>,
+    /// Optional remainder output information
+    pub remainder: Option<RemainderDataDto>,
+}
+
+impl From<&PreparedTransactionData> for PreparedTransactionDataDto {
+    fn from(value: &PreparedTransactionData) -> Self {
+        PreparedTransactionDataDto {
+            essence: TransactionEssenceDto::from(&value.essence),
+            inputs_data: value.inputs_data.iter().map(InputSigningDataDto::from).collect(),
+            remainder: value.remainder.as_ref().map(RemainderDataDto::from),
+        }
+    }
+}
+
+impl TryFrom<&PreparedTransactionDataDto> for PreparedTransactionData {
+    type Error = DtoError;
+    fn try_from(value: &PreparedTransactionDataDto) -> Result<Self, Self::Error> {
+        Ok(PreparedTransactionData {
+            essence: TransactionEssence::try_from(&value.essence).map_err(|_| DtoError::InvalidField("essence"))?,
+            inputs_data: value
+                .inputs_data
+                .iter()
+                .map(InputSigningData::try_from)
+                .collect::<crate::Result<Vec<InputSigningData>>>()
+                .map_err(|_| DtoError::InvalidField("input_data"))?,
+            remainder: match &value.remainder {
+                Some(remainder) => {
+                    Some(RemainderData::try_from(remainder).map_err(|_| DtoError::InvalidField("remainder"))?)
+                }
+                None => None,
+            },
+        })
+    }
+}
+
+/// Helper struct for offline signing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignedTransactionData {
+    /// Signed transaction payload
+    #[serde(rename = "transactionPayload")]
+    pub transaction_payload: TransactionPayload,
+    /// Required address information for signing
+    #[serde(rename = "inputsData")]
+    pub inputs_data: Vec<InputSigningData>,
+}
+
+/// SignedTransactionData Dto
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignedTransactionDataDto {
+    /// Transaction essence
+    #[serde(rename = "transactionPayload")]
+    pub transaction_payload: TransactionPayloadDto,
+    /// Required address information for signing
+    #[serde(rename = "inputsData")]
+    pub inputs_data: Vec<InputSigningDataDto>,
+}
+
+impl From<&SignedTransactionData> for SignedTransactionDataDto {
+    fn from(value: &SignedTransactionData) -> Self {
+        SignedTransactionDataDto {
+            transaction_payload: TransactionPayloadDto::from(&value.transaction_payload),
+            inputs_data: value.inputs_data.iter().map(InputSigningDataDto::from).collect(),
+        }
+    }
+}
+
+impl TryFrom<&SignedTransactionDataDto> for SignedTransactionData {
+    type Error = DtoError;
+    fn try_from(value: &SignedTransactionDataDto) -> Result<Self, Self::Error> {
+        Ok(SignedTransactionData {
+            transaction_payload: TransactionPayload::try_from(&value.transaction_payload)
+                .map_err(|_| DtoError::InvalidField("transaction_payload"))?,
+            inputs_data: value
+                .inputs_data
+                .iter()
+                .map(InputSigningData::try_from)
+                .collect::<crate::Result<Vec<InputSigningData>>>()
+                .map_err(|_| DtoError::InvalidField("input_data"))?,
+        })
+    }
 }
 
 /// Data for a remainder output, used for ledger nano
@@ -65,48 +161,6 @@ impl From<&RemainderData> for RemainderDataDto {
             chain: remainder.chain.clone(),
             address: AddressDto::from(&remainder.address),
         }
-    }
-}
-
-/// PreparedTransactionData Dto
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PreparedTransactionDataDto {
-    /// Transaction essence
-    pub essence: TransactionEssenceDto,
-    /// Required address information for signing
-    pub inputs_data: Vec<InputSigningDataDto>,
-    /// Optional remainder output information
-    pub remainder: Option<RemainderDataDto>,
-}
-
-impl From<&PreparedTransactionData> for PreparedTransactionDataDto {
-    fn from(value: &PreparedTransactionData) -> Self {
-        PreparedTransactionDataDto {
-            essence: TransactionEssenceDto::from(&value.essence),
-            inputs_data: value.inputs_data.iter().map(InputSigningDataDto::from).collect(),
-            remainder: value.remainder.as_ref().map(RemainderDataDto::from),
-        }
-    }
-}
-
-impl TryFrom<&PreparedTransactionDataDto> for PreparedTransactionData {
-    type Error = DtoError;
-    fn try_from(value: &PreparedTransactionDataDto) -> Result<Self, Self::Error> {
-        Ok(PreparedTransactionData {
-            essence: TransactionEssence::try_from(&value.essence).map_err(|_| DtoError::InvalidField("essence"))?,
-            inputs_data: value
-                .inputs_data
-                .iter()
-                .map(InputSigningData::try_from)
-                .collect::<crate::Result<Vec<InputSigningData>>>()
-                .map_err(|_| DtoError::InvalidField("input_data"))?,
-            remainder: match &value.remainder {
-                Some(remainder) => {
-                    Some(RemainderData::try_from(remainder).map_err(|_| DtoError::InvalidField("remainder"))?)
-                }
-                None => None,
-            },
-        })
     }
 }
 


### PR DESCRIPTION
# Description of change

Add and use SignedTransactionData for offline signing so we don't have to keep track of the PreparedTransactionData and the signed TransactionPayload separated

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

With the offline signing examples

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
