### PR TITLE
Reduce DEFAULT_TIPS_INTERVAL

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,7 +10,7 @@ pub(crate) const DEFAULT_API_TIMEOUT: Duration = Duration::from_secs(15);
 pub(crate) const DEFAULT_REMOTE_POW_API_TIMEOUT: Duration = Duration::from_secs(100);
 /// Interval in seconds when new tips will be requested during PoW, so the final block always will be attached to a
 /// new part of the Tangle
-pub(crate) const DEFAULT_TIPS_INTERVAL: u64 = 15;
+pub(crate) const DEFAULT_TIPS_INTERVAL: u64 = 5;
 /// Interval in which the nodeinfo will be requested and healty nodes will be added to the synced node pool
 pub(crate) const NODE_SYNC_INTERVAL: Duration = Duration::from_secs(60);
 pub(crate) const DEFAULT_MIN_QUORUM_SIZE: usize = 3;


### PR DESCRIPTION
Reduce DEFAULT_TIPS_INTERVAL, because with a milestone interval of 1 and below max depth of 15, the 15 seconds could already create blocks with parents block ids, that are too old