### PR TITLE
Add get_storage_deposit_return_outputs()

### DIFF
--- a/src/api/block_builder/input_selection/automatic.rs
+++ b/src/api/block_builder/input_selection/automatic.rs
@@ -89,6 +89,8 @@ pub(crate) async fn get_inputs(
     let (force_use_all_inputs, required_ed25519_inputs) = get_inputs_for_sender_and_issuer(block_builder).await?;
     available_inputs.extend(required_ed25519_inputs.into_iter());
 
+    let local_time = block_builder.client.get_time_checked().await?;
+
     // Try to select inputs with required inputs for utxo chains alone before requesting more inputs from addresses
     if let Ok(selected_transaction_data) = try_select_inputs(
         available_inputs.clone(),
@@ -99,6 +101,7 @@ pub(crate) async fn get_inputs(
         // Don't allow burning of native tokens during automatic input selection, because otherwise it
         // could lead to burned native tokens by accident
         false,
+        local_time,
     )
     .await
     {
@@ -145,7 +148,6 @@ pub(crate) async fn get_inputs(
                 // Reset counter if there is an output
                 empty_address_count = 0;
 
-                let local_time = block_builder.client.get_time_checked().await?;
                 for output_response in address_outputs {
                     let output = Output::try_from(&output_response.output)?;
                     let address = Address::try_from_bech32(str_address)?.1;
@@ -174,6 +176,7 @@ pub(crate) async fn get_inputs(
                     // Don't allow burning of native tokens during automatic input selection, because otherwise it
                     // could lead to burned native tokens by accident
                     false,
+                    local_time,
                 )
                 .await
                 {

--- a/src/api/block_builder/input_selection/manual.rs
+++ b/src/api/block_builder/input_selection/manual.rs
@@ -35,9 +35,8 @@ pub(crate) async fn get_custom_inputs(
     log::debug!("[get_custom_inputs]");
     let mut inputs_data = Vec::new();
 
+    let local_time = block_builder.client.get_time_checked().await?;
     if let Some(inputs) = &block_builder.inputs {
-        let local_time = block_builder.client.get_time_checked().await?;
-
         for input in inputs {
             let output_response = block_builder.client.get_output(input.output_id()).await?;
             let output = Output::try_from(&output_response.output)?;
@@ -92,6 +91,7 @@ pub(crate) async fn get_custom_inputs(
         block_builder.custom_remainder_address,
         byte_cost_config,
         allow_burning,
+        local_time,
     )
     .await?;
     Ok(selected_transaction_data)

--- a/src/api/block_builder/input_selection/remainder.rs
+++ b/src/api/block_builder/input_selection/remainder.rs
@@ -34,16 +34,7 @@ pub(crate) fn get_storage_deposit_return_outputs<'a>(
     log::debug!("[get_storage_deposit_return_outputs]");
 
     // Get inputs with storage deposit return unlock condition that are not expired
-    let inputs_sdr = inputs
-        .filter(|i| sdr_not_expired(&i.output, current_time).is_some())
-        // Safe to unwrap since we only return outputs with a sdr when filtering with sdr_not_expired()
-        .map(|i| {
-            i.output
-                .unlock_conditions()
-                .expect("Output need to have unlock conditions")
-                .storage_deposit_return()
-                .expect("Output needs to have a sdr")
-        });
+    let inputs_sdr = inputs.filter_map(|i| sdr_not_expired(&i.output, current_time));
 
     // There could be multiple sdr outputs required for the same address, so we keep track of the required amount here.
     let mut required_address_returns: HashMap<Address, u64> = HashMap::new();


### PR DESCRIPTION
# Description of change

Add get_storage_deposit_return_outputs(), because this wasn't handled before
Add sdr amounts to the required amounts, so we select enough inputs
Also changed the dedup of inputs, because we could get the same output with multiple addresses

## Links to any relevant issues

Fixes #1082 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
