### PR TITLE
Install libudev-dev in python publish

### DIFF
--- a/.github/workflows/python-bindings-publish.yml
+++ b/.github/workflows/python-bindings-publish.yml
@@ -50,6 +50,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install required packages (Ubuntu)
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install libudev-dev libusb-1.0-0-dev
+
       - name: Build Wheels
         working-directory: bindings/python/native
         run: |


### PR DESCRIPTION
# Description of change

Install libudev-dev in python publish, because it failed https://github.com/iotaledger/iota.rs/actions/runs/3105298794/jobs/5030746005

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
