### PR TITLE
Add ED25519 check for remainder address

### DIFF
--- a/src/api/block_builder/input_selection/remainder.rs
+++ b/src/api/block_builder/input_selection/remainder.rs
@@ -88,27 +88,19 @@ pub(crate) async fn get_remainder_output<'a>(
 }
 
 // Get an Ed25519 address from the inputs as remainder address
-// We don't want to use nft or alias addresses as remainder address, because we might can't control them later
+// We don't want to use nft or alias addresses as remainder address, because we might not be able to control them later
 pub(crate) fn get_remainder_address<'a>(
     inputs: impl Iterator<Item = &'a InputSigningData>,
 ) -> Result<(Address, Option<Chain>)> {
-    // get address from an input, by default we only allow ed25519 addresses as remainder, because then we're sure that
-    // the sender can access it
-    let mut address = None;
-    'outer: for input in inputs {
-        if let Some(unlock_conditions) = input.output.unlock_conditions() {
-            for unlock_condition in unlock_conditions.iter() {
-                if let UnlockCondition::Address(address_unlock_condition) = unlock_condition {
-                    address.replace((*address_unlock_condition.address(), input.chain.clone()));
-                    break 'outer;
-                }
+    for input in inputs {
+        if let Some(address_unlock_condition) = input.output.unlock_conditions().and_then(|o| o.address()) {
+            if address_unlock_condition.address().is_ed25519() {
+                return Ok((*address_unlock_condition.address(), input.chain.clone()));
             }
         }
     }
-    match address {
-        Some(addr) => Ok(addr),
-        None => Err(Error::MissingInputWithEd25519UnlockCondition),
-    }
+
+    Err(Error::MissingInputWithEd25519UnlockCondition)
 }
 
 // Get additional required storage deposit amount for the remainder output


### PR DESCRIPTION
Also fixes https://github.com/iotaledger/iota.rs/issues/1074 as it was the only method used from the unlock conditions.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
