### PR TITLE
Update consolidate_funds() parameters

### DIFF
--- a/.changes/consolidation.md
+++ b/.changes/consolidation.md
@@ -1,0 +1,6 @@
+
+---
+"nodejs-binding": patch
+---
+
+Accept `IGenerateAddressesOptions` in `consolidateFunds()` instead of `accountIndex` and `addressRange`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `finish_pow` to `finish_multi_threaded_pow`;
 - Rename `finish_single_thread_pow` to `finish_single_threaded_pow`;
 - Rename `minimum_storage_deposit` to `minimum_storage_deposit_basic_output`;
+- Accept `GenerateAddressesOptions` in `consolidate_funds()` instead of `account_index` and `address_range`;
 
 ### Removed
 - Removed `snapshot_loaded` field from StrongholdAdapter;
+- Removed `outputs()` field from GetAddressBuilder;
 
 ### Fixed
 

--- a/bindings/java/iota-client-java/src/main/java/org/iota/Client.java
+++ b/bindings/java/iota-client-java/src/main/java/org/iota/Client.java
@@ -178,8 +178,8 @@ public class Client {
         return highLevelApi.retryUntilIncluded(blockId, interval, maxAttempts);
     }
 
-    public String consolidateFunds(SecretManager secretManager, int accountIndex, Range addressRange) throws ClientException {
-        return highLevelApi.consolidateFunds(secretManager, accountIndex, addressRange);
+    public String consolidateFunds(SecretManager secretManager, GenerateAddressesOptions generateAddressesOptions) throws ClientException {
+        return highLevelApi.consolidateFunds(secretManager, generateAddressesOptions);
     }
 
     public UtxoInput[] findInputs(String[] addresses, int amount) throws ClientException {

--- a/bindings/java/iota-client-java/src/main/java/org/iota/apis/HighLevelApi.java
+++ b/bindings/java/iota-client-java/src/main/java/org/iota/apis/HighLevelApi.java
@@ -95,11 +95,10 @@ public class HighLevelApi extends BaseApi {
         return blocks;
     }
 
-    public String consolidateFunds(SecretManager secretManager, int accountIndex, Range addressRange) throws ClientException {
+    public String consolidateFunds(SecretManager secretManager, GenerateAddressesOptions generateAddressesOptions) throws ClientException {
         JsonObject o = new JsonObject();
         o.add("secretManager", secretManager.getJson());
-        o.addProperty("accountIndex", accountIndex);
-        o.add("addressRange", addressRange.getAsJson());
+        o.add("generateAddressesOptions", generateAddressesOptions.getAsJson());
 
         String responsePayload = callBaseApi(new ClientCommand("ConsolidateFunds", o)).getAsString();
 

--- a/bindings/java/iota-client-java/src/test/java/org/iota/HighLevelApiTest.java
+++ b/bindings/java/iota-client-java/src/test/java/org/iota/HighLevelApiTest.java
@@ -77,7 +77,7 @@ public class HighLevelApiTest extends ApiTest {
         SecretManager secretManager = new MnemonicSecretManager(DEFAULT_DEVELOPMENT_MNEMONIC);
         String address = client.generateAddresses(secretManager, new GenerateAddressesOptions().withRange(new Range(0, 1)))[0];
         requestFundsFromFaucet(address);
-        String consolidatedAddress = client.consolidateFunds(secretManager, 0, new Range(0, 5));
+        String consolidatedAddress = client.consolidateFunds(secretManager, new GenerateAddressesOptions().withRange(new Range(0, 1)));
         System.out.println(consolidatedAddress);
     }
 

--- a/bindings/nodejs/Cargo.lock
+++ b/bindings/nodejs/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -155,50 +155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "axum"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9496f0c1d1afb7a2af4338bbe1d969cddfead41d87a9fb3aaa6d0bbc7af648"
-dependencies = [
- "async-trait",
- "axum-core",
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,11 +189,10 @@ checksum = "c5738be7561b0eeb501ef1d5c5db3f24e01ceb55fededd9b00039aada34966ad"
 
 [[package]]
 name = "bee-api-types"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef944f0af59a74f23f759bd607280af063906e58dff41d01803338487d3026e"
+checksum = "3434e02f5f8c8f4908c67f4894103977755aa52efb4050fb4d922b9dceb71eb4"
 dependencies = [
- "axum",
  "bee-block",
  "bee-ledger-types",
  "serde",
@@ -246,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "bee-block"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400e3fbac56e7c7e4d69af820f18a02e4ee89d8cf52a5b2e267b0b9d2d85d7f7"
+checksum = "6cb8c012aa282cc0477dc59540fcb137b3168360a089ece506a2f7a8cdf4a4e6"
 dependencies = [
  "bech32 0.9.0",
  "bee-pow",
@@ -271,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "bee-ledger-types"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71691001d120a2dc1223b1330fedf84fe3e09c121eb18940d9aec2954c08343"
+checksum = "7ac5191caacaeceb7551d94cc83e1840eaa4252112bd3aa884660cecc37161a5"
 dependencies = [
  "bee-block",
  "packable",
@@ -381,9 +336,9 @@ checksum = "87c5fdd0166095e1d463fc6cc01aa8ce547ad77a4e84d42eb6762b084e28067e"
 
 [[package]]
 name = "bytemuck"
-version = "1.10.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53dfa917ec274df8ed3c572698f381a24eef2efba9492d797301b72b6db408a"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
 
 [[package]]
 name = "byteorder"
@@ -1073,12 +1028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
-
-[[package]]
 name = "httparse"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,12 +1385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
-name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,26 +1599,6 @@ checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
  "rustc_version",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2092,9 +2015,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
@@ -2110,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2121,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa",
  "ryu",
@@ -2340,12 +2263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
-
-[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2365,18 +2282,18 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2420,9 +2337,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2483,47 +2400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
-
-[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,7 +2412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if",
- "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/bindings/nodejs/examples/consolidation.ts
+++ b/bindings/nodejs/examples/consolidation.ts
@@ -1,6 +1,6 @@
 // Copyright 2021-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-import { Client, initLogger } from '@iota/client';
+import { Client, CoinType, initLogger } from '@iota/client';
 require('dotenv').config({ path: '../.env' });
 
 // Run with command:
@@ -36,11 +36,15 @@ async function run() {
         };
 
         // Here all funds will be sent to the address with the lowest index in the range
-        const address = await client.consolidateFunds(
-            secretManager,
-            0,
-            addressRange,
-        );
+        const address = await client.consolidateFunds(secretManager, {
+            coinType: CoinType.Shimmer,
+            accountIndex: 0,
+            range: {
+                start: 0,
+                end: 2,
+            },
+            internal: false,
+        });
         console.log('Funds consolidated to: ', address);
     } catch (error) {
         console.error('Error: ', error);

--- a/bindings/nodejs/examples/consolidation.ts
+++ b/bindings/nodejs/examples/consolidation.ts
@@ -19,11 +19,6 @@ async function run() {
         localPow: true,
     });
 
-    const addressRange = {
-        start: 0,
-        end: 10,
-    };
-
     try {
         if (!process.env.NON_SECURE_USE_OF_DEVELOPMENT_MNEMONIC_1) {
             throw new Error('.env mnemonic is undefined, see .env.example');
@@ -41,7 +36,7 @@ async function run() {
             accountIndex: 0,
             range: {
                 start: 0,
-                end: 2,
+                end: 10,
             },
             internal: false,
         });

--- a/bindings/nodejs/lib/Client.ts
+++ b/bindings/nodejs/lib/Client.ts
@@ -846,15 +846,13 @@ export class Client {
      */
     async consolidateFunds(
         secretManager: SecretManager,
-        accountIndex: number,
-        addressRange?: IRange,
+        generateAddressesOptions: IGenerateAddressesOptions,
     ): Promise<string> {
         const response = await this.messageHandler.sendMessage({
             name: 'ConsolidateFunds',
             data: {
                 secretManager,
-                accountIndex,
-                addressRange,
+                generateAddressesOptions,
             },
         });
 

--- a/bindings/nodejs/types/bridge/client.ts
+++ b/bindings/nodejs/types/bridge/client.ts
@@ -382,8 +382,7 @@ export interface __ConsolidateFundsMessage__ {
     name: 'ConsolidateFunds';
     data: {
         secretManager: SecretManager;
-        accountIndex: number;
-        addressRange?: IRange;
+        generateAddressesOptions: IGenerateAddressesOptions;
     };
 }
 

--- a/bindings/python/native/iota_client/_high_level_api.py
+++ b/bindings/python/native/iota_client/_high_level_api.py
@@ -42,14 +42,13 @@ class HighLevelAPI(BaseAPI):
             'maxAttempts': max_attempts
         })
 
-    def consolidate_funds(self, secret_manager, account_index, address_range):
+    def consolidate_funds(self, secret_manager, generate_addresses_options):
         """Function to consolidate all funds from a range of addresses to the address with the lowest index in that range
            Returns the address to which the funds got consolidated, if any were available.
         """
         return self.send_message('ConsolidateFunds', {
             'secretManager': secret_manager,
-            'accountIndex': account_index,
-            'addressRange': address_range
+            'generateAddressesOptions': generate_addresses_options,
         })
 
     def find_inputs(self, addresses, amount):

--- a/documentation/docs/libraries/nodejs/references/classes/Client.md
+++ b/documentation/docs/libraries/nodejs/references/classes/Client.md
@@ -1021,7 +1021,7 @@ ___
 
 ### consolidateFunds
 
-▸ **consolidateFunds**(`secretManager`, `accountIndex`, `addressRange?`): `Promise`<`string`\>
+▸ **consolidateFunds**(`secretManager`, `generateAddressesOptions`): `Promise`<`string`\>
 
 Function to consolidate all funds from a range of addresses to the address with the lowest index in that range
 Returns the address to which the funds got consolidated, if any were available
@@ -1031,8 +1031,7 @@ Returns the address to which the funds got consolidated, if any were available
 | Name | Type |
 | :------ | :------ |
 | `secretManager` | [`SecretManager`](../api_ref.md#secretmanager) |
-| `accountIndex` | `number` |
-| `addressRange?` | [`IRange`](../interfaces/IRange.md) |
+| `generateAddressesOptions` | [`IGenerateAddressesOptions`](../interfaces/IGenerateAddressesOptions.md) |
 
 #### Returns
 

--- a/documentation/docs/libraries/python/api_reference.md
+++ b/documentation/docs/libraries/python/api_reference.md
@@ -348,7 +348,7 @@ Returns the unsynced nodes.
 
 <a id="iota_client.client.IotaClient.get_ledger_nano_status"></a>
 
-#### get\_ledger\_status
+#### get\_ledger\_nano\_status
 
 ```python
 def get_ledger_nano_status(is_simulator)
@@ -467,7 +467,7 @@ position and additional reattached blocks.
 #### consolidate\_funds
 
 ```python
-def consolidate_funds(secret_manager, account_index, address_range)
+def consolidate_funds(secret_manager, generate_addresses_options)
 ```
 
 Function to consolidate all funds from a range of addresses to the address with the lowest index in that range

--- a/examples/high_level/consolidation.rs
+++ b/examples/high_level/consolidation.rs
@@ -4,7 +4,7 @@
 //! cargo run --example consolidation --release
 
 use iota_client::{
-    api::consolidate_funds,
+    api::GetAddressesBuilderOptions,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     Client, Result,
 };
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
 
     let node_url = std::env::var("NODE_URL").unwrap();
 
-    let address_range = 0..150;
+    let address_range = 0u32..150;
     // Create a client instance
     let client = Client::builder().with_node(&node_url)?.finish()?;
 
@@ -29,7 +29,15 @@ async fn main() -> Result<()> {
     )?);
 
     // Here all funds will be send to the address with the lowest index in the range
-    let address = consolidate_funds(&client, &secret_manager, 0, address_range).await?;
+    let address = client
+        .consolidate_funds(
+            &secret_manager,
+            GetAddressesBuilderOptions {
+                range: Some(address_range),
+                ..Default::default()
+            },
+        )
+        .await?;
 
     println!("Funds consolidated to {}", address);
     Ok(())

--- a/src/api/address.rs
+++ b/src/api/address.rs
@@ -27,7 +27,7 @@ pub struct GetAddressesBuilder<'a> {
 }
 
 /// Get address builder from string
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetAddressesBuilderOptions {
     /// Coin type

--- a/src/api/consolidation.rs
+++ b/src/api/consolidation.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{ops::Range, str::FromStr};
+use std::str::FromStr;
 
 use bee_block::{
     address::Address,
@@ -14,117 +14,107 @@ use bee_block::{
 };
 
 use crate::{
-    api::block_builder::ClientBlockBuilder, node_api::indexer::query_parameters::QueryParameter, secret::SecretManager,
+    api::GetAddressesBuilderOptions, node_api::indexer::query_parameters::QueryParameter, secret::SecretManager,
     Client, Result,
 };
 
-/// Function to consolidate all funds and native tokens from a range of addresses to the address with the lowest index
-/// in that range. Returns the address to which the funds got consolidated, if any were available
-pub async fn consolidate_funds(
-    client: &Client,
-    secret_manager: &SecretManager,
-    account_index: u32,
-    address_range: Range<u32>,
-) -> Result<String> {
-    let addresses = client
-        .get_addresses(secret_manager)
-        .with_account_index(account_index)
-        .with_range(address_range.clone())
-        .finish()
-        .await?;
+impl Client {
+    /// Function to consolidate all funds and native tokens from a range of addresses to the address with the lowest
+    /// index in that range. Returns the address to which the funds got consolidated, if any were available
+    pub async fn consolidate_funds(
+        &self,
+        secret_manager: &SecretManager,
+        address_builder_options: GetAddressesBuilderOptions,
+    ) -> Result<String> {
+        let mut last_transfer_index = address_builder_options.range.as_ref().unwrap_or(&(0..1)).start;
+        // use the start index as offset
+        let offset = last_transfer_index;
 
-    let consolidation_address = addresses[0].clone();
+        let addresses = self
+            .get_addresses(secret_manager)
+            .set_options(address_builder_options)?
+            .finish()
+            .await?;
 
-    let mut last_transfer_index = address_range.start;
-    let offset = address_range.start;
-    let local_time = client.get_time_checked().await?;
+        let consolidation_address = addresses[0].clone();
 
-    'consolidation: loop {
-        let mut block_ids = Vec::new();
-        // Iterate over addresses reversed so the funds end up on the first address in the range
-        for (index, address) in addresses.iter().enumerate().rev() {
-            let index = index as u32;
-            // add the offset so the index matches the address index also for higher start indexes
-            let index = index + offset;
+        'consolidation: loop {
+            let mut block_ids = Vec::new();
+            // Iterate over addresses reversed so the funds end up on the first address in the range
+            for (index, address) in addresses.iter().enumerate().rev() {
+                let index = index as u32;
+                // add the offset so the index matches the address index also for higher start indexes
+                let index = index + offset;
 
-            // Get output ids of outputs that can be controlled by this address without further unlock constraints
-            let basic_outputs = client
-                .get_address()
-                .outputs(vec![
-                    QueryParameter::Address(address.to_string()),
-                    QueryParameter::HasExpiration(false),
-                    QueryParameter::HasTimelock(false),
-                    QueryParameter::HasStorageDepositReturn(false),
-                ])
-                .await?;
-
-            let mut output_with_metadata = Vec::new();
-
-            for output in &basic_outputs {
-                let (amount, _output_address) = ClientBlockBuilder::get_output_amount_and_address(
-                    &Output::try_from(&output.output)?,
-                    None,
-                    local_time,
-                )?;
-                output_with_metadata.push((output.clone(), amount));
-            }
-
-            if !output_with_metadata.is_empty() {
-                // If we reach the same index again
-                if last_transfer_index == index {
-                    if output_with_metadata.len() < 2 {
-                        break 'consolidation;
-                    }
-                } else {
-                    last_transfer_index = index;
-                }
-            }
-
-            let outputs_chunks = output_with_metadata.chunks(INPUT_COUNT_MAX.into());
-
-            for chunk in outputs_chunks {
-                let mut block_builder = client.block().with_secret_manager(secret_manager);
-                let mut total_amount = 0;
-                let mut total_native_tokens = NativeTokensBuilder::new();
-
-                for (input, amount) in chunk {
-                    block_builder = block_builder.with_input(UtxoInput::from(OutputId::new(
-                        TransactionId::from_str(&input.metadata.transaction_id)?,
-                        input.metadata.output_index,
-                    )?))?;
-
-                    let output = Output::try_from(&input.output)?;
-
-                    if let Some(native_tokens) = output.native_tokens() {
-                        total_native_tokens.add_native_tokens(native_tokens.clone())?;
-                    }
-                    total_amount += amount;
-                }
-
-                let consolidation_output = BasicOutputBuilder::new_with_amount(total_amount)?
-                    .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
-                        Address::try_from_bech32(&consolidation_address)?.1,
-                    )))
-                    .with_native_tokens(total_native_tokens.finish()?)
-                    .finish_output()?;
-
-                let block = block_builder
-                    .with_input_range(index..index + 1)
-                    .with_outputs(vec![consolidation_output])?
-                    .with_initial_address_index(0)
-                    .finish()
+                // Get output ids of outputs that can be controlled by this address without further unlock constraints
+                let basic_output_ids = self
+                    .basic_output_ids(vec![
+                        QueryParameter::Address(address.to_string()),
+                        QueryParameter::HasExpiration(false),
+                        QueryParameter::HasTimelock(false),
+                        QueryParameter::HasStorageDepositReturn(false),
+                    ])
                     .await?;
-                block_ids.push(block.id());
+
+                let basic_outputs_responses = self.get_outputs(basic_output_ids).await?;
+
+                if !basic_outputs_responses.is_empty() {
+                    // If we reach the same index again
+                    if last_transfer_index == index {
+                        if basic_outputs_responses.len() < 2 {
+                            break 'consolidation;
+                        }
+                    } else {
+                        last_transfer_index = index;
+                    }
+                }
+
+                let outputs_chunks = basic_outputs_responses.chunks(INPUT_COUNT_MAX.into());
+
+                for chunk in outputs_chunks {
+                    let mut block_builder = self.block().with_secret_manager(secret_manager);
+                    let mut total_amount = 0;
+                    let mut total_native_tokens = NativeTokensBuilder::new();
+
+                    for output_response in chunk {
+                        block_builder = block_builder.with_input(UtxoInput::from(OutputId::new(
+                            TransactionId::from_str(&output_response.metadata.transaction_id)?,
+                            output_response.metadata.output_index,
+                        )?))?;
+
+                        let output = Output::try_from(&output_response.output)?;
+
+                        if let Some(native_tokens) = output.native_tokens() {
+                            total_native_tokens.add_native_tokens(native_tokens.clone())?;
+                        }
+                        total_amount += output.amount();
+                    }
+
+                    let consolidation_output = BasicOutputBuilder::new_with_amount(total_amount)?
+                        .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
+                            Address::try_from_bech32(&consolidation_address)?.1,
+                        )))
+                        .with_native_tokens(total_native_tokens.finish()?)
+                        .finish_output()?;
+
+                    let block = block_builder
+                        .with_input_range(index..index + 1)
+                        .with_outputs(vec![consolidation_output])?
+                        .with_initial_address_index(0)
+                        .finish()
+                        .await?;
+                    block_ids.push(block.id());
+                }
+            }
+
+            if block_ids.is_empty() {
+                break 'consolidation;
+            }
+            // Wait for txs to get confirmed so we don't create conflicting txs
+            for block_id in block_ids {
+                let _ = self.retry_until_included(&block_id, None, None).await?;
             }
         }
-
-        if block_ids.is_empty() {
-            break 'consolidation;
-        }
-        // Wait for txs to get confirmed so we don't create conflicting txs
-        for block_id in block_ids {
-            let _ = client.retry_until_included(&block_id, None, None).await?;
-        }
+        Ok(consolidation_address)
     }
-    Ok(consolidation_address)
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,7 +11,6 @@ mod types;
 pub use self::{
     address::*,
     block_builder::{pow::*, *},
-    consolidation::*,
     types::*,
 };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,6 @@
 
 use std::{
     collections::HashSet,
-    ops::Range,
     str::FromStr,
     sync::{Arc, RwLock},
     time::Duration,
@@ -607,17 +606,6 @@ impl Client {
         Err(Error::TangleInclusionError(block_id.to_string()))
     }
 
-    /// Function to consolidate all funds from a range of addresses to the address with the lowest index in that range
-    /// Returns the address to which the funds got consolidated, if any were available
-    pub async fn consolidate_funds(
-        &self,
-        secret_manager: &SecretManager,
-        account_index: u32,
-        address_range: Range<u32>,
-    ) -> crate::Result<String> {
-        crate::api::consolidate_funds(self, secret_manager, account_index, address_range).await
-    }
-
     /// Function to find inputs from addresses for a provided amount (useful for offline signing), ignoring outputs with
     /// additional unlock conditions
     pub async fn find_inputs(&self, addresses: Vec<String>, amount: u64) -> Result<Vec<UtxoInput>> {
@@ -625,17 +613,16 @@ impl Client {
         let mut available_outputs = Vec::new();
 
         for address in addresses {
-            available_outputs.extend_from_slice(
-                &self
-                    .get_address()
-                    .outputs(vec![
-                        QueryParameter::Address(address.to_string()),
-                        QueryParameter::HasExpiration(false),
-                        QueryParameter::HasTimelock(false),
-                        QueryParameter::HasStorageDepositReturn(false),
-                    ])
-                    .await?,
-            );
+            let basic_output_ids = self
+                .basic_output_ids(vec![
+                    QueryParameter::Address(address.to_string()),
+                    QueryParameter::HasExpiration(false),
+                    QueryParameter::HasTimelock(false),
+                    QueryParameter::HasStorageDepositReturn(false),
+                ])
+                .await?;
+
+            available_outputs.extend(self.get_outputs(basic_output_ids).await?);
         }
 
         let mut basic_outputs = Vec::new();
@@ -686,25 +673,25 @@ impl Client {
     /// Find all outputs based on the requests criteria. This method will try to query multiple nodes if
     /// the request amount exceeds individual node limit.
     pub async fn find_outputs(&self, output_ids: &[OutputId], addresses: &[String]) -> Result<Vec<OutputResponse>> {
-        let mut output_metadata = self.get_outputs(output_ids.to_vec()).await?;
+        let mut output_responses = self.get_outputs(output_ids.to_vec()).await?;
 
         // Use `get_address()` API to get the address outputs first,
         // then collect the `UtxoInput` in the HashSet.
         for address in addresses {
             // Get output ids of outputs that can be controlled by this address without further unlock constraints
-            let address_outputs = self
-                .get_address()
-                .outputs(vec![
+            let basic_output_ids = self
+                .basic_output_ids(vec![
                     QueryParameter::Address(address.to_string()),
                     QueryParameter::HasExpiration(false),
                     QueryParameter::HasTimelock(false),
                     QueryParameter::HasStorageDepositReturn(false),
                 ])
                 .await?;
-            output_metadata.extend(address_outputs.into_iter());
+
+            output_responses.extend(self.get_outputs(basic_output_ids).await?);
         }
 
-        Ok(output_metadata.clone())
+        Ok(output_responses.clone())
     }
 
     /// Reattaches blocks for provided block id. Blocks can be reattached only if they are valid and haven't been

--- a/src/message_interface/message.rs
+++ b/src/message_interface/message.rs
@@ -1,8 +1,6 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Range;
-
 use bee_block::{
     address::AliasAddress,
     output::{
@@ -383,12 +381,9 @@ pub enum Message {
         /// Secret manager
         #[serde(rename = "secretManager")]
         secret_manager: SecretManagerDto,
-        /// Account index
-        #[serde(rename = "accountIndex")]
-        account_index: u32,
-        /// Address_range
-        #[serde(rename = "addressRange")]
-        address_range: Range<u32>,
+        /// Addresses generation options
+        #[serde(rename = "generateAddressesOptions")]
+        generate_addresses_options: GenerateAddressesOptions,
     },
     /// Function to find inputs from addresses for a provided amount (useful for offline signing)
     FindInputs {

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -117,11 +117,10 @@ impl ClientMessageHandler {
             }
             Message::ConsolidateFunds {
                 secret_manager: _,
-                account_index,
-                address_range,
+                generate_addresses_options,
             } => {
                 log::debug!(
-                    "Response: ConsolidateFunds{{ secret_manager: <omitted>, account_index: {account_index:?}, address_range: {address_range:?} }}"
+                    "Response: ConsolidateFunds{{ secret_manager: <omitted>, generate_addresses_options: {generate_addresses_options:?} }}"
                 )
             }
             Message::MnemonicToHexSeed { .. } => {
@@ -474,13 +473,12 @@ impl ClientMessageHandler {
             }
             Message::ConsolidateFunds {
                 secret_manager,
-                account_index,
-                address_range,
+                generate_addresses_options,
             } => {
                 let secret_manager = (&secret_manager).try_into()?;
                 Ok(Response::ConsolidatedFunds(
                     self.client
-                        .consolidate_funds(&secret_manager, account_index, address_range)
+                        .consolidate_funds(&secret_manager, generate_addresses_options)
                         .await?,
                 ))
             }

--- a/src/node_api/high_level/address.rs
+++ b/src/node_api/high_level/address.rs
@@ -1,7 +1,6 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use bee_api_types::responses::OutputResponse;
 use bee_block::output::{NativeToken, NativeTokensBuilder, Output};
 
 use crate::{node_api::indexer::query_parameters::QueryParameter, Client, Result};
@@ -73,12 +72,5 @@ impl<'a> GetAddressBuilder<'a> {
             ledger_index,
             native_tokens: native_tokens_builder.finish_vec()?,
         })
-    }
-
-    /// Get outputs
-    pub async fn outputs(self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputResponse>> {
-        let output_ids = self.client.basic_output_ids(query_parameters).await?;
-
-        self.client.get_outputs(output_ids).await
     }
 }


### PR DESCRIPTION
# Description of change

Accept `GenerateAddressesOptions` in `consolidate_funds()` instead of `account_index` and `address_range`;
Remove `outputs()` field from GetAddressBuilder;

## Links to any relevant issues

Fixes #1192 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Updated example

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
