### PR TITLE
Use `target_family` instead of `feature`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update dependencies;
 - Return `NetworkInfoDto` instead of `NetworkInfo` in message_interface;
 
+## 2.0.1-rc.2 - 2022-09-29
+
+### Added
+
+- `NetworkInfoDto`;
+
+### Changed
+
+- Update dependencies;
+- Return `NetworkInfoDto` instead of `NetworkInfo` in message_interface;
+- Use `#[cfg(target_family = "wasm")]` instead of `#[cfg(feature = "wasm")]`;
+
 ## 2.0.1-rc.1 - 2022-09-28
 
 Re-release as RC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,17 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## Unreleased - YYYY-MM-DD
-
-### Added
-
-- `NetworkInfoDto`;
-
-### Changed
-
-- Update dependencies;
-- Return `NetworkInfoDto` instead of `NetworkInfo` in message_interface;
-
 ## 2.0.1-rc.2 - 2022-09-29
 
 ### Added

--- a/src/node_manager/http_client.rs
+++ b/src/node_manager/http_client.rs
@@ -69,9 +69,9 @@ impl HttpClient {
         {
             request_builder = request_builder.timeout(_timeout);
         }
-        #[cfg(feature = "wasm")]
+        #[cfg(target_family = "wasm")]
         let start_time = instant::Instant::now();
-        #[cfg(not(feature = "wasm"))]
+        #[cfg(not(target_family = "wasm"))]
         let start_time = std::time::Instant::now();
         let resp = request_builder.send().await?;
         log::debug!(


### PR DESCRIPTION
# Description of change

Use `target_family` instead of the "wasm" feature, which doesn't exist. The current code leads to a panic when called from Wasm.

## Links to any relevant issues

None.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Compiled and ran a test program in iota.rs-wasm.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
