### PR TITLE
Use custom url in Python example

### DIFF
--- a/bindings/python/examples/01_get_info.py
+++ b/bindings/python/examples/01_get_info.py
@@ -1,5 +1,7 @@
 import iota_client
 
-# client will connect to testnet by default
-client = iota_client.Client()
+# create a client with a node
+client = iota_client.Client(
+    nodes_name_password=[['https://api.lb-0.h.chrysalis-devnet.iota.cafe']])
+
 print(client.get_info())


### PR DESCRIPTION
# Description of change

Update example with custom url, because default urls don't work anymore with older builds and multiple people already had a problem because of that and then didn't know how to get it working

## Type of change

- Documentation Fix

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
