### PR TITLE
Fix Wasm proof-of-work, time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased - YYYY-MM-DD
 
+### Added
+
+- Add `SingleThreadedMiner`, `SingleThreadedMinerBuilder` for Wasm;
+
 ### Changed
 
 - Use NativeTokensBuilder::finish_vec to lift some unnecessary 64 Native Tokens limits;
+- Change `Client::get_pow_provider()` to return `SingleThreadedMiner` on Wasm, otherwise `ClientMiner`, to fix `promote`, `reattach`, and `retry_until_included` for Wasm;
+- Change `ClientMinerBuilder::default()` to match `new()` and default `local_pow` to `true`;
+- Rename `finish_pow` to `finish_multi_threaded_pow`;
+- Rename `finish_single_thread_pow` to `finish_single_threaded_pow`;
+
+### Fixed
+
+- Fix `Client::get_time_checked()` panic on Wasm.
+- Fix `Client::get_pow_provider()` not using the `worker_count`.
 
 ## 2.0.0-beta.1 - 2022-08-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,50 +155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "axum"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9496f0c1d1afb7a2af4338bbe1d969cddfead41d87a9fb3aaa6d0bbc7af648"
-dependencies = [
- "async-trait",
- "axum-core",
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,11 +189,10 @@ checksum = "c5738be7561b0eeb501ef1d5c5db3f24e01ceb55fededd9b00039aada34966ad"
 
 [[package]]
 name = "bee-api-types"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8c1d70108dde51cd3e3877248b4f302de4913e410c70f56ce2e267d54ed16a"
+checksum = "3434e02f5f8c8f4908c67f4894103977755aa52efb4050fb4d922b9dceb71eb4"
 dependencies = [
- "axum",
  "bee-block",
  "bee-ledger-types",
  "serde",
@@ -246,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "bee-block"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400e3fbac56e7c7e4d69af820f18a02e4ee89d8cf52a5b2e267b0b9d2d85d7f7"
+checksum = "6cb8c012aa282cc0477dc59540fcb137b3168360a089ece506a2f7a8cdf4a4e6"
 dependencies = [
  "bech32 0.9.0",
  "bee-pow",
@@ -272,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "bee-ledger-types"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71691001d120a2dc1223b1330fedf84fe3e09c121eb18940d9aec2954c08343"
+checksum = "7ac5191caacaeceb7551d94cc83e1840eaa4252112bd3aa884660cecc37161a5"
 dependencies = [
  "bee-block",
  "packable",
@@ -382,9 +337,9 @@ checksum = "87c5fdd0166095e1d463fc6cc01aa8ce547ad77a4e84d42eb6762b084e28067e"
 
 [[package]]
 name = "bytemuck"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53dfa917ec274df8ed3c572698f381a24eef2efba9492d797301b72b6db408a"
+checksum = "a5377c8865e74a160d21f29c2d40669f53286db6eab59b88540cbb12ffc8b835"
 
 [[package]]
 name = "byteorder"
@@ -1061,12 +1016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
-
-[[package]]
 name = "httparse"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,12 +1365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
-name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,26 +1538,6 @@ checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
  "rustc_version",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2244,12 +2167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
-
-[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,47 +2305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
-
-[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,7 +2317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if",
- "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,50 +155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "axum"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de18bc5f2e9df8f52da03856bf40e29b747de5a84e43aefff90e3dc4a21529b"
-dependencies = [
- "async-trait",
- "axum-core",
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,11 +189,10 @@ checksum = "c5738be7561b0eeb501ef1d5c5db3f24e01ceb55fededd9b00039aada34966ad"
 
 [[package]]
 name = "bee-api-types"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8c1d70108dde51cd3e3877248b4f302de4913e410c70f56ce2e267d54ed16a"
+checksum = "3434e02f5f8c8f4908c67f4894103977755aa52efb4050fb4d922b9dceb71eb4"
 dependencies = [
- "axum",
  "bee-block",
  "bee-ledger-types",
  "serde",
@@ -272,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "bee-ledger-types"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71691001d120a2dc1223b1330fedf84fe3e09c121eb18940d9aec2954c08343"
+checksum = "7ac5191caacaeceb7551d94cc83e1840eaa4252112bd3aa884660cecc37161a5"
 dependencies = [
  "bee-block",
  "packable",
@@ -1061,12 +1016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
-
-[[package]]
 name = "httparse"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,12 +1365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
-name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,26 +1538,6 @@ checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
  "rustc_version",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2244,12 +2167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
-
-[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,47 +2305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
-
-[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,7 +2317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if",
- "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ categories = [ "cryptography::cryptocurrencies" ]
 
 [dependencies]
 async-trait = { version = "0.1.57", default-features = false }
-bee-api-types = { version = "1.0.0-beta.4", default-features = false }
-bee-block = { version = "1.0.0-beta.5", default-features = false, features = [ "serde", "dto", "std" ] }
+bee-api-types = { version = "1.0.0-beta.5", default-features = false }
+bee-block = { version = "1.0.0-beta.6", default-features = false, features = [ "serde", "dto", "std" ] }
 bee-pow = { version = "1.0.0-alpha.1", default-features = false }
 derive_builder = { version = "0.11.2", default-features = false, features = [ "std" ]}
 futures = { version = "0.3.21", default-features = false, features = [ "thread-pool" ] }
@@ -51,11 +51,11 @@ tokio = { version = "1.20.1", default-features = false, features = [ "macros", "
 [target.'cfg(target_family = "wasm")'.dependencies]
 instant = { version = "0.1.12", default-features = false }
 gloo-timers = { version = "0.2.4", default-features = false, features = [ "futures" ] }
-# single thread pow for wasm
+# Single-threaded PoW for Wasm.
 bee-ternary = { version = "1.0.0-alpha.1", default-features = false }
 
 [dev-dependencies]
-bee-block = { version = "1.0.0-beta.5", default-features = false, features = [ "rand" ] }
+bee-block = { version = "1.0.0-beta.6", default-features = false, features = [ "rand" ] }
 dotenv = { version = "0.15.0", default-features = false }
 fern-logger = { version = "0.5.0", default-features = false }
 

--- a/src/api/block_builder/pow/miner.rs
+++ b/src/api/block_builder/pow/miner.rs
@@ -9,7 +9,6 @@ use bee_pow::providers::{
 };
 
 /// The miner builder.
-#[derive(Default)]
 #[must_use]
 pub struct ClientMinerBuilder {
     local_pow: bool,
@@ -35,13 +34,20 @@ impl ClientMinerBuilder {
     }
 }
 
+impl Default for ClientMinerBuilder {
+    fn default() -> Self {
+        ClientMinerBuilder::new()
+    }
+}
+
 impl NonceProviderBuilder for ClientMinerBuilder {
     type Provider = ClientMiner;
 
     fn new() -> Self {
         Self {
             worker_count: num_cpus::get(),
-            ..Default::default()
+            local_pow: true,
+            cancel: MinerCancel::default(),
         }
     }
 

--- a/src/api/block_builder/pow/miner.rs
+++ b/src/api/block_builder/pow/miner.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! PoW Miner
+//! Multi-threaded PoW miner
 
 use bee_pow::providers::{
     miner::{MinerBuilder, MinerCancel},

--- a/src/api/block_builder/pow/mod.rs
+++ b/src/api/block_builder/pow/mod.rs
@@ -114,7 +114,7 @@ pub async fn finish_single_threaded_pow(client: &Client, payload: Option<Payload
 
         // The nonce defaults to 0 on errors (from the tips interval elapsing),
         // we need to re-run proof-of-work with new parents.
-        if block.nonce() == 0 && !local_pow {
+        if block.nonce() == 0 && local_pow {
             parent_blocks = client.get_tips().await?;
         } else {
             return Ok(block);

--- a/src/api/block_builder/pow/mod.rs
+++ b/src/api/block_builder/pow/mod.rs
@@ -3,23 +3,43 @@
 
 //! PoW functions
 
+#[cfg(target_family = "wasm")]
+pub mod wasm_miner;
+
 pub mod miner;
 
 use bee_block::{parent::Parents, payload::Payload, Block, BlockBuilder, BlockId};
+use bee_pow::providers::{NonceProvider, NonceProviderBuilder};
 use packable::PackableExt;
-#[cfg(not(target_family = "wasm"))]
-use {
-    crate::api::miner::ClientMinerBuilder,
-    bee_pow::providers::{miner::MinerCancel, NonceProviderBuilder},
-};
 #[cfg(target_family = "wasm")]
-use {bee_block::payload::OptionalPayload, packable::Packable};
-
-use crate::{api::miner::ClientMiner, Client, Error, Result};
-
-/// Does PoW with always new tips
+use wasm_miner::SingleThreadedMiner;
 #[cfg(not(target_family = "wasm"))]
-pub async fn finish_pow(client: &Client, payload: Option<Payload>) -> Result<Block> {
+use {crate::api::miner::ClientMiner, bee_pow::providers::miner::MinerCancel};
+
+use crate::{Client, Error, Result};
+
+/// Performs proof-of-work to construct a [`Block`].
+pub fn do_pow<P: NonceProvider>(
+    miner: P,
+    min_pow_score: f64,
+    payload: Option<Payload>,
+    parent_blocks: Vec<BlockId>,
+) -> Result<Block> {
+    let mut block = BlockBuilder::<P>::new(Parents::new(parent_blocks)?);
+    if let Some(p) = payload {
+        block = block.with_payload(p);
+    }
+    block
+        .with_nonce_provider(miner, min_pow_score)
+        .finish()
+        .map_err(Error::BlockError)
+}
+
+/// Performs multi-threaded proof-of-work.
+///
+/// Always fetches new tips after each tips interval elapses.
+#[cfg(not(target_family = "wasm"))]
+pub async fn finish_multi_threaded_pow(client: &Client, payload: Option<Payload>) -> Result<Block> {
     let local_pow = client.get_local_pow().await;
     let pow_worker_count = client.pow_worker_count;
     let min_pow_score = client.get_min_pow_score().await?;
@@ -33,13 +53,12 @@ pub async fn finish_pow(client: &Client, payload: Option<Payload>) -> Result<Blo
         parent_blocks.dedup();
         let time_thread = std::thread::spawn(move || Ok(pow_timeout(tips_interval, cancel)));
         let pow_thread = std::thread::spawn(move || {
-            let mut client_miner = ClientMinerBuilder::new()
-                .with_local_pow(local_pow)
-                .with_cancel(cancel_2);
+            let mut client_miner = ClientMiner::builder().with_local_pow(local_pow).with_cancel(cancel_2);
             if let Some(worker_count) = pow_worker_count {
                 client_miner = client_miner.with_worker_count(worker_count);
             }
             do_pow(client_miner.finish(), min_pow_score, payload_, parent_blocks)
+                .map(|block| (block.nonce(), Some(block)))
         });
 
         let threads = vec![pow_thread, time_thread];
@@ -60,7 +79,7 @@ pub async fn finish_pow(client: &Client, payload: Option<Payload>) -> Result<Blo
     }
 }
 
-// PoW timeout, if we reach this we will restart the PoW with new tips, so the final block will never be lazy
+// PoW timeout, if we reach this we will restart the PoW with new tips, so the final block will never be lazy.
 #[cfg(not(target_family = "wasm"))]
 fn pow_timeout(after_seconds: u64, cancel: MinerCancel) -> (u64, Option<Block>) {
     std::thread::sleep(std::time::Duration::from_secs(after_seconds));
@@ -68,122 +87,37 @@ fn pow_timeout(after_seconds: u64, cancel: MinerCancel) -> (u64, Option<Block>) 
     (0, None)
 }
 
-/// Does PoW
-pub fn do_pow(
-    client_miner: ClientMiner,
-    min_pow_score: f64,
-    payload: Option<Payload>,
-    parent_blocks: Vec<BlockId>,
-) -> Result<(u64, Option<Block>)> {
-    let mut block = BlockBuilder::<ClientMiner>::new(Parents::new(parent_blocks)?);
-    if let Some(p) = payload {
-        block = block.with_payload(p);
-    }
-    let block = block
-        .with_nonce_provider(client_miner, min_pow_score)
-        .finish()
-        .map_err(Error::BlockError)?;
-    Ok((block.nonce(), Some(block)))
-}
-
-// Single threaded PoW for wasm
+/// Single threaded proof-of-work for Wasm, which cannot generally spawn the native threads used
+/// by the `ClientMiner`.
+///
+/// Always fetches new tips after each tips interval elapses.
 #[cfg(target_family = "wasm")]
-use {
-    bee_ternary::{b1t6, Btrit, T1B1Buf, TritBuf},
-    crypto::hashes::ternary::{
-        curl_p::{CurlPBatchHasher, BATCH_SIZE},
-        HASH_LENGTH,
-    },
-    crypto::hashes::{blake2b::Blake2b256, Digest},
-};
-
-// Precomputed natural logarithm of 3 for performance reasons.
-// See https://oeis.org/A002391.
-#[cfg(target_family = "wasm")]
-const LN_3: f64 = 1.098_612_288_668_109;
-#[cfg(target_family = "wasm")]
-// should take around one second to reach on an average CPU, so shouldn't cause a noticeable delay on tips_interval
-const POW_ROUNDS_BEFORE_INTERVAL_CHECK: usize = 3000;
-#[cfg(target_family = "wasm")]
-/// Single threaded PoW function for wasm
-pub async fn finish_single_thread_pow(
-    client: &Client,
-    network_id: u64,
-    parent_blocks: Option<Vec<BlockId>>,
-    payload: Option<bee_block::payload::Payload>,
-    target_score: f64,
-) -> crate::Result<Block> {
-    let mut parent_blocks = match parent_blocks {
-        Some(parents) => parents,
-        None => client.get_tips().await?,
-    };
-
-    // return with 0 as nonce if remote PoW should be used
-    if !client.get_local_pow().await {
-        let mut block_bytes: Vec<u8> = Vec::new();
-        network_id.pack(&mut block_bytes).unwrap();
-        Parents::new(parent_blocks.clone())?.pack(&mut block_bytes).unwrap();
-        OptionalPayload::pack(&OptionalPayload::from(payload.clone()), &mut block_bytes)
-            .map_err(|_| crate::Error::PackableError)?;
-        (0_u64).pack(&mut block_bytes).unwrap();
-        return Block::unpack_verified(&mut block_bytes.as_slice()).map_err(|_| crate::Error::PackableError);
-    }
-
-    let tips_interval = client.get_tips_interval().await;
-
+pub async fn finish_single_threaded_pow(client: &Client, payload: Option<Payload>) -> Result<Block> {
+    let min_pow_score: f64 = client.get_min_pow_score().await?;
+    let tips_interval: u64 = client.get_tips_interval().await;
+    let local_pow: bool = client.get_local_pow().await;
+    let mut parent_blocks = client.get_tips().await?;
     loop {
-        let mut block_bytes: Vec<u8> = Vec::new();
-        network_id.pack(&mut block_bytes).unwrap();
-        Parents::new(parent_blocks.clone())?.pack(&mut block_bytes).unwrap();
-        OptionalPayload::pack(&OptionalPayload::from(payload.clone()), &mut block_bytes)
-            .map_err(|_| crate::Error::PackableError)?;
+        parent_blocks.sort_unstable_by_key(PackableExt::pack_to_vec);
+        parent_blocks.dedup();
 
-        let mut pow_digest = TritBuf::<T1B1Buf>::new();
-        let target_zeros =
-            (((block_bytes.len() + std::mem::size_of::<u64>()) as f64 * target_score).ln() / LN_3).ceil() as usize;
+        let single_threaded_miner = SingleThreadedMiner::builder()
+            .tips_interval_secs(tips_interval)
+            .local_pow(local_pow)
+            .finish();
+        let block: Block = do_pow(
+            single_threaded_miner,
+            min_pow_score,
+            payload.clone(),
+            parent_blocks.clone(),
+        )?;
 
-        if target_zeros > HASH_LENGTH {
-            return Err(bee_pow::providers::miner::Error::InvalidPowScore(target_score, target_zeros).into());
-        }
-
-        let hash = Blake2b256::digest(&block_bytes);
-
-        b1t6::encode::<T1B1Buf>(&hash).iter().for_each(|t| pow_digest.push(t));
-
-        let mut nonce = 0;
-        let mut hasher = CurlPBatchHasher::<T1B1Buf>::new(HASH_LENGTH);
-        let mut buffers = Vec::<TritBuf<T1B1Buf>>::with_capacity(BATCH_SIZE);
-        for _ in 0..BATCH_SIZE {
-            let mut buffer = TritBuf::<T1B1Buf>::zeros(HASH_LENGTH);
-            buffer[..pow_digest.len()].copy_from(&pow_digest);
-            buffers.push(buffer);
-        }
-        let mining_start = instant::Instant::now();
-        // counter to reduce amount of mining_start.elapsed() calls
-        let mut counter = 0;
-        loop {
-            if counter % POW_ROUNDS_BEFORE_INTERVAL_CHECK == 0
-                && mining_start.elapsed() > std::time::Duration::from_secs(tips_interval)
-            {
-                // update parents
-                parent_blocks = client.get_tips().await?;
-                break;
-            }
-            for (i, buffer) in buffers.iter_mut().enumerate() {
-                let nonce_trits = b1t6::encode::<T1B1Buf>(&(nonce + i as u64).to_le_bytes());
-                buffer[pow_digest.len()..pow_digest.len() + nonce_trits.len()].copy_from(&nonce_trits);
-                hasher.add(buffer.clone());
-            }
-            for (i, hash) in hasher.hash().enumerate() {
-                let trailing_zeros = hash.iter().rev().take_while(|t| *t == Btrit::Zero).count();
-                if trailing_zeros >= target_zeros {
-                    Box::new(nonce + i as u64).pack(&mut block_bytes).unwrap();
-                    return Block::unpack_verified(&mut block_bytes.as_slice())
-                        .map_err(|_| crate::Error::PackableError);
-                }
-            }
-            nonce += BATCH_SIZE as u64;
-            counter += 1;
+        // The nonce defaults to 0 on errors (from the tips interval elapsing),
+        // we need to re-run proof-of-work with new parents.
+        if block.nonce() == 0 && !local_pow {
+            parent_blocks = client.get_tips().await?;
+        } else {
+            return Ok(block);
         }
     }
 }

--- a/src/api/block_builder/pow/mod.rs
+++ b/src/api/block_builder/pow/mod.rs
@@ -14,7 +14,7 @@ use packable::PackableExt;
 #[cfg(target_family = "wasm")]
 use wasm_miner::SingleThreadedMiner;
 #[cfg(not(target_family = "wasm"))]
-use {crate::api::miner::ClientMinerBuilder, bee_pow::providers::miner::MinerCancel};
+use {crate::api::miner::ClientMiner, bee_pow::providers::miner::MinerCancel};
 
 use crate::{Client, Error, Result};
 
@@ -53,9 +53,7 @@ pub async fn finish_multi_threaded_pow(client: &Client, payload: Option<Payload>
         parent_blocks.dedup();
         let time_thread = std::thread::spawn(move || Ok(pow_timeout(tips_interval, cancel)));
         let pow_thread = std::thread::spawn(move || {
-            let mut client_miner = ClientMinerBuilder::new()
-                .with_local_pow(local_pow)
-                .with_cancel(cancel_2);
+            let mut client_miner = ClientMiner::builder().with_local_pow(local_pow).with_cancel(cancel_2);
             if let Some(worker_count) = pow_worker_count {
                 client_miner = client_miner.with_worker_count(worker_count);
             }

--- a/src/api/block_builder/pow/mod.rs
+++ b/src/api/block_builder/pow/mod.rs
@@ -14,7 +14,7 @@ use packable::PackableExt;
 #[cfg(target_family = "wasm")]
 use wasm_miner::SingleThreadedMiner;
 #[cfg(not(target_family = "wasm"))]
-use {crate::api::miner::ClientMiner, bee_pow::providers::miner::MinerCancel};
+use {crate::api::miner::ClientMinerBuilder, bee_pow::providers::miner::MinerCancel};
 
 use crate::{Client, Error, Result};
 
@@ -53,7 +53,9 @@ pub async fn finish_multi_threaded_pow(client: &Client, payload: Option<Payload>
         parent_blocks.dedup();
         let time_thread = std::thread::spawn(move || Ok(pow_timeout(tips_interval, cancel)));
         let pow_thread = std::thread::spawn(move || {
-            let mut client_miner = ClientMiner::builder().with_local_pow(local_pow).with_cancel(cancel_2);
+            let mut client_miner = ClientMinerBuilder::new()
+                .with_local_pow(local_pow)
+                .with_cancel(cancel_2);
             if let Some(worker_count) = pow_worker_count {
                 client_miner = client_miner.with_worker_count(worker_count);
             }

--- a/src/api/block_builder/pow/wasm_miner.rs
+++ b/src/api/block_builder/pow/wasm_miner.rs
@@ -1,0 +1,124 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Single-threaded PoW miner
+
+use bee_pow::providers::{NonceProvider, NonceProviderBuilder};
+use bee_ternary::{b1t6, Btrit, T1B1Buf, TritBuf};
+use crypto::hashes::{
+    blake2b::Blake2b256,
+    ternary::{
+        curl_p::{CurlPBatchHasher, BATCH_SIZE},
+        HASH_LENGTH,
+    },
+    Digest,
+};
+
+// Precomputed natural logarithm of 3 for performance reasons.
+// See https://oeis.org/A002391.
+const LN_3: f64 = 1.098_612_288_668_109;
+
+// Should take around one second to reach on an average CPU,
+// so shouldn't cause a noticeable delay on tips_interval.
+const POW_ROUNDS_BEFORE_INTERVAL_CHECK: usize = 3000;
+
+/// Single-threaded proof-of-work for Wasm.
+pub struct SingleThreadedMiner {
+    local_pow: bool,
+    tips_interval_secs: Option<u64>,
+}
+
+/// Builder for [`SingleThreadedMiner`].
+#[derive(Default)]
+#[must_use]
+pub struct SingleThreadedMinerBuilder {
+    local_pow: bool,
+    tips_interval_secs: Option<u64>,
+}
+
+impl SingleThreadedMinerBuilder {
+    /// Immediately return a default 0 nonce if false (remote proof-of-work).
+    pub fn local_pow(mut self, local_pow: bool) -> Self {
+        self.local_pow = local_pow;
+        self
+    }
+
+    /// Aborts and returns a "cancelled" error after the interval elapses, if set.
+    /// New parents (tips) should be fetched and proof-of-work re-run afterwards.
+    pub fn tips_interval_secs(mut self, tips_interval_secs: u64) -> Self {
+        self.tips_interval_secs = Some(tips_interval_secs);
+        self
+    }
+}
+
+impl NonceProviderBuilder for SingleThreadedMinerBuilder {
+    type Provider = SingleThreadedMiner;
+
+    fn finish(self) -> Self::Provider {
+        SingleThreadedMiner {
+            local_pow: self.local_pow,
+            tips_interval_secs: self.tips_interval_secs,
+        }
+    }
+}
+
+impl NonceProvider for SingleThreadedMiner {
+    type Builder = SingleThreadedMinerBuilder;
+    type Error = crate::Error;
+
+    fn nonce(&self, bytes: &[u8], target_score: f64) -> Result<u64, Self::Error> {
+        // Remote proof-of-work will compute the block nonce.
+        if !self.local_pow {
+            return Ok(0);
+        }
+
+        let mut pow_digest = TritBuf::<T1B1Buf>::new();
+        let target_zeros =
+            (((bytes.len() + std::mem::size_of::<u64>()) as f64 * target_score).ln() / LN_3).ceil() as usize;
+        if target_zeros > HASH_LENGTH {
+            return Err(bee_pow::providers::miner::Error::InvalidPowScore(target_score, target_zeros).into());
+        }
+
+        let hash = Blake2b256::digest(bytes);
+        b1t6::encode::<T1B1Buf>(&hash).iter().for_each(|t| pow_digest.push(t));
+
+        let mut nonce = 0;
+        let mut hasher = CurlPBatchHasher::<T1B1Buf>::new(HASH_LENGTH);
+        let mut buffers = Vec::<TritBuf<T1B1Buf>>::with_capacity(BATCH_SIZE);
+        for _ in 0..BATCH_SIZE {
+            let mut buffer = TritBuf::<T1B1Buf>::zeros(HASH_LENGTH);
+            buffer[..pow_digest.len()].copy_from(&pow_digest);
+            buffers.push(buffer);
+        }
+
+        // Counter to reduce number of mining_start.elapsed() calls.
+        let mut counter = 0;
+        let mining_start = instant::Instant::now();
+        loop {
+            if let Some(tips_interval) = self.tips_interval_secs {
+                if counter % POW_ROUNDS_BEFORE_INTERVAL_CHECK == 0
+                    && mining_start.elapsed() > instant::Duration::from_secs(tips_interval)
+                {
+                    // Tips interval elapsed, cancel work and get new parents.
+                    break;
+                }
+            }
+
+            for (i, buffer) in buffers.iter_mut().enumerate() {
+                let nonce_trits = b1t6::encode::<T1B1Buf>(&(nonce + i as u64).to_le_bytes());
+                buffer[pow_digest.len()..pow_digest.len() + nonce_trits.len()].copy_from(&nonce_trits);
+                hasher.add(buffer.clone());
+            }
+            for (i, hash) in hasher.hash().enumerate() {
+                let trailing_zeros = hash.iter().rev().take_while(|t| *t == Btrit::Zero).count();
+                if trailing_zeros >= target_zeros {
+                    return Ok(nonce + i as u64);
+                }
+            }
+            nonce += BATCH_SIZE as u64;
+            counter += 1;
+        }
+
+        Err(bee_pow::providers::miner::Error::Cancelled.into())
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -263,8 +263,10 @@ impl Client {
             .finish();
         #[cfg(not(target_family = "wasm"))]
         let miner = {
-            let mut miner = crate::api::miner::ClientMiner::builder().with_local_pow(local_pow);
-            // Do not set worker_count here, breaks Java bindings!
+            let mut miner = crate::api::miner::ClientMinerBuilder::new().with_local_pow(local_pow);
+            if let Some(worker_count) = self.pow_worker_count {
+                miner = miner.with_worker_count(worker_count)
+            }
             miner.finish()
         };
         miner

--- a/src/client.rs
+++ b/src/client.rs
@@ -263,7 +263,7 @@ impl Client {
             .finish();
         #[cfg(not(target_family = "wasm"))]
         let miner = {
-            let mut miner = crate::api::miner::ClientMinerBuilder::new().with_local_pow(local_pow);
+            let mut miner = crate::api::miner::ClientMiner::builder().with_local_pow(local_pow);
             if let Some(worker_count) = self.pow_worker_count {
                 miner = miner.with_worker_count(worker_count)
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -264,9 +264,7 @@ impl Client {
         #[cfg(not(target_family = "wasm"))]
         let miner = {
             let mut miner = crate::api::miner::ClientMiner::builder().with_local_pow(local_pow);
-            if let Some(worker_count) = self.pow_worker_count {
-                miner = miner.with_worker_count(worker_count)
-            }
+            // Do not set worker_count here, breaks Java bindings!
             miner.finish()
         };
         miner

--- a/src/node_api/core/routes.rs
+++ b/src/node_api/core/routes.rs
@@ -130,20 +130,9 @@ impl Client {
                             client_network_info.local_pow = true;
                         }
                         #[cfg(not(target_family = "wasm"))]
-                        let block_res = crate::api::finish_pow(self, block.payload().cloned()).await;
+                        let block_res = crate::api::finish_multi_threaded_pow(self, block.payload().cloned()).await;
                         #[cfg(target_family = "wasm")]
-                        let block_res = {
-                            let min_pow_score = self.get_min_pow_score().await?;
-                            let network_id = self.get_network_id().await?;
-                            crate::api::finish_single_thread_pow(
-                                self,
-                                network_id,
-                                None,
-                                block.payload().cloned(),
-                                min_pow_score,
-                            )
-                            .await
-                        };
+                        let block_res = crate::api::finish_single_threaded_pow(self, block.payload().cloned()).await;
                         let block_with_local_pow = match block_res {
                             Ok(block) => {
                                 // reset local PoW state
@@ -213,20 +202,9 @@ impl Client {
                             client_network_info.local_pow = true;
                         }
                         #[cfg(not(target_family = "wasm"))]
-                        let block_res = crate::api::finish_pow(self, block.payload().cloned()).await;
+                        let block_res = crate::api::finish_multi_threaded_pow(self, block.payload().cloned()).await;
                         #[cfg(target_family = "wasm")]
-                        let block_res = {
-                            let min_pow_score = self.get_min_pow_score().await?;
-                            let network_id = self.get_network_id().await?;
-                            crate::api::finish_single_thread_pow(
-                                self,
-                                network_id,
-                                None,
-                                block.payload().cloned(),
-                                min_pow_score,
-                            )
-                            .await
-                        };
+                        let block_res = crate::api::finish_single_threaded_pow(self, block.payload().cloned()).await;
                         let block_with_local_pow = match block_res {
                             Ok(block) => {
                                 // reset local PoW state


### PR DESCRIPTION
# Description of change

Fixes several runtime and compilation errors for the `wasm32-unknown-unknown` target related to publishing and proof-of-work computations.

Notably, `finish_single_thread_pow` used outdated `Block` packing logic, causing publishing to fail completely on Wasm. It now goes through the same `NonceProvider` interface used to construct a `Block`, so it should be more maintainable.

This also consolidates some of the PoW logic but I made sure the non-Wasm logic is completely unchanged. It's just slightly cleaned up ~and now sets the workers in `promote_unchecked` and `reattach_unchecked` where it didn't before, not sure if that was intentional.~ Edit: ~reverted this change, but the Java bindings tests still fail with the following error, not sure why yet:~ https://github.com/iotaledger/iota.rs/runs/7830007231?check_suite_focus=true

Edit2: error was due to calling `ClientMiner::builder()`, which defaulted to `0` workers, instead of `ClientMinerBuilder::new()`. Un-reverted change and made `default` match `new`. The below errors no longer occur.

```
thread '<unnamed>' panicked at 'attempt to divide by zero', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/bee-pow-1.0.0-alpha.1/src/providers/miner.rs:164:28
thread '<unnamed>' panicked at 'Failed to join threads.: Any { .. }', /home/runner/work/iota.rs/iota.rs/src/api/block_builder/pow/mod.rs:66:28
```

The conditional PoW checks (single-threaded vs multi-threaded, whether or not to stop after the tips interval and fetch new parents) could be internalised further to a single `finish_pow` function, but I think being explicit might be preferred and it would mess with the public interface (e.g. `get_pow_provider` is public).

**NOTE: a new version of `bee-api-types` needs to be released with the changes in https://github.com/iotaledger/bee/pull/1495 (not sure if other `bee` crates need new versions too) for `iota.rs` to compile to the `wasm32-unknown-unknown` target.** I confirmed this PR works with the updated `bee-api-types` locally though.

### Changed 

- Change `Client::get_time_checked()` to use [instant](https://crates.io/crates/instant) on Wasm. It previously panicked with `"time not implemented on this platform"`.
- Change `Client::get_pow_provider()` to return a generic `NonceProvider` based on the target (`SingleThreadedMiner` on Wasm, otherwise `ClientMiner`). This fixes `retry_until_included`/`promote`/`reattach` calls for Wasm.
- Change `Client::get_pow_provider()` to set the worker count on `ClientMiner`.
- Change `ClientMinerBuilder::default()` implementation to match `new()` and default `local_pow` to `true`.
- Rename `finish_pow` to `finish_multi_threaded_pow`.
- Rename `finish_single_thread_pow` to `finish_single_threaded_pow`.

### Added

- Add `SingleThreadedMiner`.
- Add `SingleThreadedMinerBuilder`.

## Type of change

Technically a breaking change due to renaming public functions (`finish_pow`) and changing the return type of `Client::get_pow_provider()`.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Built on both targets:
- `cargo clippy`
- `cargo clippy --target wasm32-unknown-unknown`

Unit tests pass too.

I also ran examples using local Wasm bindings to confirm the runtime errors and panics no longer occur (coming in a future PR maybe, I followed the Node.js bindings approach and re-used its TypeScript definitions now, so hopefully it will be a plug-and-play replacement with a common base).

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
