### PR TITLE
Remove some defaults from NetworkInfo

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -18,9 +18,7 @@ use {
 use crate::node_api::mqtt::{BrokerOptions, MqttEvent};
 use crate::{
     client::Client,
-    constants::{
-        DEFAULT_API_TIMEOUT, DEFAULT_REMOTE_POW_API_TIMEOUT, DEFAULT_TIPS_INTERVAL, SHIMMER_TESTNET_BECH32_HRP,
-    },
+    constants::{DEFAULT_API_TIMEOUT, DEFAULT_REMOTE_POW_API_TIMEOUT, DEFAULT_TIPS_INTERVAL},
     error::{Error, Result},
     node_manager::{
         builder::validate_url,
@@ -37,8 +35,8 @@ pub struct NetworkInfo {
     #[serde(rename = "networkId")]
     pub network_id: Option<u64>,
     /// Bech32 HRP
-    #[serde(rename = "bech32HRP", default = "default_bech32_hrp")]
-    pub bech32_hrp: String,
+    #[serde(rename = "bech32HRP", default)]
+    pub bech32_hrp: Option<String>,
     /// Mininum proof of work score
     #[serde(rename = "minPoWScore", default)]
     pub min_pow_score: Option<f64>,
@@ -54,10 +52,6 @@ pub struct NetworkInfo {
     /// Rent structure of the protocol
     #[serde(rename = "rentStructure", default)]
     pub rent_structure: Option<RentStructureResponse>,
-}
-
-fn default_bech32_hrp() -> String {
-    SHIMMER_TESTNET_BECH32_HRP.into()
 }
 
 fn default_local_pow() -> bool {
@@ -124,7 +118,7 @@ impl Default for NetworkInfo {
             min_pow_score: None,
             local_pow: default_local_pow(),
             fallback_to_local_pow: true,
-            bech32_hrp: SHIMMER_TESTNET_BECH32_HRP.into(),
+            bech32_hrp: None,
             tips_interval: DEFAULT_TIPS_INTERVAL,
             rent_structure: None,
         }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -19,8 +19,7 @@ use crate::node_api::mqtt::{BrokerOptions, MqttEvent};
 use crate::{
     client::Client,
     constants::{
-        DEFAULT_API_TIMEOUT, DEFAULT_MIN_POW, DEFAULT_REMOTE_POW_API_TIMEOUT, DEFAULT_TIPS_INTERVAL,
-        SHIMMER_TESTNET_BECH32_HRP,
+        DEFAULT_API_TIMEOUT, DEFAULT_REMOTE_POW_API_TIMEOUT, DEFAULT_TIPS_INTERVAL, SHIMMER_TESTNET_BECH32_HRP,
     },
     error::{Error, Result},
     node_manager::{
@@ -41,8 +40,8 @@ pub struct NetworkInfo {
     #[serde(rename = "bech32HRP", default = "default_bech32_hrp")]
     pub bech32_hrp: String,
     /// Mininum proof of work score
-    #[serde(rename = "minPoWScore", default = "default_min_pow_score")]
-    pub min_pow_score: f64,
+    #[serde(rename = "minPoWScore", default)]
+    pub min_pow_score: Option<f64>,
     /// Local proof of work
     #[serde(rename = "localPow", default = "default_local_pow")]
     pub local_pow: bool,
@@ -53,22 +52,12 @@ pub struct NetworkInfo {
     #[serde(rename = "tipsInterval", default = "default_tips_interval")]
     pub tips_interval: u64,
     /// Rent structure of the protocol
-    #[serde(rename = "rentStructure", default = "default_rent_structure")]
-    pub rent_structure: RentStructureResponse,
+    #[serde(rename = "rentStructure", default)]
+    pub rent_structure: Option<RentStructureResponse>,
 }
 
 fn default_bech32_hrp() -> String {
     SHIMMER_TESTNET_BECH32_HRP.into()
-}
-fn default_min_pow_score() -> f64 {
-    DEFAULT_MIN_POW
-}
-fn default_rent_structure() -> RentStructureResponse {
-    RentStructureResponse {
-        v_byte_cost: 500,
-        v_byte_factor_data: 1,
-        v_byte_factor_key: 10,
-    }
 }
 
 fn default_local_pow() -> bool {
@@ -132,12 +121,12 @@ impl Default for NetworkInfo {
         Self {
             network: None,
             network_id: None,
-            min_pow_score: DEFAULT_MIN_POW,
+            min_pow_score: None,
             local_pow: default_local_pow(),
             fallback_to_local_pow: true,
             bech32_hrp: SHIMMER_TESTNET_BECH32_HRP.into(),
             tips_interval: DEFAULT_TIPS_INTERVAL,
-            rent_structure: default_rent_structure(),
+            rent_structure: None,
         }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -232,7 +232,7 @@ impl Client {
                     client_network_info.network_id = hash_network(&info.protocol.network_name).ok();
                     // todo update protocol version
                     client_network_info.min_pow_score = Some(info.protocol.min_pow_score);
-                    client_network_info.bech32_hrp = info.protocol.bech32_hrp.clone();
+                    client_network_info.bech32_hrp = Some(info.protocol.bech32_hrp.clone());
                     client_network_info.rent_structure = Some(info.protocol.rent_structure.clone());
                     if !client_network_info.local_pow {
                         if info.features.contains(&"PoW".to_string()) {
@@ -280,7 +280,7 @@ impl Client {
             let network_id = hash_network(&info.protocol.network_name).ok();
             {
                 let mut client_network_info = self.network_info.write().map_err(|_| crate::Error::PoisonError)?;
-                client_network_info.bech32_hrp = info.protocol.bech32_hrp;
+                client_network_info.bech32_hrp = Some(info.protocol.bech32_hrp);
                 client_network_info.min_pow_score = Some(info.protocol.min_pow_score);
                 client_network_info.network_id = network_id;
                 client_network_info.rent_structure = Some(info.protocol.rent_structure);
@@ -303,16 +303,22 @@ impl Client {
 
     /// returns the bech32_hrp
     pub async fn get_bech32_hrp(&self) -> Result<String> {
-        Ok(self.get_network_info().await?.bech32_hrp)
+        let bech32_hrp = match self.get_network_info().await?.bech32_hrp {
+            Some(hrp) => hrp,
+            None => self.get_info().await?.node_info.protocol.bech32_hrp,
+        };
+
+        Ok(bech32_hrp)
     }
 
     /// returns the min pow score
     pub async fn get_min_pow_score(&self) -> Result<f64> {
-        Ok(self
-            .get_network_info()
-            .await?
-            .min_pow_score
-            .unwrap_or(self.get_info().await?.node_info.protocol.min_pow_score))
+        let min_pow_score = match self.get_network_info().await?.min_pow_score {
+            Some(min_pow_score) => min_pow_score,
+            None => self.get_info().await?.node_info.protocol.min_pow_score,
+        };
+
+        Ok(min_pow_score)
     }
 
     /// returns the tips interval
@@ -331,11 +337,11 @@ impl Client {
 
     /// returns the byte cost configuration
     pub async fn get_byte_cost_config(&self) -> Result<ByteCostConfig> {
-        let rent_structure = self
-            .get_network_info()
-            .await?
-            .rent_structure
-            .unwrap_or(self.get_info().await?.node_info.protocol.rent_structure);
+        let rent_structure = match self.get_network_info().await?.rent_structure {
+            Some(rent_structure) => rent_structure,
+            None => self.get_info().await?.node_info.protocol.rent_structure,
+        };
+
         let byte_cost_config = ByteCostConfigBuilder::new()
             .byte_cost(rent_structure.v_byte_cost)
             .key_factor(rent_structure.v_byte_factor_key)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -11,7 +11,6 @@ pub(crate) const DEFAULT_REMOTE_POW_API_TIMEOUT: Duration = Duration::from_secs(
 /// Interval in seconds when new tips will be requested during PoW, so the final block always will be attached to a
 /// new part of the Tangle
 pub(crate) const DEFAULT_TIPS_INTERVAL: u64 = 15;
-pub(crate) const DEFAULT_MIN_POW: f64 = 4000f64;
 /// Interval in which the nodeinfo will be requested and healty nodes will be added to the synced node pool
 pub(crate) const NODE_SYNC_INTERVAL: Duration = Duration::from_secs(60);
 pub(crate) const DEFAULT_MIN_QUORUM_SIZE: usize = 3;


### PR DESCRIPTION
# Description of change

Remove some defaults from NetworkInfo so they will not be used even if we have node sync disabled.

Should we update the NetworkInfo after we got something once, to reduce the necessary requests?

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
