### PR TITLE
Add `AliasOutput::alias_id_non_null` and `NftOutput::nft_id_non_null` methods;

### DIFF
--- a/client/examples/output/alias.rs
+++ b/client/examples/output/alias.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
     // create second transaction with the actual AliasId (BLAKE2b-160 hash of the Output ID that created the alias)
     //////////////////////////////////
     let alias_output_id = get_alias_output_id(block.payload().unwrap())?;
-    let alias_id = AliasId::from(alias_output_id);
+    let alias_id = AliasId::from(&alias_output_id);
     let outputs = vec![
         alias_output_builder
             .with_alias_id(alias_id)

--- a/client/examples/output/all.rs
+++ b/client/examples/output/all.rs
@@ -102,14 +102,14 @@ async fn main() -> Result<()> {
     // create foundry, native tokens and nft output
     ///////////////////////////////////////////////
     let alias_output_id = get_alias_output_id(block.payload().unwrap())?;
-    let alias_id = AliasId::from(alias_output_id);
+    let alias_id = AliasId::from(&alias_output_id);
 
     let nft_output_id = get_nft_output_id(block.payload().unwrap())?;
-    let nft_id = NftId::from(nft_output_id);
+    let nft_id = NftId::from(&nft_output_id);
 
     let token_scheme = TokenScheme::Simple(SimpleTokenScheme::new(U256::from(50), U256::from(0), U256::from(100))?);
     let foundry_id = FoundryId::build(
-        &AliasAddress::from(AliasId::from(alias_output_id)),
+        &AliasAddress::from(AliasId::from(&alias_output_id)),
         1,
         token_scheme.kind(),
     );

--- a/client/examples/output/all_automatic_input_selection.rs
+++ b/client/examples/output/all_automatic_input_selection.rs
@@ -99,12 +99,12 @@ async fn main() -> Result<()> {
     // create foundry output, native tokens and nft
     //////////////////////////////////
     let alias_output_id_1 = get_alias_output_id(block.payload().unwrap())?;
-    let alias_id = AliasId::from(alias_output_id_1);
+    let alias_id = AliasId::from(&alias_output_id_1);
     let nft_output_id = get_nft_output_id(block.payload().unwrap())?;
-    let nft_id = NftId::from(nft_output_id);
+    let nft_id = NftId::from(&nft_output_id);
     let token_scheme = TokenScheme::Simple(SimpleTokenScheme::new(U256::from(50), U256::from(0), U256::from(100))?);
     let foundry_id = FoundryId::build(
-        &AliasAddress::from(AliasId::from(alias_output_id_1)),
+        &AliasAddress::from(AliasId::from(&alias_output_id_1)),
         1,
         token_scheme.kind(),
     );

--- a/client/examples/output/foundry.rs
+++ b/client/examples/output/foundry.rs
@@ -89,14 +89,14 @@ async fn main() -> Result<()> {
     // create foundry output and mint 70 native tokens
     //////////////////////////////////////////////////
     let alias_output_id = get_alias_output_id(block.payload().unwrap())?;
-    let alias_id = AliasId::from(alias_output_id);
+    let alias_id = AliasId::from(&alias_output_id);
     let token_scheme = TokenScheme::Simple(SimpleTokenScheme::new(
         U256::from(70u8),
         U256::from(0u8),
         U256::from(100u8),
     )?);
     let foundry_id = FoundryId::build(
-        &AliasAddress::from(AliasId::from(alias_output_id)),
+        &AliasAddress::from(AliasId::from(&alias_output_id)),
         1,
         token_scheme.kind(),
     );

--- a/client/examples/output/nft.rs
+++ b/client/examples/output/nft.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
     //////////////////////////////////
 
     let nft_output_id = get_nft_output_id(block.payload().unwrap())?;
-    let nft_id = NftId::from(nft_output_id);
+    let nft_id = NftId::from(&nft_output_id);
 
     let nft_address = NftAddress::new(nft_id);
     let bech32_nft_address = Address::Nft(nft_address).to_bech32(client.get_bech32_hrp().await?);

--- a/client/examples/output/recursive_alias.rs
+++ b/client/examples/output/recursive_alias.rs
@@ -91,9 +91,9 @@ async fn main() -> Result<()> {
     // make both alias outputs controlled by the first one
     //////////////////////////////////
     let alias_output_ids = get_new_alias_output_ids(block_1.payload().unwrap())?;
-    let alias_id_0 = AliasId::from(alias_output_ids[0]);
-    let alias_id_1 = AliasId::from(alias_output_ids[1]);
-    let alias_id_2 = AliasId::from(alias_output_ids[2]);
+    let alias_id_0 = AliasId::from(&alias_output_ids[0]);
+    let alias_id_1 = AliasId::from(&alias_output_ids[1]);
+    let alias_id_2 = AliasId::from(&alias_output_ids[2]);
 
     let alias_0_address = Address::Alias(AliasAddress::new(alias_id_0));
     let alias_1_address = Address::Alias(AliasAddress::new(alias_id_1));

--- a/client/src/api/block_builder/input_selection/automatic.rs
+++ b/client/src/api/block_builder/input_selection/automatic.rs
@@ -144,7 +144,7 @@ impl<'a> ClientBlockBuilder<'a> {
                         let (required_unlock_address, _unlocked_alias_or_nft_address) = output
                             .required_and_unlocked_address(
                                 current_time,
-                                output_response.metadata.output_id()?,
+                                &output_response.metadata.output_id()?,
                                 false,
                             )?;
                         if required_unlock_address == address {

--- a/client/src/api/block_builder/input_selection/helpers.rs
+++ b/client/src/api/block_builder/input_selection/helpers.rs
@@ -100,18 +100,14 @@ pub(crate) fn sort_input_signing_data(inputs: Vec<InputSigningData>) -> crate::R
             Ok((_, unlock_address)) => match unlock_address {
                 Address::Alias(unlock_address) => {
                     if let Output::Alias(alias_output) = &input_signing_data.output {
-                        *unlock_address.alias_id()
-                            == alias_output
-                                .alias_id()
-                                .or_from_output_id(input_signing_data.output_id())
+                        *unlock_address.alias_id() == alias_output.alias_id_non_null(input_signing_data.output_id())
                     } else {
                         false
                     }
                 }
                 Address::Nft(unlock_address) => {
                     if let Output::Nft(nft_output) = &input_signing_data.output {
-                        *unlock_address.nft_id()
-                            == nft_output.nft_id().or_from_output_id(input_signing_data.output_id())
+                        *unlock_address.nft_id() == nft_output.nft_id_non_null(input_signing_data.output_id())
                     } else {
                         false
                     }
@@ -128,10 +124,10 @@ pub(crate) fn sort_input_signing_data(inputs: Vec<InputSigningData>) -> crate::R
                 // insert before address
                 let alias_or_nft_address = match &input.output {
                     Output::Alias(alias_output) => Some(Address::Alias(AliasAddress::new(
-                        alias_output.alias_id().or_from_output_id(input.output_id()),
+                        alias_output.alias_id_non_null(input.output_id()),
                     ))),
                     Output::Nft(nft_output) => Some(Address::Nft(NftAddress::new(
-                        nft_output.nft_id().or_from_output_id(input.output_id()),
+                        nft_output.nft_id_non_null(input.output_id()),
                     ))),
                     _ => None,
                 };

--- a/client/src/api/block_builder/input_selection/helpers.rs
+++ b/client/src/api/block_builder/input_selection/helpers.rs
@@ -103,7 +103,7 @@ pub(crate) fn sort_input_signing_data(inputs: Vec<InputSigningData>) -> crate::R
                         *unlock_address.alias_id()
                             == alias_output
                                 .alias_id()
-                                .or_from_output_id(*input_signing_data.output_id())
+                                .or_from_output_id(input_signing_data.output_id())
                     } else {
                         false
                     }
@@ -111,7 +111,7 @@ pub(crate) fn sort_input_signing_data(inputs: Vec<InputSigningData>) -> crate::R
                 Address::Nft(unlock_address) => {
                     if let Output::Nft(nft_output) = &input_signing_data.output {
                         *unlock_address.nft_id()
-                            == nft_output.nft_id().or_from_output_id(*input_signing_data.output_id())
+                            == nft_output.nft_id().or_from_output_id(input_signing_data.output_id())
                     } else {
                         false
                     }
@@ -128,10 +128,10 @@ pub(crate) fn sort_input_signing_data(inputs: Vec<InputSigningData>) -> crate::R
                 // insert before address
                 let alias_or_nft_address = match &input.output {
                     Output::Alias(alias_output) => Some(Address::Alias(AliasAddress::new(
-                        alias_output.alias_id().or_from_output_id(*input.output_id()),
+                        alias_output.alias_id().or_from_output_id(input.output_id()),
                     ))),
                     Output::Nft(nft_output) => Some(Address::Nft(NftAddress::new(
-                        nft_output.nft_id().or_from_output_id(*input.output_id()),
+                        nft_output.nft_id().or_from_output_id(input.output_id()),
                     ))),
                     _ => None,
                 };

--- a/client/src/api/block_builder/input_selection/sender_issuer.rs
+++ b/client/src/api/block_builder/input_selection/sender_issuer.rs
@@ -58,7 +58,7 @@ impl<'a> ClientBlockBuilder<'a> {
                         let (required_unlock_address, _unlocked_alias_or_nft_address) = output
                             .required_and_unlocked_address(
                                 current_time,
-                                output_response.metadata.output_id()?,
+                                &output_response.metadata.output_id()?,
                                 false,
                             )?;
 
@@ -235,7 +235,7 @@ pub(crate) fn select_inputs_for_sender_and_issuer<'a>(
             let alias_state_transition = alias_state_transition(input_signing_data, outputs)?.unwrap_or(true);
             let (required_unlock_address, unlocked_alias_or_nft_address) = input_signing_data
                 .output
-                .required_and_unlocked_address(current_time, *input_signing_data.output_id(), alias_state_transition)?;
+                .required_and_unlocked_address(current_time, input_signing_data.output_id(), alias_state_transition)?;
 
             if required_unlock_address == required_address {
                 continue 'addresses_loop;
@@ -259,7 +259,7 @@ pub(crate) fn select_inputs_for_sender_and_issuer<'a>(
             let alias_state_transition = alias_state_transition(input_signing_data, outputs)?.unwrap_or(true);
             let (required_unlock_address, unlocked_alias_or_nft_address) = input_signing_data
                 .output
-                .required_and_unlocked_address(current_time, *output_id, alias_state_transition)?;
+                .required_and_unlocked_address(current_time, output_id, alias_state_transition)?;
 
             if required_unlock_address == required_address {
                 selected_inputs.push(input_signing_data.clone());
@@ -298,7 +298,7 @@ fn get_required_addresses_for_sender_and_issuer(
         let (required_unlock_address, unlocked_alias_or_nft_address) =
             input_signing_data.output.required_and_unlocked_address(
                 current_time,
-                *input_signing_data.output_id(),
+                input_signing_data.output_id(),
                 alias_state_transition.unwrap_or(false),
             )?;
         unlocked_addresses.insert(required_unlock_address);
@@ -346,9 +346,7 @@ pub(crate) fn alias_state_transition(
     outputs: &[Output],
 ) -> Result<Option<bool>> {
     Ok(if let Output::Alias(alias_input) = &input_signing_data.output {
-        let alias_id = alias_input
-            .alias_id()
-            .or_from_output_id(*input_signing_data.output_id());
+        let alias_id = alias_input.alias_id().or_from_output_id(input_signing_data.output_id());
         // Check if alias exists in the outputs and get the required transition type
         outputs
             .iter()

--- a/client/src/api/block_builder/input_selection/sender_issuer.rs
+++ b/client/src/api/block_builder/input_selection/sender_issuer.rs
@@ -346,7 +346,7 @@ pub(crate) fn alias_state_transition(
     outputs: &[Output],
 ) -> Result<Option<bool>> {
     Ok(if let Output::Alias(alias_input) = &input_signing_data.output {
-        let alias_id = alias_input.alias_id().or_from_output_id(input_signing_data.output_id());
+        let alias_id = alias_input.alias_id_non_null(input_signing_data.output_id());
         // Check if alias exists in the outputs and get the required transition type
         outputs
             .iter()

--- a/client/src/api/block_builder/input_selection/utxo_chains/mod.rs
+++ b/client/src/api/block_builder/input_selection/utxo_chains/mod.rs
@@ -82,7 +82,7 @@ pub(crate) fn select_utxo_chain_inputs(
 
             match &input_signing_data.output {
                 Output::Nft(nft_input) => {
-                    let nft_id = nft_input.nft_id().or_from_output_id(&output_id);
+                    let nft_id = nft_input.nft_id_non_null(&output_id);
                     // or if an output contains an nft output with the same nft id
                     let is_required_for_output = outputs.iter().any(|output| {
                         if let Output::Nft(nft_output) = output {
@@ -135,7 +135,7 @@ pub(crate) fn select_utxo_chain_inputs(
                             .filter(|feature| feature.kind() != SenderFeature::KIND);
                         // else add output to outputs with minimum_required_storage_deposit
                         let new_output = NftOutputBuilder::from(nft_input)
-                            .with_nft_id(nft_input.nft_id().or_from_output_id(&output_id))
+                            .with_nft_id(nft_input.nft_id_non_null(&output_id))
                             .with_amount(minimum_required_storage_deposit)?
                             // replace with filtered features
                             .with_features(filtered_features)
@@ -145,7 +145,7 @@ pub(crate) fn select_utxo_chain_inputs(
                     }
                 }
                 Output::Alias(alias_input) => {
-                    let alias_id = alias_input.alias_id().or_from_output_id(&output_id);
+                    let alias_id = alias_input.alias_id_non_null(&output_id);
                     // Don't add if output has not the same AliasId, so we don't burn it
                     let alias_in_outputs = outputs
                         .iter()
@@ -217,7 +217,7 @@ pub(crate) fn select_utxo_chain_inputs(
                             .filter(|feature| feature.kind() != SenderFeature::KIND);
                         // else add output to outputs with minimum_required_storage_deposit
                         let new_output = AliasOutputBuilder::from(alias_input)
-                            .with_alias_id(alias_input.alias_id().or_from_output_id(&output_id))
+                            .with_alias_id(alias_input.alias_id_non_null(&output_id))
                             .with_state_index(alias_input.state_index() + 1)
                             .with_amount(minimum_required_storage_deposit)?
                             // replace with filtered features
@@ -391,7 +391,7 @@ fn add_output_for_input(
 
     match &input_signing_data.output {
         Output::Nft(nft_input) => {
-            let nft_id = nft_input.nft_id().or_from_output_id(output_id);
+            let nft_id = nft_input.nft_id_non_null(output_id);
             // Don't add if nft output is already present in the outputs.
             if !outputs.iter().any(|output| {
                 if let Output::Nft(nft_output) = output {
@@ -408,7 +408,7 @@ fn add_output_for_input(
                     .filter(|feature| feature.kind() != SenderFeature::KIND);
                 // add output to outputs with minimum_required_storage_deposit
                 let new_output = NftOutputBuilder::from(nft_input)
-                    .with_nft_id(nft_input.nft_id().or_from_output_id(output_id))
+                    .with_nft_id(nft_input.nft_id_non_null(output_id))
                     .with_amount(minimum_required_storage_deposit)?
                     // replace with filtered features
                     .with_features(filtered_features)
@@ -417,7 +417,7 @@ fn add_output_for_input(
             }
         }
         Output::Alias(alias_input) => {
-            let alias_id = alias_input.alias_id().or_from_output_id(output_id);
+            let alias_id = alias_input.alias_id_non_null(output_id);
             // Don't add if alias output is already present in the outputs.
             if !outputs.iter().any(|output| {
                 if let Output::Alias(alias_output) = output {
@@ -434,7 +434,7 @@ fn add_output_for_input(
                     .filter(|feature| feature.kind() != SenderFeature::KIND);
                 // else add output to outputs with minimum_required_storage_deposit
                 let new_output = AliasOutputBuilder::from(alias_input)
-                    .with_alias_id(alias_input.alias_id().or_from_output_id(output_id))
+                    .with_alias_id(alias_input.alias_id_non_null(output_id))
                     .with_state_index(alias_input.state_index() + 1)
                     .with_amount(minimum_required_storage_deposit)?
                     // replace with filtered features

--- a/client/src/api/block_builder/input_selection/utxo_chains/mod.rs
+++ b/client/src/api/block_builder/input_selection/utxo_chains/mod.rs
@@ -82,7 +82,7 @@ pub(crate) fn select_utxo_chain_inputs(
 
             match &input_signing_data.output {
                 Output::Nft(nft_input) => {
-                    let nft_id = nft_input.nft_id().or_from_output_id(output_id);
+                    let nft_id = nft_input.nft_id().or_from_output_id(&output_id);
                     // or if an output contains an nft output with the same nft id
                     let is_required_for_output = outputs.iter().any(|output| {
                         if let Output::Nft(nft_output) = output {
@@ -102,7 +102,7 @@ pub(crate) fn select_utxo_chain_inputs(
                                     // It's a new output, so the output id doesn't matter, since the id will either
                                     // already be set and then the null output id isn't used, or it will be null and
                                     // then it can't unlock anything anyways
-                                    OutputId::null(),
+                                    &OutputId::null(),
                                     false,
                                 )
                             {
@@ -135,7 +135,7 @@ pub(crate) fn select_utxo_chain_inputs(
                             .filter(|feature| feature.kind() != SenderFeature::KIND);
                         // else add output to outputs with minimum_required_storage_deposit
                         let new_output = NftOutputBuilder::from(nft_input)
-                            .with_nft_id(nft_input.nft_id().or_from_output_id(output_id))
+                            .with_nft_id(nft_input.nft_id().or_from_output_id(&output_id))
                             .with_amount(minimum_required_storage_deposit)?
                             // replace with filtered features
                             .with_features(filtered_features)
@@ -145,7 +145,7 @@ pub(crate) fn select_utxo_chain_inputs(
                     }
                 }
                 Output::Alias(alias_input) => {
-                    let alias_id = alias_input.alias_id().or_from_output_id(output_id);
+                    let alias_id = alias_input.alias_id().or_from_output_id(&output_id);
                     // Don't add if output has not the same AliasId, so we don't burn it
                     let alias_in_outputs = outputs
                         .iter()
@@ -179,7 +179,7 @@ pub(crate) fn select_utxo_chain_inputs(
                                     // It's a new output, so the output id doesn't matter, since the id will either
                                     // already be set and then the null output id isn't used, or it will be null and
                                     // then it can't unlock anything anyways
-                                    OutputId::null(),
+                                    &OutputId::null(),
                                     // The alias address is only returned if it's a state transition, so we set it to
                                     // true, even if it's not a state transition, because we're checking the output and
                                     // not the input and then we want to see if the alias is required in the input,
@@ -217,7 +217,7 @@ pub(crate) fn select_utxo_chain_inputs(
                             .filter(|feature| feature.kind() != SenderFeature::KIND);
                         // else add output to outputs with minimum_required_storage_deposit
                         let new_output = AliasOutputBuilder::from(alias_input)
-                            .with_alias_id(alias_input.alias_id().or_from_output_id(output_id))
+                            .with_alias_id(alias_input.alias_id().or_from_output_id(&output_id))
                             .with_state_index(alias_input.state_index() + 1)
                             .with_amount(minimum_required_storage_deposit)?
                             // replace with filtered features
@@ -312,10 +312,10 @@ pub(crate) async fn get_alias_and_nft_outputs_recursively(
 
         match Output::try_from_dto(&output_response.output, token_supply)? {
             Output::Alias(alias_output) => {
-                processed_alias_nft_addresses.insert(Address::Alias(alias_output.alias_address(output_id)));
+                processed_alias_nft_addresses.insert(Address::Alias(alias_output.alias_address(&output_id)));
             }
             Output::Nft(nft_output) => {
-                processed_alias_nft_addresses.insert(Address::Nft(nft_output.nft_address(output_id)));
+                processed_alias_nft_addresses.insert(Address::Nft(nft_output.nft_address(&output_id)));
             }
             _ => {}
         }
@@ -386,7 +386,7 @@ fn add_output_for_input(
     outputs: &mut Vec<Output>,
     token_supply: u64,
 ) -> crate::Result<()> {
-    let output_id = *input_signing_data.output_id();
+    let output_id = input_signing_data.output_id();
     let minimum_required_storage_deposit = input_signing_data.output.rent_cost(rent_structure);
 
     match &input_signing_data.output {

--- a/client/src/api/block_builder/input_selection/utxo_chains/validation.rs
+++ b/client/src/api/block_builder/input_selection/utxo_chains/validation.rs
@@ -23,7 +23,7 @@ pub(crate) fn check_utxo_chain_inputs(
 
                 if !selected_inputs.iter().any(|data| {
                     if let Output::Alias(input_alias_output) = &data.output {
-                        input_alias_output.alias_id().or_from_output_id(*data.output_id()) == *alias_id
+                        input_alias_output.alias_id().or_from_output_id(data.output_id()) == *alias_id
                     } else {
                         false
                     }
@@ -37,7 +37,7 @@ pub(crate) fn check_utxo_chain_inputs(
                 let required_alias = foundry_output.alias_address().alias_id();
                 if !selected_inputs.iter().any(|data| {
                     if let Output::Alias(input_alias_output) = &data.output {
-                        input_alias_output.alias_id().or_from_output_id(*data.output_id()) == *required_alias
+                        input_alias_output.alias_id().or_from_output_id(data.output_id()) == *required_alias
                     } else {
                         false
                     }
@@ -57,7 +57,7 @@ pub(crate) fn check_utxo_chain_inputs(
 
                 if !selected_inputs.iter().any(|data| {
                     if let Output::Nft(input_nft_output) = &data.output {
-                        input_nft_output.nft_id().or_from_output_id(*data.output_id()) == *nft_id
+                        input_nft_output.nft_id().or_from_output_id(data.output_id()) == *nft_id
                     } else {
                         false
                     }

--- a/client/src/api/block_builder/input_selection/utxo_chains/validation.rs
+++ b/client/src/api/block_builder/input_selection/utxo_chains/validation.rs
@@ -23,7 +23,7 @@ pub(crate) fn check_utxo_chain_inputs(
 
                 if !selected_inputs.iter().any(|data| {
                     if let Output::Alias(input_alias_output) = &data.output {
-                        input_alias_output.alias_id().or_from_output_id(data.output_id()) == *alias_id
+                        input_alias_output.alias_id_non_null(data.output_id()) == *alias_id
                     } else {
                         false
                     }
@@ -37,7 +37,7 @@ pub(crate) fn check_utxo_chain_inputs(
                 let required_alias = foundry_output.alias_address().alias_id();
                 if !selected_inputs.iter().any(|data| {
                     if let Output::Alias(input_alias_output) = &data.output {
-                        input_alias_output.alias_id().or_from_output_id(data.output_id()) == *required_alias
+                        input_alias_output.alias_id_non_null(data.output_id()) == *required_alias
                     } else {
                         false
                     }
@@ -57,7 +57,7 @@ pub(crate) fn check_utxo_chain_inputs(
 
                 if !selected_inputs.iter().any(|data| {
                     if let Output::Nft(input_nft_output) = &data.output {
-                        input_nft_output.nft_id().or_from_output_id(data.output_id()) == *nft_id
+                        input_nft_output.nft_id_non_null(data.output_id()) == *nft_id
                     } else {
                         false
                     }

--- a/client/src/message_interface/message_handler.rs
+++ b/client/src/message_interface/message_handler.rs
@@ -573,8 +573,8 @@ impl ClientMessageHandler {
                 let payload = TransactionPayload::try_from_dto_unverified(&payload)?;
                 Ok(Response::TransactionId(payload.id()))
             }
-            Message::ComputeAliasId { output_id } => Ok(Response::AliasId(AliasId::from(output_id))),
-            Message::ComputeNftId { output_id } => Ok(Response::NftId(NftId::from(output_id))),
+            Message::ComputeAliasId { output_id } => Ok(Response::AliasId(AliasId::from(&output_id))),
+            Message::ComputeNftId { output_id } => Ok(Response::NftId(NftId::from(&output_id))),
             Message::ComputeFoundryId {
                 alias_address,
                 serial_number,

--- a/client/src/secret/ledger_nano.rs
+++ b/client/src/secret/ledger_nano.rs
@@ -437,15 +437,11 @@ fn merge_unlocks(
         // that have the corresponding alias or nft address in their unlock condition
         match &input.output {
             Output::Alias(alias_output) => block_indexes.insert(
-                Address::Alias(AliasAddress::new(
-                    alias_output.alias_id().or_from_output_id(input.output_id()),
-                )),
+                Address::Alias(AliasAddress::new(alias_output.alias_id_non_null(input.output_id()))),
                 current_block_index,
             ),
             Output::Nft(nft_output) => block_indexes.insert(
-                Address::Nft(NftAddress::new(
-                    nft_output.nft_id().or_from_output_id(input.output_id()),
-                )),
+                Address::Nft(NftAddress::new(nft_output.nft_id_non_null(input.output_id()))),
                 current_block_index,
             ),
             _ => None,

--- a/client/src/secret/ledger_nano.rs
+++ b/client/src/secret/ledger_nano.rs
@@ -438,13 +438,13 @@ fn merge_unlocks(
         match &input.output {
             Output::Alias(alias_output) => block_indexes.insert(
                 Address::Alias(AliasAddress::new(
-                    alias_output.alias_id().or_from_output_id(*input.output_id()),
+                    alias_output.alias_id().or_from_output_id(input.output_id()),
                 )),
                 current_block_index,
             ),
             Output::Nft(nft_output) => block_indexes.insert(
                 Address::Nft(NftAddress::new(
-                    nft_output.nft_id().or_from_output_id(*input.output_id()),
+                    nft_output.nft_id().or_from_output_id(input.output_id()),
                 )),
                 current_block_index,
             ),

--- a/client/src/secret/mod.rs
+++ b/client/src/secret/mod.rs
@@ -339,11 +339,11 @@ impl SecretManager {
             // that have the corresponding alias or nft address in their unlock condition
             match &input.output {
                 Output::Alias(alias_output) => block_indexes.insert(
-                    Address::Alias(alias_output.alias_address(*input.output_id())),
+                    Address::Alias(alias_output.alias_address(input.output_id())),
                     current_block_index,
                 ),
                 Output::Nft(nft_output) => block_indexes.insert(
-                    Address::Nft(nft_output.nft_address(*input.output_id())),
+                    Address::Nft(nft_output.nft_address(input.output_id())),
                     current_block_index,
                 ),
                 _ => None,

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `OutputResponse` enum with `Json` and `Raw` variants;
+- `AliasOutput::alias_id_non_null` and `NftOutput::nft_id_non_null` methods;
 
 ### Changed
 

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Renamed `OutputResponse` to `OutputWithMetadataResponse`;
+- `OutputId::hash` now takes a `&self`;
+- `impl From<OutputId> for {AliasId, NftId}` now takes an `&OutputId`;
+- `{AliasId, NftId, ChainId}::or_from_output_id` now takes an `&OutputId`;
+- `AliasOutput::alias_address` now takes an `&OutputId`;
+- `NftOutput::nft_address` now takes an `&OutputId`;
 
 ## 1.0.0-rc.1 - 2022-10-25
 

--- a/types/src/block/address/mod.rs
+++ b/types/src/block/address/mod.rs
@@ -116,7 +116,7 @@ impl Address {
             (Address::Alias(alias_address), Unlock::Alias(unlock)) => {
                 // PANIC: indexing is fine as it is already syntactically verified that indexes reference below.
                 if let (output_id, Output::Alias(alias_output)) = inputs[unlock.index() as usize] {
-                    if &alias_output.alias_id().or_from_output_id(output_id) != alias_address.alias_id() {
+                    if &alias_output.alias_id().or_from_output_id(&output_id) != alias_address.alias_id() {
                         return Err(ConflictReason::InvalidUnlock);
                     }
                     if !context.unlocked_addresses.contains(self) {
@@ -129,7 +129,7 @@ impl Address {
             (Address::Nft(nft_address), Unlock::Nft(unlock)) => {
                 // PANIC: indexing is fine as it is already syntactically verified that indexes reference below.
                 if let (output_id, Output::Nft(nft_output)) = inputs[unlock.index() as usize] {
-                    if &nft_output.nft_id().or_from_output_id(output_id) != nft_address.nft_id() {
+                    if &nft_output.nft_id().or_from_output_id(&output_id) != nft_address.nft_id() {
                         return Err(ConflictReason::InvalidUnlock);
                     }
                     if !context.unlocked_addresses.contains(self) {

--- a/types/src/block/address/mod.rs
+++ b/types/src/block/address/mod.rs
@@ -116,7 +116,7 @@ impl Address {
             (Address::Alias(alias_address), Unlock::Alias(unlock)) => {
                 // PANIC: indexing is fine as it is already syntactically verified that indexes reference below.
                 if let (output_id, Output::Alias(alias_output)) = inputs[unlock.index() as usize] {
-                    if &alias_output.alias_id().or_from_output_id(&output_id) != alias_address.alias_id() {
+                    if &alias_output.alias_id_non_null(&output_id) != alias_address.alias_id() {
                         return Err(ConflictReason::InvalidUnlock);
                     }
                     if !context.unlocked_addresses.contains(self) {
@@ -129,7 +129,7 @@ impl Address {
             (Address::Nft(nft_address), Unlock::Nft(unlock)) => {
                 // PANIC: indexing is fine as it is already syntactically verified that indexes reference below.
                 if let (output_id, Output::Nft(nft_output)) = inputs[unlock.index() as usize] {
-                    if &nft_output.nft_id().or_from_output_id(&output_id) != nft_address.nft_id() {
+                    if &nft_output.nft_id_non_null(&output_id) != nft_address.nft_id() {
                         return Err(ConflictReason::InvalidUnlock);
                     }
                     if !context.unlocked_addresses.contains(self) {

--- a/types/src/block/output/alias.rs
+++ b/types/src/block/output/alias.rs
@@ -370,6 +370,12 @@ impl AliasOutput {
         &self.alias_id
     }
 
+    /// Returns the alias ID if not null, or creates it from the output ID.
+    #[inline(always)]
+    pub fn alias_id_non_null(&self, output_id: &OutputId) -> AliasId {
+        self.alias_id.or_from_output_id(output_id)
+    }
+
     ///
     #[inline(always)]
     pub fn state_index(&self) -> u32 {
@@ -434,7 +440,7 @@ impl AliasOutput {
 
     /// Returns the alias address for this output.
     pub fn alias_address(&self, output_id: &OutputId) -> AliasAddress {
-        AliasAddress::new(self.alias_id().or_from_output_id(output_id))
+        AliasAddress::new(self.alias_id_non_null(output_id))
     }
 
     ///

--- a/types/src/block/output/alias.rs
+++ b/types/src/block/output/alias.rs
@@ -433,7 +433,7 @@ impl AliasOutput {
     }
 
     /// Returns the alias address for this output.
-    pub fn alias_address(&self, output_id: OutputId) -> AliasAddress {
+    pub fn alias_address(&self, output_id: &OutputId) -> AliasAddress {
         AliasAddress::new(self.alias_id().or_from_output_id(output_id))
     }
 
@@ -446,7 +446,7 @@ impl AliasOutput {
         context: &mut ValidationContext,
     ) -> Result<(), ConflictReason> {
         let alias_id = if self.alias_id().is_null() {
-            AliasId::from(*output_id)
+            AliasId::from(output_id)
         } else {
             *self.alias_id()
         };

--- a/types/src/block/output/alias_id.rs
+++ b/types/src/block/output/alias_id.rs
@@ -8,15 +8,15 @@ impl_id!(pub AliasId, 32, "TODO.");
 #[cfg(feature = "serde")]
 string_serde_impl!(AliasId);
 
-impl From<OutputId> for AliasId {
-    fn from(output_id: OutputId) -> Self {
+impl From<&OutputId> for AliasId {
+    fn from(output_id: &OutputId) -> Self {
         Self::from(output_id.hash())
     }
 }
 
 impl AliasId {
     ///
-    pub fn or_from_output_id(self, output_id: OutputId) -> Self {
+    pub fn or_from_output_id(self, output_id: &OutputId) -> Self {
         if self.is_null() { Self::from(output_id) } else { self }
     }
 }

--- a/types/src/block/output/chain_id.rs
+++ b/types/src/block/output/chain_id.rs
@@ -27,7 +27,7 @@ impl ChainId {
     }
 
     ///
-    pub fn or_from_output_id(self, output_id: OutputId) -> Self {
+    pub fn or_from_output_id(self, output_id: &OutputId) -> Self {
         if !self.is_null() {
             return self;
         }

--- a/types/src/block/output/mod.rs
+++ b/types/src/block/output/mod.rs
@@ -189,7 +189,7 @@ impl Output {
     pub fn required_and_unlocked_address(
         &self,
         current_time: u32,
-        output_id: OutputId,
+        output_id: &OutputId,
         alias_state_transition: bool,
     ) -> Result<(Address, Option<Address>), Error> {
         match self {

--- a/types/src/block/output/nft.rs
+++ b/types/src/block/output/nft.rs
@@ -351,7 +351,7 @@ impl NftOutput {
     }
 
     /// Returns the nft address for this output.
-    pub fn nft_address(&self, output_id: OutputId) -> NftAddress {
+    pub fn nft_address(&self, output_id: &OutputId) -> NftAddress {
         NftAddress::new(self.nft_id().or_from_output_id(output_id))
     }
 
@@ -368,7 +368,7 @@ impl NftOutput {
             .unlock(unlock, inputs, context)?;
 
         let nft_id = if self.nft_id().is_null() {
-            NftId::from(*output_id)
+            NftId::from(output_id)
         } else {
             *self.nft_id()
         };

--- a/types/src/block/output/nft.rs
+++ b/types/src/block/output/nft.rs
@@ -316,6 +316,12 @@ impl NftOutput {
         &self.nft_id
     }
 
+    /// Returns the nft ID if not null, or creates it from the output ID.
+    #[inline(always)]
+    pub fn nft_id_non_null(&self, output_id: &OutputId) -> NftId {
+        self.nft_id.or_from_output_id(output_id)
+    }
+
     ///
     #[inline(always)]
     pub fn unlock_conditions(&self) -> &UnlockConditions {
@@ -352,7 +358,7 @@ impl NftOutput {
 
     /// Returns the nft address for this output.
     pub fn nft_address(&self, output_id: &OutputId) -> NftAddress {
-        NftAddress::new(self.nft_id().or_from_output_id(output_id))
+        NftAddress::new(self.nft_id_non_null(output_id))
     }
 
     ///

--- a/types/src/block/output/nft_id.rs
+++ b/types/src/block/output/nft_id.rs
@@ -8,15 +8,15 @@ impl_id!(pub NftId, 32, "TODO.");
 #[cfg(feature = "serde")]
 string_serde_impl!(NftId);
 
-impl From<OutputId> for NftId {
-    fn from(output_id: OutputId) -> Self {
+impl From<&OutputId> for NftId {
+    fn from(output_id: &OutputId) -> Self {
         Self::from(output_id.hash())
     }
 }
 
 impl NftId {
     ///
-    pub fn or_from_output_id(self, output_id: OutputId) -> Self {
+    pub fn or_from_output_id(self, output_id: &OutputId) -> Self {
         if self.is_null() { Self::from(output_id) } else { self }
     }
 }

--- a/types/src/block/output/output_id.rs
+++ b/types/src/block/output/output_id.rs
@@ -60,7 +60,7 @@ impl OutputId {
 
     /// Hash the [`OutputId`] with BLAKE2b-256.
     #[inline(always)]
-    pub fn hash(self) -> [u8; 32] {
+    pub fn hash(&self) -> [u8; 32] {
         Blake2b256::digest(self.pack_to_vec()).into()
     }
 }

--- a/types/src/block/semantic.rs
+++ b/types/src/block/semantic.rs
@@ -158,7 +158,7 @@ impl<'a> ValidationContext<'a> {
                 .filter_map(|(output_id, input)| {
                     input
                         .chain_id()
-                        .map(|chain_id| (chain_id.or_from_output_id(*output_id), input))
+                        .map(|chain_id| (chain_id.or_from_output_id(output_id), input))
                 })
                 .collect(),
             output_amount: 0,
@@ -170,7 +170,7 @@ impl<'a> ValidationContext<'a> {
                 .filter_map(|(index, output)| {
                     output.chain_id().map(|chain_id| {
                         (
-                            chain_id.or_from_output_id(OutputId::new(*transaction_id, index as u16).unwrap()),
+                            chain_id.or_from_output_id(&OutputId::new(*transaction_id, index as u16).unwrap()),
                             output,
                         )
                     })


### PR DESCRIPTION
More convenient, less OutputId copies.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
