### PR TITLE
Rename `StrongholdAdapterBuilder::try_build` to `StrongholdAdapterBuilder::build`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 2.0.0-beta.3 - 2022-XX-XX
+
+### Changed
+
+- Rename `StrongholdAdapterBuilder::build` to `StrongholdAdapterBuilder::try_build`;
+
+### Fixed
+
+- Fix Wasm compilation with iota-crypto curl-p feature;
+
 ## 2.0.0-beta.2 - 2022-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `StrongholdAdapterBuilder::try_build` now takes a `snapshot_path: <P: AsRef<Path>>` instead of a `snapshot_path: PathBuf`;
-- Rename `StrongholdAdapterBuilder::build` to `StrongholdAdapterBuilder::try_build`;
+- Rename `StrongholdAdapterBuilder::try_build` to `StrongholdAdapterBuilder::build`;
 
 ### Fixed
 

--- a/examples/stronghold.rs
+++ b/examples/stronghold.rs
@@ -17,7 +17,7 @@ use iota_client::{
 async fn main() -> Result<()> {
     let mut stronghold_secret_manager = StrongholdSecretManager::builder()
         .password("some_hopefully_secure_password")
-        .try_build(PathBuf::from("test.stronghold"))?;
+        .build(PathBuf::from("test.stronghold"))?;
 
     // This example uses dotenv, which is not safe for use in production
     dotenv::dotenv().ok();

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -161,7 +161,7 @@ impl TryFrom<&SecretManagerDto> for SecretManager {
                     builder = builder.timeout(Duration::from_secs(*timeout));
                 }
 
-                Self::Stronghold(builder.try_build(PathBuf::from(&stronghold_dto.snapshot_path))?)
+                Self::Stronghold(builder.build(PathBuf::from(&stronghold_dto.snapshot_path))?)
             }
 
             #[cfg(feature = "ledger_nano")]

--- a/src/stronghold/db.rs
+++ b/src/stronghold/db.rs
@@ -84,7 +84,7 @@ mod tests {
         let stronghold_path = PathBuf::from(snapshot_path);
         let mut stronghold = StrongholdAdapter::builder()
             .password("drowssap")
-            .try_build(stronghold_path)
+            .build(stronghold_path)
             .unwrap();
 
         assert!(matches!(stronghold.get(b"test-0").await, Ok(None)));

--- a/src/stronghold/mod.rs
+++ b/src/stronghold/mod.rs
@@ -158,7 +158,7 @@ impl StrongholdAdapterBuilder {
     ///
     /// [`password()`]: Self::password()
     /// [`timeout()`]: Self::timeout()
-    pub fn try_build(mut self, snapshot_path: PathBuf) -> Result<StrongholdAdapter> {
+    pub fn build(mut self, snapshot_path: PathBuf) -> Result<StrongholdAdapter> {
         // In any case, Stronghold - as a necessary component - needs to be present at this point.
         let stronghold = if let Some(stronghold) = self.stronghold {
             stronghold
@@ -550,7 +550,7 @@ mod tests {
         let mut adapter = StrongholdAdapter::builder()
             .password("drowssap")
             .timeout(timeout)
-            .try_build(stronghold_path)
+            .build(stronghold_path)
             .unwrap();
 
         // There is a small delay between `build()` and the key clearing task being actually spawned and kept.
@@ -593,7 +593,7 @@ mod tests {
         let stronghold_path = PathBuf::from(snapshot_path);
         let mut adapter = StrongholdAdapter::builder()
             .password("drowssap")
-            .try_build(stronghold_path)
+            .build(stronghold_path)
             .unwrap();
 
         adapter.clear_key().await;

--- a/src/stronghold/secret.rs
+++ b/src/stronghold/secret.rs
@@ -239,7 +239,7 @@ mod tests {
         );
         let mut stronghold_adapter = StrongholdAdapter::builder()
             .password("drowssap")
-            .try_build(stronghold_path.clone())
+            .build(stronghold_path.clone())
             .unwrap();
 
         stronghold_adapter.store_mnemonic(mnemonic).await.unwrap();
@@ -275,7 +275,7 @@ mod tests {
         );
         let mut stronghold_adapter = StrongholdAdapter::builder()
             .password("drowssap")
-            .try_build(stronghold_path.clone())
+            .build(stronghold_path.clone())
             .unwrap();
 
         stronghold_adapter.store_mnemonic(mnemonic).await.unwrap();
@@ -286,18 +286,16 @@ mod tests {
         stronghold_adapter.clear_key().await;
 
         // Address generation returns an error when the key is cleared.
-        assert!(
-            stronghold_adapter
-                .generate_addresses(
-                    IOTA_COIN_TYPE,
-                    0,
-                    0..1,
-                    false,
-                    GenerateAddressMetadata { syncing: false },
-                )
-                .await
-                .is_err()
-        );
+        assert!(stronghold_adapter
+            .generate_addresses(
+                IOTA_COIN_TYPE,
+                0,
+                0..1,
+                false,
+                GenerateAddressMetadata { syncing: false },
+            )
+            .await
+            .is_err());
 
         stronghold_adapter.set_password("drowssap").await.unwrap();
 

--- a/src/stronghold/secret.rs
+++ b/src/stronghold/secret.rs
@@ -286,16 +286,18 @@ mod tests {
         stronghold_adapter.clear_key().await;
 
         // Address generation returns an error when the key is cleared.
-        assert!(stronghold_adapter
-            .generate_addresses(
-                IOTA_COIN_TYPE,
-                0,
-                0..1,
-                false,
-                GenerateAddressMetadata { syncing: false },
-            )
-            .await
-            .is_err());
+        assert!(
+            stronghold_adapter
+                .generate_addresses(
+                    IOTA_COIN_TYPE,
+                    0,
+                    0..1,
+                    false,
+                    GenerateAddressMetadata { syncing: false },
+                )
+                .await
+                .is_err()
+        );
 
         stronghold_adapter.set_password("drowssap").await.unwrap();
 

--- a/tests/addresses.rs
+++ b/tests/addresses.rs
@@ -193,7 +193,7 @@ async fn address_generation() {
         let stronghold_filename = format!("{}.stronghold", address.bech32_address);
         let mut stronghold_secret_manager = StrongholdSecretManager::builder()
             .password("some_hopefully_secure_password")
-            .try_build(PathBuf::from(stronghold_filename.to_string()))
+            .build(PathBuf::from(stronghold_filename.to_string()))
             .unwrap();
 
         stronghold_secret_manager


### PR DESCRIPTION
A request/suggestion from the identity team. I personally agree.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
