### PR TITLE
Fix Wasm compilation with iota-crypto curl-p feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aee0fbdc68c475a78fd19a6509280b25166499f1bfe087a81237813e7b951667"
 dependencies = [
  "aead",
+ "bee-ternary",
  "blake2 0.10.4",
  "chacha20poly1305",
  "digest 0.10.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ instant = { version = "0.1.12", default-features = false }
 gloo-timers = { version = "0.2.4", default-features = false, features = [ "futures" ] }
 # Single-threaded PoW for Wasm.
 bee-ternary = { version = "1.0.0-alpha.1", default-features = false }
+iota-crypto = { version = "0.14.0", default-features = false, features = [ "curl-p" ] }
 
 [dev-dependencies]
 bee-block = { version = "1.0.0-beta.6", default-features = false, features = [ "rand" ] }

--- a/src/node_manager/mod.rs
+++ b/src/node_manager/mod.rs
@@ -15,7 +15,6 @@ use std::{
 };
 
 use bee_api_types::responses::InfoResponse;
-use log::warn;
 use serde_json::Value;
 
 use self::{http_client::HttpClient, node::Node};
@@ -177,7 +176,7 @@ impl NodeManager {
                                 *counters += 1;
                                 result_counter += 1;
                             } else {
-                                warn!("Couldn't convert noderesult to text");
+                                log::warn!("Couldn't convert noderesult to text");
                             }
                         }
                         Err(Error::ResponseError { code: 404, .. }) => {


### PR DESCRIPTION
# Description of change

Enable the `curl-p` feature for `iota-crypto`, which fixes Wasm compilation after the latest changes bumping the `iota-crypto` dependency to `0.14.0`. 

Specifically fixes this error on the `wasm32-unknown-unknown` target:
```rust
error[E0433]: failed to resolve: could not find `ternary` in `hashes`
  --> src\api\block_builder\pow\wasm_miner.rs:10:5
   |
10 |     ternary::{
   |     ^^^^^^^ could not find `ternary` in `hashes`

error[E0432]: unresolved import `crypto::hashes::ternary`
  --> src\api\block_builder\pow\wasm_miner.rs:10:5
   |
10 |     ternary::{
   |     ^^^^^^^ could not find `ternary` in `hashes`
```

The Wasm miner needs this feature since it uses `curl-p` hashing directly. This previously compiled due to `bee-pow`  coincidentally enabling the `curl-p` feature. Now, since it's still on `iota-crypto 0.13`, `bee-pow` does not enable the feature for `iota-crypto 0.14.0` which `iota.rs` now uses.

Note that we avoid the wildcard version because `version = "*"` will enable it for `0.13` instead of `0.14.0` if used in the Wasm bindings, but not in this crate, hence why I specified `version = "0.14.0"` explicitly. Bit odd.

Aside: the `log::warn` change was to fix an "unused import" warning.

Aside2: much of the Wasm miner code could be removed by refactoring `bee-pow` to export the inner hashing function. It would reduce the need to maintain the duplicate code here, but it might mean breaking changes to that interface (to avoid things like `MinerCancel` which may or not work on all targets), so I'll hold off on that for now. 

## Type of change

Simple compilation fix, no release required.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo clippy --target wasm32-unknown-unknown`.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
