### PR TITLE
Change packing order of `RentStructure` to be inline with `iota.go`

### DIFF
--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AliasOutput::alias_address` now takes an `&OutputId`;
 - `NftOutput::nft_address` now takes an `&OutputId`;
 
+### Fixed
+
+- Packing order of `v_byte_factor_data` and `v_byte_factor_key`;
+
 ## 1.0.0-rc.1 - 2022-10-25
 
 First release based on `bee-api-types` and `bee-block`.

--- a/types/src/block/output/rent.rs
+++ b/types/src/block/output/rent.rs
@@ -107,8 +107,8 @@ impl Packable for RentStructure {
 
     fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
         self.v_byte_cost.pack(packer)?;
-        self.v_byte_factor_key.pack(packer)?;
         self.v_byte_factor_data.pack(packer)?;
+        self.v_byte_factor_key.pack(packer)?;
 
         Ok(())
     }
@@ -118,8 +118,8 @@ impl Packable for RentStructure {
         visitor: &Self::UnpackVisitor,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         let v_byte_cost = u32::unpack::<_, VERIFY>(unpacker, visitor).coerce()?;
-        let v_byte_factor_key = u8::unpack::<_, VERIFY>(unpacker, visitor).coerce()?;
         let v_byte_factor_data = u8::unpack::<_, VERIFY>(unpacker, visitor).coerce()?;
+        let v_byte_factor_key = u8::unpack::<_, VERIFY>(unpacker, visitor).coerce()?;
         let v_byte_offset = v_byte_offset(v_byte_factor_key, v_byte_factor_data);
 
         Ok(Self {


### PR DESCRIPTION
# Description of change

Changes the packing order of `RentStructure`.

## Links to any relevant issues

Closes #1364.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
