### PR TITLE
Fix get_time_checked() in WASM

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -30,13 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `OutputWithMetadataResponse` instead of `OutputResponse`;
 - `ClientBlockBuilder::{with_output, with_output_hex, set_options}` made async;
 - `Client::{hex_to_bech32, hex_public_key_to_bech32_address}` made async;
-- `Client::{get_network_info, get_protocol_parameters, get_protocol_version, get_network_name, get_network_id, get_bech32_hrp, get_min_pow_score, get_below_max_depth, get_rent_structure, get_token_supply}` made async;
+- `Client::{get_network_info, get_protocol_parameters, get_protocol_version, get_network_name, get_network_id, get_bech32_hrp, get_min_pow_score, get_below_max_depth, get_rent_structure, get_time_checked, get_token_supply}` made async;
 - All fields of `OutputMetadata` are now private;
 - `InputSigningData::output_id()` is not fallible anymore;
 
 ### Removed
 
 - `OutputMetadata::{transaction_id, output_index}` replaced with `OutputMetadata::output_id`;
+
+### Fixed
+
+- `get_time_checked()` in wasm;
 
 ## 2.0.1-rc.3 - 2022-10-25
 

--- a/client/examples/offline_signing/3_send_block.rs
+++ b/client/examples/offline_signing/3_send_block.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
 
     let signed_transaction_payload = read_signed_transaction_from_file(SIGNED_TRANSACTION_FILE_NAME)?;
 
-    let current_time = online_client.get_time_checked()?;
+    let current_time = online_client.get_time_checked().await?;
 
     let conflict = verify_semantic(
         &signed_transaction_payload.inputs_data,

--- a/client/src/api/block_builder/input_selection/automatic.rs
+++ b/client/src/api/block_builder/input_selection/automatic.rs
@@ -76,7 +76,7 @@ impl<'a> ClientBlockBuilder<'a> {
         let mut available_inputs = self.get_utxo_chains_inputs(self.outputs.iter()).await?;
         let required_inputs_for_sender_or_issuer = self.get_inputs_for_sender_and_issuer(&available_inputs).await?;
 
-        let current_time = self.client.get_time_checked()?;
+        let current_time = self.client.get_time_checked().await?;
 
         // Try to select inputs with required inputs for utxo chains alone before requesting more inputs from addresses.
         if let Ok(selected_transaction_data) = try_select_inputs(

--- a/client/src/api/block_builder/input_selection/manual.rs
+++ b/client/src/api/block_builder/input_selection/manual.rs
@@ -36,7 +36,7 @@ impl<'a> ClientBlockBuilder<'a> {
         log::debug!("[get_custom_inputs]");
 
         let mut inputs_data = Vec::new();
-        let current_time = self.client.get_time_checked()?;
+        let current_time = self.client.get_time_checked().await?;
         let token_supply = self.client.get_token_supply().await?;
 
         if let Some(inputs) = &self.inputs {

--- a/client/src/api/block_builder/input_selection/sender_issuer.rs
+++ b/client/src/api/block_builder/input_selection/sender_issuer.rs
@@ -27,7 +27,7 @@ impl<'a> ClientBlockBuilder<'a> {
 
         let mut required_inputs = Vec::new();
         let bech32_hrp = self.client.get_bech32_hrp().await?;
-        let current_time = self.client.get_time_checked()?;
+        let current_time = self.client.get_time_checked().await?;
         let token_supply = self.client.get_token_supply().await?;
 
         let required_sender_or_issuer_addresses =

--- a/client/src/api/block_builder/input_selection/utxo_chains/automatic.rs
+++ b/client/src/api/block_builder/input_selection/utxo_chains/automatic.rs
@@ -29,7 +29,7 @@ impl<'a> ClientBlockBuilder<'a> {
         log::debug!("[get_utxo_chains_inputs]");
         let client = self.client;
         let bech32_hrp = client.get_bech32_hrp().await?;
-        let current_time = self.client.get_time_checked()?;
+        let current_time = self.client.get_time_checked().await?;
         let token_supply = client.get_token_supply().await?;
 
         let mut utxo_chains: Vec<(Address, OutputWithMetadataResponse)> = Vec::new();

--- a/client/src/api/block_builder/input_selection/utxo_chains/mod.rs
+++ b/client/src/api/block_builder/input_selection/utxo_chains/mod.rs
@@ -298,7 +298,7 @@ pub(crate) async fn get_alias_and_nft_outputs_recursively(
     utxo_chains: &mut Vec<(Address, OutputWithMetadataResponse)>,
 ) -> Result<()> {
     log::debug!("[get_alias_and_nft_outputs_recursively]");
-    let current_time = client.get_time_checked()?;
+    let current_time = client.get_time_checked().await?;
     let token_supply = client.get_token_supply().await?;
 
     let mut processed_alias_nft_addresses = std::collections::HashSet::new();

--- a/client/src/api/block_builder/transaction.rs
+++ b/client/src/api/block_builder/transaction.rs
@@ -116,7 +116,7 @@ impl<'a> ClientBlockBuilder<'a> {
 
         validate_transaction_payload_length(&tx_payload)?;
 
-        let current_time = self.client.get_time_checked()?;
+        let current_time = self.client.get_time_checked().await?;
 
         let conflict = verify_semantic(&prepared_transaction_data.inputs_data, &tx_payload, current_time)?;
 

--- a/client/src/client/high_level.rs
+++ b/client/src/client/high_level.rs
@@ -205,7 +205,7 @@ impl Client {
         }
 
         let mut basic_outputs = Vec::new();
-        let current_time = self.get_time_checked()?;
+        let current_time = self.get_time_checked().await?;
         let token_supply = self.get_token_supply().await?;
 
         for output_resp in available_outputs {
@@ -339,13 +339,13 @@ impl Client {
 
     /// Returns the local time checked with the timestamp of the latest milestone, if the difference is larger than 5
     /// minutes an error is returned to prevent locking outputs by accident for a wrong time.
-    pub fn get_time_checked(&self) -> Result<u32> {
+    pub async fn get_time_checked(&self) -> Result<u32> {
         let current_time = instant::SystemTime::now()
             .duration_since(instant::SystemTime::UNIX_EPOCH)
             .expect("time went backwards")
             .as_secs() as u32;
 
-        let network_info = self.network_info.read().map_err(|_| crate::Error::PoisonError)?;
+        let network_info = self.get_network_info().await?;
 
         if let Some(latest_ms_timestamp) = network_info.latest_milestone_timestamp {
             // Check the local time is in the range of +-5 minutes of the node to prevent locking funds by accident


### PR DESCRIPTION
# Description of change

Call get_network_info() in get_time_checked() so the info is updated in WASM since there is no automatic node syncing which would update the milestone time

## Links to any relevant issues

https://github.com/iotaledger/iota.rs/issues/1350

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
