### PR TITLE
Include native tokens when consolidating funds

### DIFF
--- a/src/api/consolidation.rs
+++ b/src/api/consolidation.rs
@@ -88,7 +88,7 @@ pub async fn consolidate_funds(
                         input.metadata.output_index,
                     )?))?;
 
-                    let output: Output = (&input.output).try_into()?;
+                    let output = Output::try_from(&input.output)?;
 
                     if let Some(native_tokens) = output.native_tokens() {
                         total_native_tokens.add_native_tokens(native_tokens.clone())?;
@@ -96,13 +96,11 @@ pub async fn consolidate_funds(
                     total_amount += amount;
                 }
 
-                let total_native_tokens = total_native_tokens.finish()?;
-
                 let consolidation_output = BasicOutputBuilder::new_with_amount(total_amount)?
                     .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
                         Address::try_from_bech32(&consolidation_address)?.1,
                     )))
-                    .with_native_tokens(total_native_tokens)
+                    .with_native_tokens(total_native_tokens.finish()?)
                     .finish_output()?;
 
                 let block = block_builder


### PR DESCRIPTION
# Description of change

Added a `NativeTokensBuilder` to `consolidate_funds`, to include native tokens from the `address_range` in the consolidated funds.

## Links to any relevant issues

Fixes issue #1038.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested with examples. I generated a mnemonic and added funds and tokens to a range of addresses using the `foundry` example. I then consolidated the funds and native tokens using the `consolidation` example. I checked the address balances before and after consolidation using the `02_get_address_balance` example.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
