### PR TITLE
Fix python packages link

### DIFF
--- a/documentation/docs/getting_started/python.mdx
+++ b/documentation/docs/getting_started/python.mdx
@@ -17,7 +17,7 @@ import WarningPasswordStorage from "../_admonitions/_password_storage.md";
 <WarningPasswordStorage />
 
 ## Installation
-Easiest way how to get python binding up and running is to leverage pre-built python libraries for linux/macos/windows that can be installed to your python environment (3.6+) via `pip`. The binding is automagically generated using github [actions](https://github.com/iotaledger/iota.rs/actions/workflows/python_binding_publish.yml).
+Easiest way how to get python binding up and running is to leverage pre-built python libraries for linux/macos/windows that can be installed to your python environment (3.6+) via `pip`. The binding is automagically generated using github [actions](https://github.com/iotaledger/iota.rs/actions/workflows/python-bindings-publish.yml?query=branch%3Aproduction).
 
 The latest artifacts for major python versions can be also grabbed using [nighly.link service](https://nightly.link/iotaledger/iota.rs/workflows/python-bindings-publish/production). Download zip file for the given os and pyversion, unpack wheel file (`.whl`) and install it via `pip`:
 


### PR DESCRIPTION
# Description of change

The packages in the old link are all expired. I was given that link but it isn't part of the docs

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
