### PR TITLE
Remove logger methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,17 +132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dcfa7026c8fa43fa767bff0b7cd4d1963cdfd946e0386bee93003e9b2498562"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,17 +437,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,29 +719,6 @@ name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
-
-[[package]]
-name = "fern"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd7b0849075e79ee9a1836df22c717d1eba30451796fdc631b04565dd11e2a"
-dependencies = [
- "colored",
- "log",
-]
-
-[[package]]
-name = "fern-logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d72fcbd7f804f2dcb89b295dfdfeff1a81338b1960387a45261f857ddc553a9f"
-dependencies = [
- "fern",
- "log",
- "serde",
- "thiserror",
- "time-helper",
-]
 
 [[package]]
 name = "fixed-hash"
@@ -1202,7 +1157,6 @@ dependencies = [
  "bee-ternary",
  "derive_builder",
  "dotenv",
- "fern-logger",
  "futures",
  "gloo-timers",
  "hex",
@@ -1396,7 +1350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ bee-block = { git = "https://github.com/iotaledger/bee", rev = "3b66992a29ca6d44
 bee-rest-api = { git = "https://github.com/iotaledger/bee", rev = "3b66992a29ca6d4434a3af08562b197b14c21541", default-features = false }
 bee-pow = { git = "https://github.com/iotaledger/bee", rev = "3b66992a29ca6d4434a3af08562b197b14c21541", default-features = false }
 derive_builder = { version = "0.11.2", default-features = false, features = [ "std" ]}
-fern-logger = { version = "0.5.0", default-features = false }
 futures = { version = "0.3.21", default-features = false, features = [ "thread-pool" ] }
 hex = { version = "0.4.3", default-features = false }
 iota-crypto = { version = "0.12.1", default-features = false, features = [ "std", "chacha", "blake2b", "ed25519", "random", "slip10", "bip39", "bip39-en" ] }

--- a/examples/outputs/all.rs
+++ b/examples/outputs/all.rs
@@ -44,7 +44,6 @@ async fn main() -> Result<()> {
     let client = Client::builder()
         .with_node(&node_url)?
         .with_node_sync_disabled()
-        .with_default_logger()?
         .finish()
         .await?;
 

--- a/examples/outputs/all_automatic_input_selection.rs
+++ b/examples/outputs/all_automatic_input_selection.rs
@@ -43,7 +43,6 @@ async fn main() -> Result<()> {
     let client = Client::builder()
         .with_node(&node_url)?
         .with_node_sync_disabled()
-        .with_default_logger()?
         .finish()
         .await?;
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use bee_rest_api::types::responses::RentStructureResponse;
-use log::LevelFilter;
 #[cfg(not(target_family = "wasm"))]
 use {
     std::collections::HashSet,
@@ -326,18 +325,6 @@ impl ClientBuilder {
     pub fn with_remote_pow_timeout(mut self, timeout: Duration) -> Self {
         self.remote_pow_timeout = timeout;
         self
-    }
-
-    /// Enables the default logger which writes debug logs to "iota.rs.log"
-    pub fn with_default_logger(self) -> Result<Self> {
-        crate::init_logger("iota.rs.log", LevelFilter::Debug)?;
-        Ok(self)
-    }
-
-    /// Write logs to a file
-    pub fn with_logger(self, filename: &str, level: LevelFilter) -> Result<Self> {
-        crate::init_logger(filename, level)?;
-        Ok(self)
     }
 
     /// Build the Client instance.

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,10 +86,6 @@ pub enum Error {
     #[error("{0}")]
     #[serde(serialize_with = "display_string")]
     FromHexError(#[from] hex::FromHexError),
-    /// Logger error
-    #[error("{0}")]
-    #[serde(serialize_with = "display_string")]
-    LoggerError(#[from] fern_logger::Error),
     /// Block types error
     #[error("{0}")]
     #[serde(serialize_with = "display_string")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,6 @@ pub use bee_block;
 pub use bee_pow as pow;
 pub use bee_rest_api;
 pub use crypto::{self, keys::slip10::Seed};
-pub use fern_logger as logger;
 pub use packable;
 pub use url::Url;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,8 +11,6 @@ use crypto::{
     keys::{bip39::wordlist, slip10::Seed},
     utils,
 };
-use fern_logger::{logger_init, LoggerConfig, LoggerOutputConfigBuilder};
-use log::LevelFilter;
 use zeroize::Zeroize;
 
 use crate::error::{Error, Result};
@@ -107,14 +105,4 @@ pub async fn request_funds_from_faucet(url: &str, bech32_address: &str) -> Resul
     let client = reqwest::Client::new();
     let faucet_response = client.post(url).json(&map).send().await?.text().await?;
     Ok(faucet_response)
-}
-
-/// creates a file in which logs will be written in
-pub fn init_logger(filename: &str, levelfilter: LevelFilter) -> crate::Result<()> {
-    let output_config = LoggerOutputConfigBuilder::new()
-        .name(filename)
-        .level_filter(levelfilter);
-    let config = LoggerConfig::build().with_output(output_config).finish();
-    logger_init(config)?;
-    Ok(())
 }


### PR DESCRIPTION
# Description of change

Remove logger methods since it's not library specific and users can just call the fern_logger methods themselves

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
