### PR TITLE
Remove docs version info

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -5,19 +5,12 @@ module.exports = {
     [
       '@docusaurus/plugin-content-docs',
       {
-        id: 'iota-rs-develop',
+        id: 'iota-rs',
         path: path.resolve(__dirname, 'docs'),
         routeBasePath: 'iota.rs',
         sidebarPath: path.resolve(__dirname, 'sidebars.js'),
         editUrl: 'https://github.com/iotaledger/iota.rs/edit/develop/documentation',
         remarkPlugins: [require('remark-code-import'), require('remark-import-partial')],
-        versions: {
-          current: {
-            label: 'Develop',
-            path: 'develop',
-            badge: true
-          },
-        },
       }
     ],
   ],


### PR DESCRIPTION
# Description of change

With wiki V3 we can get rid of this. iota.rs for Shimmer will be hosted under /shimmer/iota.rs/...

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
