### PR TITLE
StrongholdAdapterBuilder::try_build now uses a AsRef<Path>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 2.0.0-beta.3 - 2022-XX-XX
+
+### Changed
+
+- `StrongholdAdapterBuilder::try_build` now takes a `snapshot_path: <P: AsRef<Path>>` instead of a `snapshot_path: PathBuf`;
+
+### Fixed
+
+- Fix Wasm compilation with iota-crypto curl-p feature;
+
 ## 2.0.0-beta.2 - 2022-08-22
 
 ### Added

--- a/examples/stronghold.rs
+++ b/examples/stronghold.rs
@@ -3,8 +3,6 @@
 
 //! cargo run --example stronghold --features=stronghold --release
 
-use std::path::PathBuf;
-
 use iota_client::{
     api::GetAddressesBuilder,
     constants::{SHIMMER_COIN_TYPE, SHIMMER_TESTNET_BECH32_HRP},
@@ -17,7 +15,7 @@ use iota_client::{
 async fn main() -> Result<()> {
     let mut stronghold_secret_manager = StrongholdSecretManager::builder()
         .password("some_hopefully_secure_password")
-        .try_build(PathBuf::from("test.stronghold"))?;
+        .try_build("test.stronghold")?;
 
     // This example uses dotenv, which is not safe for use in production
     dotenv::dotenv().ok();

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -15,9 +15,9 @@ pub mod stronghold;
 /// Signing related types
 pub mod types;
 
-use std::{collections::HashMap, ops::Range, str::FromStr};
 #[cfg(feature = "stronghold")]
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
+use std::{collections::HashMap, ops::Range, str::FromStr};
 
 use async_trait::async_trait;
 use bee_block::{
@@ -161,7 +161,7 @@ impl TryFrom<&SecretManagerDto> for SecretManager {
                     builder = builder.timeout(Duration::from_secs(*timeout));
                 }
 
-                Self::Stronghold(builder.try_build(PathBuf::from(&stronghold_dto.snapshot_path))?)
+                Self::Stronghold(builder.try_build(&stronghold_dto.snapshot_path)?)
             }
 
             #[cfg(feature = "ledger_nano")]

--- a/src/stronghold/db.rs
+++ b/src/stronghold/db.rs
@@ -75,16 +75,15 @@ impl DatabaseProvider for StrongholdAdapter {
 mod tests {
     #[tokio::test]
     async fn test_stronghold_db() {
-        use std::{fs, path::PathBuf};
+        use std::fs;
 
         use super::StrongholdAdapter;
         use crate::db::DatabaseProvider;
 
         let snapshot_path = "test_stronghold_db.stronghold";
-        let stronghold_path = PathBuf::from(snapshot_path);
         let mut stronghold = StrongholdAdapter::builder()
             .password("drowssap")
-            .try_build(stronghold_path)
+            .try_build(snapshot_path)
             .unwrap();
 
         assert!(matches!(stronghold.get(b"test-0").await, Ok(None)));

--- a/src/stronghold/secret.rs
+++ b/src/stronghold/secret.rs
@@ -286,16 +286,18 @@ mod tests {
         stronghold_adapter.clear_key().await;
 
         // Address generation returns an error when the key is cleared.
-        assert!(stronghold_adapter
-            .generate_addresses(
-                IOTA_COIN_TYPE,
-                0,
-                0..1,
-                false,
-                GenerateAddressMetadata { syncing: false },
-            )
-            .await
-            .is_err());
+        assert!(
+            stronghold_adapter
+                .generate_addresses(
+                    IOTA_COIN_TYPE,
+                    0,
+                    0..1,
+                    false,
+                    GenerateAddressMetadata { syncing: false },
+                )
+                .await
+                .is_err()
+        );
 
         stronghold_adapter.set_password("drowssap").await.unwrap();
 

--- a/src/stronghold/secret.rs
+++ b/src/stronghold/secret.rs
@@ -226,26 +226,26 @@ impl StrongholdAdapter {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::Path;
 
     use super::*;
     use crate::constants::IOTA_COIN_TYPE;
 
     #[tokio::test]
     async fn test_address_generation() {
-        let stronghold_path = PathBuf::from("test_address_generation.stronghold");
+        let stronghold_path = "test_address_generation.stronghold";
         let mnemonic = String::from(
             "giant dynamic museum toddler six deny defense ostrich bomb access mercy blood explain muscle shoot shallow glad autumn author calm heavy hawk abuse rally",
         );
         let mut stronghold_adapter = StrongholdAdapter::builder()
             .password("drowssap")
-            .try_build(stronghold_path.clone())
+            .try_build(stronghold_path)
             .unwrap();
 
         stronghold_adapter.store_mnemonic(mnemonic).await.unwrap();
 
         // The snapshot should have been on the disk now.
-        assert!(stronghold_path.exists());
+        assert!(Path::new(stronghold_path).exists());
 
         let addresses = stronghold_adapter
             .generate_addresses(
@@ -269,35 +269,33 @@ mod tests {
 
     #[tokio::test]
     async fn test_key_cleared() {
-        let stronghold_path = PathBuf::from("test_key_cleared.stronghold");
+        let stronghold_path = "test_key_cleared.stronghold";
         let mnemonic = String::from(
             "giant dynamic museum toddler six deny defense ostrich bomb access mercy blood explain muscle shoot shallow glad autumn author calm heavy hawk abuse rally",
         );
         let mut stronghold_adapter = StrongholdAdapter::builder()
             .password("drowssap")
-            .try_build(stronghold_path.clone())
+            .try_build(stronghold_path)
             .unwrap();
 
         stronghold_adapter.store_mnemonic(mnemonic).await.unwrap();
 
         // The snapshot should have been on the disk now.
-        assert!(stronghold_path.exists());
+        assert!(Path::new(stronghold_path).exists());
 
         stronghold_adapter.clear_key().await;
 
         // Address generation returns an error when the key is cleared.
-        assert!(
-            stronghold_adapter
-                .generate_addresses(
-                    IOTA_COIN_TYPE,
-                    0,
-                    0..1,
-                    false,
-                    GenerateAddressMetadata { syncing: false },
-                )
-                .await
-                .is_err()
-        );
+        assert!(stronghold_adapter
+            .generate_addresses(
+                IOTA_COIN_TYPE,
+                0,
+                0..1,
+                false,
+                GenerateAddressMetadata { syncing: false },
+            )
+            .await
+            .is_err());
 
         stronghold_adapter.set_password("drowssap").await.unwrap();
 

--- a/tests/addresses.rs
+++ b/tests/addresses.rs
@@ -1,9 +1,6 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "stronghold")]
-use std::path::PathBuf;
-
 use bee_block::address::Address;
 #[cfg(feature = "message_interface")]
 use iota_client::api::GetAddressesBuilderOptions;
@@ -193,7 +190,7 @@ async fn address_generation() {
         let stronghold_filename = format!("{}.stronghold", address.bech32_address);
         let mut stronghold_secret_manager = StrongholdSecretManager::builder()
             .password("some_hopefully_secure_password")
-            .try_build(PathBuf::from(stronghold_filename.to_string()))
+            .try_build(&stronghold_filename)
             .unwrap();
 
         stronghold_secret_manager


### PR DESCRIPTION
A request/suggestion from the identity team.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
