### PR TITLE
Add `finish_pow` function to avoid the caller having to check for wasm family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.0.0-beta.4 - 2022-XX-XX
 
+### Added
+
+- `finish_pow` function to avoid the caller having to check for wasm family;
+
 ### Changed
 
 - Update dependencies;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update dependencies;
 - PoW node feature from `PoW` to `pow` to match TIP25;
+- Made `finish_multi_threaded_pow` and `finish_single_threaded_pow` private;
 
 ### Fixed
 

--- a/src/api/block_builder/mod.rs
+++ b/src/api/block_builder/mod.rs
@@ -414,13 +414,7 @@ impl<'a> ClientBlockBuilder<'a> {
                 let miner = self.client.get_pow_provider().await;
                 do_pow(miner, min_pow_score, payload, parents)?
             }
-            None => {
-                #[cfg(target_family = "wasm")]
-                let block = crate::api::pow::finish_single_threaded_pow(self.client, payload).await?;
-                #[cfg(not(target_family = "wasm"))]
-                let block = crate::api::pow::finish_multi_threaded_pow(self.client, payload).await?;
-                block
-            }
+            None => crate::api::pow::finish_pow(self.client, payload).await?,
         };
 
         let block_id = self.client.post_block_raw(&final_block).await?;

--- a/src/api/block_builder/pow/mod.rs
+++ b/src/api/block_builder/pow/mod.rs
@@ -35,7 +35,7 @@ pub fn do_pow<P: NonceProvider>(
         .map_err(Error::BlockError)
 }
 
-/// Calls the appropriate PoW function depending wether the compilation is for wasm or not.
+/// Calls the appropriate PoW function depending whether the compilation is for wasm or not.
 pub async fn finish_pow(client: &Client, payload: Option<Payload>) -> Result<Block> {
     #[cfg(not(target_family = "wasm"))]
     let block = crate::api::pow::finish_multi_threaded_pow(client, payload).await?;

--- a/src/api/block_builder/pow/mod.rs
+++ b/src/api/block_builder/pow/mod.rs
@@ -35,6 +35,16 @@ pub fn do_pow<P: NonceProvider>(
         .map_err(Error::BlockError)
 }
 
+/// Calls the appropriate PoW function depending wether the compilation is for wasm or not.
+pub async fn finish_pow(client: &Client, payload: Option<Payload>) -> Result<Block> {
+    #[cfg(not(target_family = "wasm"))]
+    let block = crate::api::pow::finish_multi_threaded_pow(client, payload).await?;
+    #[cfg(target_family = "wasm")]
+    let block = crate::api::pow::finish_single_threaded_pow(client, payload).await?;
+
+    Ok(block)
+}
+
 /// Performs multi-threaded proof-of-work.
 ///
 /// Always fetches new tips after each tips interval elapses.

--- a/src/api/block_builder/pow/mod.rs
+++ b/src/api/block_builder/pow/mod.rs
@@ -49,7 +49,7 @@ pub async fn finish_pow(client: &Client, payload: Option<Payload>) -> Result<Blo
 ///
 /// Always fetches new tips after each tips interval elapses.
 #[cfg(not(target_family = "wasm"))]
-pub async fn finish_multi_threaded_pow(client: &Client, payload: Option<Payload>) -> Result<Block> {
+async fn finish_multi_threaded_pow(client: &Client, payload: Option<Payload>) -> Result<Block> {
     let local_pow = client.get_local_pow().await;
     let pow_worker_count = client.pow_worker_count;
     let min_pow_score = client.get_min_pow_score().await?;
@@ -102,7 +102,7 @@ fn pow_timeout(after_seconds: u64, cancel: MinerCancel) -> (u64, Option<Block>) 
 ///
 /// Always fetches new tips after each tips interval elapses.
 #[cfg(target_family = "wasm")]
-pub async fn finish_single_threaded_pow(client: &Client, payload: Option<Payload>) -> Result<Block> {
+async fn finish_single_threaded_pow(client: &Client, payload: Option<Payload>) -> Result<Block> {
     let min_pow_score: f64 = client.get_min_pow_score().await?;
     let tips_interval: u64 = client.get_tips_interval().await;
     let local_pow: bool = client.get_local_pow().await;

--- a/src/client.rs
+++ b/src/client.rs
@@ -714,16 +714,7 @@ impl Client {
     pub async fn reattach_unchecked(&self, block_id: &BlockId) -> Result<(BlockId, Block)> {
         // Get the Block object by the BlockID.
         let block = self.get_block(block_id).await?;
-        let reattach_block = {
-            #[cfg(target_family = "wasm")]
-            {
-                crate::api::finish_single_threaded_pow(self, block.payload().cloned()).await?
-            }
-            #[cfg(not(target_family = "wasm"))]
-            {
-                crate::api::finish_multi_threaded_pow(self, block.payload().cloned()).await?
-            }
-        };
+        let reattach_block = crate::api::finish_pow(self, block.payload().cloned()).await?;
 
         // Post the modified
         let block_id = self.post_block_raw(&reattach_block).await?;

--- a/src/node_api/core/routes.rs
+++ b/src/node_api/core/routes.rs
@@ -198,10 +198,7 @@ impl Client {
                             // switch to local PoW
                             client_network_info.local_pow = true;
                         }
-                        #[cfg(not(target_family = "wasm"))]
-                        let block_res = crate::api::finish_multi_threaded_pow(self, block.payload().cloned()).await;
-                        #[cfg(target_family = "wasm")]
-                        let block_res = crate::api::finish_single_threaded_pow(self, block.payload().cloned()).await;
+                        let block_res = crate::api::finish_pow(self, block.payload().cloned()).await;
                         let block_with_local_pow = match block_res {
                             Ok(block) => {
                                 // reset local PoW state

--- a/src/node_api/core/routes.rs
+++ b/src/node_api/core/routes.rs
@@ -129,10 +129,7 @@ impl Client {
                             // switch to local PoW
                             client_network_info.local_pow = true;
                         }
-                        #[cfg(not(target_family = "wasm"))]
-                        let block_res = crate::api::finish_multi_threaded_pow(self, block.payload().cloned()).await;
-                        #[cfg(target_family = "wasm")]
-                        let block_res = crate::api::finish_single_threaded_pow(self, block.payload().cloned()).await;
+                        let block_res = crate::api::finish_pow(self, block.payload().cloned()).await;
                         let block_with_local_pow = match block_res {
                             Ok(block) => {
                                 // reset local PoW state


### PR DESCRIPTION
## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
