### PR TITLE
Add checks to set_password() and update Stronghold example

### DIFF
--- a/examples/00_mnemonic.rs
+++ b/examples/00_mnemonic.rs
@@ -5,7 +5,7 @@
 
 use iota_client::{
     api::GetAddressesBuilder,
-    constants::SHIMMER_COIN_TYPE,
+    constants::{SHIMMER_COIN_TYPE, SHIMMER_TESTNET_BECH32_HRP},
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     Client, Result,
 };
@@ -22,6 +22,7 @@ async fn main() -> Result<()> {
 
     // Generate addresses with custom account index and range
     let addresses = GetAddressesBuilder::new(&secret_manager)
+        .with_bech32_hrp(SHIMMER_TESTNET_BECH32_HRP)
         .with_coin_type(SHIMMER_COIN_TYPE)
         .with_account_index(0)
         .with_range(0..1)

--- a/examples/stronghold.rs
+++ b/examples/stronghold.rs
@@ -7,21 +7,15 @@ use std::{env, path::PathBuf};
 
 use dotenv::dotenv;
 use iota_client::{
+    api::GetAddressesBuilder,
+    constants::{SHIMMER_COIN_TYPE, SHIMMER_TESTNET_BECH32_HRP},
     secret::{stronghold::StrongholdSecretManager, SecretManager},
-    Client, Result,
+    Result,
 };
-
-/// In this example we will create addresses with a stronghold secret manager
+/// In this example we will create an address with a stronghold secret manager
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Create a client instance
-    let client = Client::builder()
-        .with_node("http://localhost:14265")? // Insert your node URL here
-        .with_node_sync_disabled()
-        .finish()
-        .await?;
-
     let mut stronghold_secret_manager = StrongholdSecretManager::builder()
         .password("some_hopefully_secure_password")
         .snapshot_path(PathBuf::from("test.stronghold"))
@@ -34,14 +28,15 @@ async fn main() -> Result<()> {
     stronghold_secret_manager.store_mnemonic(mnemonic).await.unwrap();
 
     // Generate addresses with custom account index and range
-    let addresses = client
-        .get_addresses(&SecretManager::Stronghold(stronghold_secret_manager))
+    let addresses = GetAddressesBuilder::new(&SecretManager::Stronghold(stronghold_secret_manager))
+        .with_bech32_hrp(SHIMMER_TESTNET_BECH32_HRP)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_account_index(0)
-        .with_range(0..2)
+        .with_range(0..1)
         .finish()
         .await?;
 
-    println!("List of generated public addresses:\n{:?}\n", addresses);
+    println!("First public address: {}", addresses[0]);
 
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -218,6 +218,10 @@ pub enum Error {
     #[cfg(feature = "stronghold")]
     #[error("a mnemonic has already been stored in the Stronghold vault")]
     StrongholdMnemonicAlreadyStored,
+    /// A password has already been set
+    #[cfg(feature = "stronghold")]
+    #[error("a password has already been set")]
+    StrongholdPasswordAlreadySet,
     /// No password has been supplied to a Stronghold vault, or it has been cleared
     #[cfg(feature = "stronghold")]
     #[error("no password has been supplied, or the key has been cleared from the memory")]


### PR DESCRIPTION
# Description of change

Add checks to set_password(), to prevent setting a wrong password
Update Stronghold example so it work without a node

## Links to any relevant issues

Related to https://github.com/iotaledger/wallet.rs/issues/1087

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

With the added test and with the example

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
