### PR TITLE
Fix: Added user agent to http client

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `OutputMetadata::new()` and all field getters;
 - `participation` feature with routes, responses and types;
+- `Http client` allow setting User-Agent header for requests;
 
 ### Changed
 

--- a/client/src/client/builder.rs
+++ b/client/src/client/builder.rs
@@ -317,6 +317,13 @@ impl ClientBuilder {
         self
     }
 
+    /// Set User-Agent header for requests
+    /// Default is "iota-client/[version]"
+    pub fn with_user_agent(mut self, user_agent: String) -> Self {
+        self.node_manager_builder = self.node_manager_builder.with_user_agent(user_agent);
+        self
+    }
+
     /// Build the Client instance.
     pub fn finish(self) -> Result<Client> {
         let network_info = Arc::new(RwLock::new(self.network_info));

--- a/client/src/constants.rs
+++ b/client/src/constants.rs
@@ -17,6 +17,7 @@ pub(crate) const DEFAULT_TIPS_INTERVAL: u64 = 5;
 pub(crate) const NODE_SYNC_INTERVAL: Duration = Duration::from_secs(60);
 pub(crate) const DEFAULT_MIN_QUORUM_SIZE: usize = 3;
 pub(crate) const DEFAULT_QUORUM_THRESHOLD: usize = 66;
+pub(crate) const DEFAULT_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 #[cfg(not(target_family = "wasm"))]
 pub(crate) const MAX_PARALLEL_API_REQUESTS: usize = 100;
 /// Max allowed difference between the local time and latest milestone time, 5 minutes in seconds

--- a/client/src/node_api/core/routes.rs
+++ b/client/src/node_api/core/routes.rs
@@ -27,7 +27,7 @@ use packable::PackableExt;
 use url::Url;
 
 use crate::{
-    constants::DEFAULT_API_TIMEOUT,
+    constants::{DEFAULT_API_TIMEOUT, DEFAULT_USER_AGENT},
     node_manager::node::{Node, NodeAuth},
     Client, Error, Result,
 };
@@ -52,7 +52,7 @@ impl Client {
 
         let mut url = Url::parse(url)?;
         url.set_path(path);
-        let status = crate::node_manager::http_client::HttpClient::new()
+        let status = crate::node_manager::http_client::HttpClient::new(DEFAULT_USER_AGENT.to_string())
             .get(
                 Node {
                     url,
@@ -104,7 +104,7 @@ impl Client {
         let path = "api/core/v2/info";
         url.set_path(path);
 
-        let resp: InfoResponse = crate::node_manager::http_client::HttpClient::new()
+        let resp: InfoResponse = crate::node_manager::http_client::HttpClient::new(DEFAULT_USER_AGENT.to_string())
             .get(
                 Node {
                     url,

--- a/client/src/node_manager/builder.rs
+++ b/client/src/node_manager/builder.rs
@@ -53,15 +53,15 @@ pub struct NodeManagerBuilder {
     /// % of nodes that have to return the same response so it gets accepted
     #[serde(rename = "quorumThreshold", default = "default_quorum_threshold")]
     pub quorum_threshold: usize,
-    /// % of nodes that have to return the same response so it gets accepted
+    /// The User-Agent header for requests
     #[serde(rename = "userAgent", default = "default_user_agent")]
     pub user_agent: String,
 }
 
-
 fn default_user_agent() -> String {
     DEFAULT_USER_AGENT.to_string()
 }
+
 fn default_node_sync_enabled() -> bool {
     true
 }

--- a/client/src/node_manager/builder.rs
+++ b/client/src/node_manager/builder.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::{
-    constants::{DEFAULT_MIN_QUORUM_SIZE, DEFAULT_QUORUM_THRESHOLD, NODE_SYNC_INTERVAL, DEFAULT_USER_AGENT},
+    constants::{DEFAULT_MIN_QUORUM_SIZE, DEFAULT_QUORUM_THRESHOLD, DEFAULT_USER_AGENT, NODE_SYNC_INTERVAL},
     error::{Error, Result},
     node_manager::{
         http_client::HttpClient,

--- a/client/src/node_manager/builder.rs
+++ b/client/src/node_manager/builder.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::{
-    constants::{DEFAULT_MIN_QUORUM_SIZE, DEFAULT_QUORUM_THRESHOLD, NODE_SYNC_INTERVAL},
+    constants::{DEFAULT_MIN_QUORUM_SIZE, DEFAULT_QUORUM_THRESHOLD, NODE_SYNC_INTERVAL, DEFAULT_USER_AGENT},
     error::{Error, Result},
     node_manager::{
         http_client::HttpClient,
@@ -53,8 +53,15 @@ pub struct NodeManagerBuilder {
     /// % of nodes that have to return the same response so it gets accepted
     #[serde(rename = "quorumThreshold", default = "default_quorum_threshold")]
     pub quorum_threshold: usize,
+    /// % of nodes that have to return the same response so it gets accepted
+    #[serde(rename = "userAgent", default = "default_user_agent")]
+    pub user_agent: String,
 }
 
+
+fn default_user_agent() -> String {
+    DEFAULT_USER_AGENT.to_string()
+}
 fn default_node_sync_enabled() -> bool {
     true
 }
@@ -208,6 +215,11 @@ impl NodeManagerBuilder {
         self
     }
 
+    pub(crate) fn with_user_agent(mut self, user_agent: String) -> Self {
+        self.user_agent = user_agent;
+        self
+    }
+
     pub(crate) fn build(self, healthy_nodes: Arc<RwLock<HashMap<Node, InfoResponse>>>) -> NodeManager {
         NodeManager {
             primary_node: self.primary_node.map(|node| node.into()),
@@ -222,7 +234,7 @@ impl NodeManagerBuilder {
             quorum: self.quorum,
             min_quorum_size: self.min_quorum_size,
             quorum_threshold: self.quorum_threshold,
-            http_client: HttpClient::new(),
+            http_client: HttpClient::new(self.user_agent),
         }
     }
 }
@@ -239,6 +251,7 @@ impl Default for NodeManagerBuilder {
             quorum: false,
             min_quorum_size: DEFAULT_MIN_QUORUM_SIZE,
             quorum_threshold: DEFAULT_QUORUM_THRESHOLD,
+            user_agent: DEFAULT_USER_AGENT.to_string(),
         }
     }
 }

--- a/client/src/node_manager/http_client.rs
+++ b/client/src/node_manager/http_client.rs
@@ -36,14 +36,14 @@ impl Response {
 #[derive(Clone)]
 pub(crate) struct HttpClient {
     client: reqwest::Client,
-    user_agent: String
+    user_agent: String,
 }
 
 impl HttpClient {
     pub(crate) fn new(user_agent: String) -> Self {
         Self {
             client: reqwest::Client::new(),
-            user_agent: user_agent,
+            user_agent,
         }
     }
 

--- a/client/src/node_manager/http_client.rs
+++ b/client/src/node_manager/http_client.rs
@@ -5,6 +5,7 @@
 
 use std::time::Duration;
 
+use reqwest::RequestBuilder;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
@@ -12,7 +13,6 @@ use crate::{
     error::{Error, Result},
     node_manager::node::Node,
 };
-
 pub(crate) struct Response(reqwest::Response);
 
 impl Response {
@@ -36,12 +36,14 @@ impl Response {
 #[derive(Clone)]
 pub(crate) struct HttpClient {
     client: reqwest::Client,
+    user_agent: String
 }
 
 impl HttpClient {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(user_agent: String) -> Self {
         Self {
             client: reqwest::Client::new(),
+            user_agent: user_agent,
         }
     }
 
@@ -58,10 +60,11 @@ impl HttpClient {
         }
     }
 
-    pub(crate) async fn get(&self, node: Node, _timeout: Duration) -> Result<Response> {
-        let mut request_builder = self.client.get(node.url.clone());
-        if let Some(node_auth) = node.auth {
-            if let Some(jwt) = node_auth.jwt {
+    fn build_request(&self, request_builder: RequestBuilder, node: &Node, _timeout: Duration) -> RequestBuilder {
+        let mut request_builder = request_builder.header(reqwest::header::USER_AGENT, &self.user_agent);
+
+        if let Some(node_auth) = &node.auth {
+            if let Some(jwt) = &node_auth.jwt {
                 request_builder = request_builder.bearer_auth(jwt);
             }
         }
@@ -69,6 +72,12 @@ impl HttpClient {
         {
             request_builder = request_builder.timeout(_timeout);
         }
+        request_builder
+    }
+
+    pub(crate) async fn get(&self, node: Node, timeout: Duration) -> Result<Response> {
+        let mut request_builder = self.client.get(node.url.clone());
+        request_builder = self.build_request(request_builder, &node, timeout);
         #[cfg(target_family = "wasm")]
         let start_time = instant::Instant::now();
         #[cfg(not(target_family = "wasm"))]
@@ -84,47 +93,23 @@ impl HttpClient {
     }
 
     // Get with header: "accept", "application/vnd.iota.serializer-v1"
-    pub(crate) async fn get_bytes(&self, node: Node, _timeout: Duration) -> Result<Response> {
+    pub(crate) async fn get_bytes(&self, node: Node, timeout: Duration) -> Result<Response> {
         let mut request_builder = self.client.get(node.url.clone());
-        if let Some(node_auth) = node.auth {
-            if let Some(jwt) = node_auth.jwt {
-                request_builder = request_builder.bearer_auth(jwt);
-            }
-        }
-        #[cfg(not(target_family = "wasm"))]
-        {
-            request_builder = request_builder.timeout(_timeout);
-        }
+        request_builder = self.build_request(request_builder, &node, timeout);
         request_builder = request_builder.header("accept", "application/vnd.iota.serializer-v1");
         let resp = request_builder.send().await?;
         Self::parse_response(resp, &node.url).await
     }
 
-    pub(crate) async fn post_json(&self, node: Node, _timeout: Duration, json: Value) -> Result<Response> {
+    pub(crate) async fn post_json(&self, node: Node, timeout: Duration, json: Value) -> Result<Response> {
         let mut request_builder = self.client.post(node.url.clone());
-        if let Some(node_auth) = node.auth {
-            if let Some(jwt) = node_auth.jwt {
-                request_builder = request_builder.bearer_auth(jwt);
-            }
-        }
-        #[cfg(not(target_family = "wasm"))]
-        {
-            request_builder = request_builder.timeout(_timeout);
-        }
+        request_builder = self.build_request(request_builder, &node, timeout);
         Self::parse_response(request_builder.json(&json).send().await?, &node.url).await
     }
 
-    pub(crate) async fn post_bytes(&self, node: Node, _timeout: Duration, body: &[u8]) -> Result<Response> {
+    pub(crate) async fn post_bytes(&self, node: Node, timeout: Duration, body: &[u8]) -> Result<Response> {
         let mut request_builder = self.client.post(node.url.clone());
-        if let Some(node_auth) = node.auth {
-            if let Some(jwt) = node_auth.jwt {
-                request_builder = request_builder.bearer_auth(jwt);
-            }
-        }
-        #[cfg(not(target_family = "wasm"))]
-        {
-            request_builder = request_builder.timeout(_timeout);
-        }
+        request_builder = self.build_request(request_builder, &node, timeout);
         request_builder = request_builder.header("Content-Type", "application/vnd.iota.serializer-v1");
         Self::parse_response(request_builder.body(body.to_vec()).send().await?, &node.url).await
     }


### PR DESCRIPTION
# Description of change

Allows users to set their user agent for http requests.
Certain servers discard requests without user agent set. 

Default agent: `iota_client/[version]`

Based on https://github.com/iotaledger/iota.rs/pull/775

## Links to any relevant issues

fixes issue #1333

## Type of change

Choose a type of change, and delete any options that are not relevant.
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested



## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
