### PR TITLE
Improve type safety by using `Uint8Array` over `number[]`

### DIFF
--- a/.changes/uint8array-aliasbuilder-type.md
+++ b/.changes/uint8array-aliasbuilder-type.md
@@ -1,0 +1,6 @@
+
+---
+"nodejs-binding": patch
+---
+
+Use `Uint8Array` over `number[]` in `IAliasOutputBuilderOptions` to better reflect the type requirements.

--- a/.changes/uint8array-aliasbuilder-type.md
+++ b/.changes/uint8array-aliasbuilder-type.md
@@ -1,6 +1,0 @@
-
----
-"nodejs-binding": patch
----
-
-Use `Uint8Array` over `number[]` in `IAliasOutputBuilderOptions` to better reflect the type requirements.

--- a/.changes/uint8array-replace-number-array.md
+++ b/.changes/uint8array-replace-number-array.md
@@ -1,0 +1,6 @@
+
+---
+"nodejs-binding": patch
+---
+
+Use `Uint8Array` over `number[]` in `IAliasOutputBuilderOptions` and other places to better reflect the type requirements.

--- a/bindings/nodejs/lib/Client.ts
+++ b/bindings/nodejs/lib/Client.ts
@@ -500,7 +500,7 @@ export class Client {
     /**
      * Get block as raw bytes.
      */
-    async getBlockRaw(blockId: BlockId): Promise<number[]> {
+    async getBlockRaw(blockId: BlockId): Promise<Uint8Array> {
         const response = await this.messageHandler.sendMessage({
             name: 'GetBlockRaw',
             data: {

--- a/bindings/nodejs/types/outputBuilderOptions/aliasOutputOptions.ts
+++ b/bindings/nodejs/types/outputBuilderOptions/aliasOutputOptions.ts
@@ -7,7 +7,7 @@ import type { IBasicOutputBuilderOptions } from './basicOutputOptions';
 export interface IAliasOutputBuilderOptions extends IBasicOutputBuilderOptions {
     aliasId: string;
     stateIndex?: number;
-    stateMetadata?: number[];
+    stateMetadata?: Uint8Array;
     foundryCounter?: number;
     immutableFeatures?: FeatureTypes[];
 }

--- a/bindings/nodejs/types/preparedTransactionData.ts
+++ b/bindings/nodejs/types/preparedTransactionData.ts
@@ -65,5 +65,5 @@ export interface IRemainder {
 }
 export interface ISegment {
     hardened: boolean;
-    bs: number[];
+    bs: Uint8Array;
 }


### PR DESCRIPTION
# Description of change

Use `Uint8Array` over `number[]` in the `IAliasOutputBuilderOptions`. `number[]` suggests that values larger than those that fit into a byte can be used, which causes a runtime error. `Uint8Array` more accurately captures the requirement.

## Links to any relevant issues

n/a

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

None. This only changes the type definition which doesn't affect executed code.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
