### PR TITLE
Use aliases instead of rename_all for backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `finish_pow` function to avoid the caller having to check for wasm family;
+- Added `#[serde(rename_all = "camelCase")]` to enums and aliases for `SecretManagerDto` and `LedgerDeviceType` fields;
 
 ### Changed
 
@@ -33,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned up error enum;
 - Replaced `force_use_all_inputs` in `try_select_inputs()` with `mandatory_inputs`;
 - Rename `inputs` parameter in `try_select_inputs()` to `additional_inputs`;
-- Added `#[serde(rename_all = "camelCase")]` to enums;
 
 ### Fixed
 

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -130,20 +130,24 @@ impl FromStr for SecretManager {
 
 /// DTO for secret manager types with required data.
 #[derive(Debug, Clone, Serialize, Deserialize, ZeroizeOnDrop)]
-#[serde(rename_all = "camelCase")]
 pub enum SecretManagerDto {
     /// Stronghold
     #[cfg(feature = "stronghold")]
     #[cfg_attr(docsrs, doc(cfg(feature = "stronghold")))]
+    #[serde(alias = "stronghold")]
     Stronghold(StrongholdDto),
     /// Ledger Device, bool specifies if it's a simulator or not
     #[cfg(feature = "ledger_nano")]
+    #[serde(alias = "ledgerNano")]
     LedgerNano(bool),
     /// Mnemonic
+    #[serde(alias = "mnemonic")]
     Mnemonic(String),
     /// Hex seed
+    #[serde(alias = "hexSeed")]
     HexSeed(String),
     /// Placeholder
+    #[serde(alias = "placeholder")]
     Placeholder,
 }
 

--- a/src/secret/types.rs
+++ b/src/secret/types.rs
@@ -74,13 +74,15 @@ impl LedgerApp {
 
 /// Ledger Device Type
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub enum LedgerDeviceType {
     /// Device Type Nano S
+    #[serde(alias = "ledgerNanoS")]
     LedgerNanoS,
     /// Device Type Nano X
+    #[serde(alias = "ledgerNanoX")]
     LedgerNanoX,
     /// Device Type Nano S Plus
+    #[serde(alias = "ledgerNanoSPlus")]
     LedgerNanoSPlus,
 }
 


### PR DESCRIPTION
# Description of change

Use aliases instead of rename_all for backwards compatibility

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running the address generation nodejs example

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
