### PR TITLE
Fix ledger nano unlocks

### DIFF
--- a/.changes/ledger-nano-unlocks.md
+++ b/.changes/ledger-nano-unlocks.md
@@ -1,0 +1,6 @@
+
+---
+"nodejs-binding": patch
+---
+
+Fix missing reference unlocks with ledger nano secret manager.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix Wasm compilation with iota-crypto curl-p feature;
+- Fix missing reference unlocks with ledger nano secret manager;
 
 ## 2.0.0-beta.2 - 2022-08-22
 

--- a/src/secret/ledger_nano.rs
+++ b/src/secret/ledger_nano.rs
@@ -294,8 +294,14 @@ impl SecretManageExt for LedgerSecretManager {
         for _ in 0..input_len {
             let unlock = Unlock::unpack::<_, true>(&mut unpacker).map_err(|_| crate::Error::PackableError)?;
             // The ledger nano can return the same SignatureUnlocks multiple times, so only insert it once
-            if !unlocks.contains(&unlock) {
-                unlocks.push(unlock);
+            match unlock {
+                Unlock::Signature(_) => {
+                    if !unlocks.contains(&unlock) {
+                        unlocks.push(unlock);
+                    }
+                }
+                // Multiple reference unlocks with the same index are allowed
+                _ => unlocks.push(unlock),
             }
         }
 


### PR DESCRIPTION
# Description of change

Fix ledger nano unlocks with multiple reference unlocks that have the same index

## Links to any relevant issues

Fixes #1213 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ledger nano transaction example with multiple inputs from the same address

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
