### PR TITLE
Add alias and nfts if required for unlock condition of inputs

### DIFF
--- a/.changes/alias-nft-unlock.md
+++ b/.changes/alias-nft-unlock.md
@@ -1,0 +1,6 @@
+
+---
+"nodejs-binding": patch
+---
+
+Add alias and nfts output in `try_select_input` to the inputs, when required for an unlock condition of an input.

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 2.0.1-rc.2 - YYYY-MM-DD
+
+### Fixed
+
+- Add alias and nfts output in `try_select_input` to the inputs, when required for an unlock condition of an input;
+
 ## 2.0.1-rc.2 - 2022-09-29
 
 ### Added

--- a/client/src/api/block_builder/input_selection/mod.rs
+++ b/client/src/api/block_builder/input_selection/mod.rs
@@ -301,6 +301,21 @@ pub fn try_select_inputs(
         get_storage_deposit_return_outputs(all_inputs, outputs.iter(), current_time, token_supply)?;
     outputs.extend(additional_storage_deposit_return_outputs.into_iter());
 
+    // Check utxo chain inputs again, because new inputs could have an alias or nft address in their unlock condition
+    select_utxo_chain_inputs(
+        &mut selected_inputs,
+        &mut selected_inputs_output_ids,
+        &mut selected_input_amount,
+        &mut selected_input_native_tokens,
+        &mut outputs,
+        &mut required,
+        &utxo_chain_inputs,
+        allow_burning,
+        current_time,
+        rent_structure,
+        token_supply,
+    )?;
+
     // create remainder output if necessary
     // get_remainder also checks for amounts and returns an error if we don't have enough
     let remainder_data = get_remainder_output(

--- a/client/src/api/block_builder/input_selection/utxo_chains/mod.rs
+++ b/client/src/api/block_builder/input_selection/utxo_chains/mod.rs
@@ -47,6 +47,8 @@ pub(crate) fn select_utxo_chain_inputs(
     // We track here for which outputs we did that, to prevent doing it multiple times.
     let mut added_output_for_input_signing_data = HashSet::new();
 
+    let mut required_alias_nft_addresses = HashSet::new();
+
     // Add existing selected inputs we added for sender and issuer features before
     for input_signing_data in selected_inputs.iter() {
         // Add inputs to outputs if not already there, so they don't get burned
@@ -54,6 +56,10 @@ pub(crate) fn select_utxo_chain_inputs(
             add_output_for_input(input_signing_data, rent_structure, outputs, token_supply)?;
         }
         added_output_for_input_signing_data.insert(input_signing_data.output_id()?);
+        let address = Address::try_from_bech32(&input_signing_data.bech32_address)?.1;
+        if address.is_alias() || address.is_nft() {
+            required_alias_nft_addresses.insert(address);
+        }
     }
 
     loop {
@@ -73,14 +79,16 @@ pub(crate) fn select_utxo_chain_inputs(
                 Output::Nft(nft_input) => {
                     let nft_id = nft_input.nft_id().or_from_output_id(output_id);
                     // or if an output contains an nft output with the same nft id
-                    let is_required = outputs.iter().any(|output| {
+                    let is_required_for_output = outputs.iter().any(|output| {
                         if let Output::Nft(nft_output) = output {
                             nft_id == *nft_output.nft_id()
                         } else {
                             false
                         }
                     });
-                    if !is_required && !allow_burning {
+                    let is_required_for_input =
+                        required_alias_nft_addresses.contains(&Address::Nft(NftAddress::new(nft_id)));
+                    if !is_required_for_output && !allow_burning || is_required_for_input {
                         let nft_address = Address::Nft(NftAddress::new(nft_id));
                         let nft_required_in_unlock_condition = outputs.iter().any(|output| {
                             // check if alias address is in unlock condition
@@ -91,6 +99,7 @@ pub(crate) fn select_utxo_chain_inputs(
                         if !nft_required_in_unlock_condition
                             && input_signing_data.output.amount() == minimum_required_storage_deposit
                             && nft_input.native_tokens().is_empty()
+                            && !is_required_for_input
                         {
                             continue;
                         }
@@ -114,14 +123,17 @@ pub(crate) fn select_utxo_chain_inputs(
                 Output::Alias(alias_input) => {
                     let alias_id = alias_input.alias_id().or_from_output_id(output_id);
                     // Don't add if output has not the same AliasId, so we don't burn it
-                    if !outputs.iter().any(|output| {
+                    let is_required_for_output = outputs.iter().any(|output| {
                         if let Output::Alias(alias_output) = output {
                             alias_id == *alias_output.alias_id()
                         } else {
                             false
                         }
-                    }) && !allow_burning
-                    {
+                    });
+                    let is_required_for_input =
+                        required_alias_nft_addresses.contains(&Address::Alias(AliasAddress::new(alias_id)));
+
+                    if !is_required_for_output && !allow_burning || is_required_for_input {
                         let alias_address = Address::Alias(AliasAddress::new(alias_id));
                         let alias_required_in_unlock_condition = outputs.iter().any(|output| {
                             // check if alias address is in unlock condition
@@ -132,6 +144,7 @@ pub(crate) fn select_utxo_chain_inputs(
                         if !alias_required_in_unlock_condition
                             && input_signing_data.output.amount() == minimum_required_storage_deposit
                             && alias_input.native_tokens().is_empty()
+                            && !is_required_for_input
                         {
                             continue;
                         }


### PR DESCRIPTION
# Description of change

Add alias and nfts if required for unlock condition of inputs

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

With the cli wallet, sending a basic output which has an nft address in the address unlock condition https://explorer.shimmer.network/testnet/block/0xf3b6c907b3dc26e5059cdca39e88e27b90ebae14ae670369f4471f78bf28eb9a

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
