### PR TITLE
Update healthy nodes to included all, even without pow feature

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add alias and nfts output in `try_select_input` to the inputs, when required for an unlock condition of an input;
+- Healthy node list, when building with `.with_local_pow(false)`;
 
 ## 2.0.1-rc.2 - 2022-09-29
 

--- a/client/src/client/builder.rs
+++ b/client/src/client/builder.rs
@@ -3,7 +3,7 @@
 
 //! Builder of the Client Instance
 use std::{
-    collections::HashSet,
+    collections::HashMap,
     sync::{Arc, RwLock},
     time::Duration,
 };
@@ -316,7 +316,7 @@ impl ClientBuilder {
     /// Build the Client instance.
     pub fn finish(self) -> Result<Client> {
         let network_info = Arc::new(RwLock::new(self.network_info));
-        let healthy_nodes = Arc::new(RwLock::new(HashSet::new()));
+        let healthy_nodes = Arc::new(RwLock::new(HashMap::new()));
 
         #[cfg(not(target_family = "wasm"))]
         let (runtime, sync_kill_sender) = {

--- a/client/src/node_api/mqtt/mod.rs
+++ b/client/src/node_api/mqtt/mod.rs
@@ -73,7 +73,9 @@ async fn get_mqtt_client(client: &mut Client) -> Result<&mut MqttClient> {
                         .node_manager
                         .healthy_nodes
                         .read()
-                        .map_or(client.node_manager.nodes.clone(), |healthy_nodes| healthy_nodes.clone())
+                        .map_or(client.node_manager.nodes.clone(), |healthy_nodes| {
+                            healthy_nodes.iter().map(|(node, _)| node.clone()).collect()
+                        })
                 }
                 #[cfg(target_family = "wasm")]
                 {

--- a/client/src/node_manager/builder.rs
+++ b/client/src/node_manager/builder.rs
@@ -4,11 +4,12 @@
 //! The node manager that takes care of sending requests with healthy nodes and quorum if enabled
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     sync::{Arc, RwLock},
     time::Duration,
 };
 
+use iota_types::api::response::InfoResponse;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -207,7 +208,7 @@ impl NodeManagerBuilder {
         self
     }
 
-    pub(crate) fn build(self, healthy_nodes: Arc<RwLock<HashSet<Node>>>) -> NodeManager {
+    pub(crate) fn build(self, healthy_nodes: Arc<RwLock<HashMap<Node, InfoResponse>>>) -> NodeManager {
         NodeManager {
             primary_node: self.primary_node.map(|node| node.into()),
             primary_pow_node: self.primary_pow_node.map(|node| node.into()),


### PR DESCRIPTION
# Description of change

Update healthy nodes to included all, even without pow feature, because most requests are independent of pow and should still work, even if the node doesn't support remote pow.

## Links to any relevant issues

Fixes #1264 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running get_info example with `with_node_sync_disabled()` removed and `.with_local_pow(false)` added and it still returns the nodeinfo

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
