### PR TITLE
Fix client builder deserialization with older versions

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `ClientBuilder::with_node_sync_disabled()` by `ClientBuilder::with_ignore_node_health()`;
 - Replace `NodeManagerBuilder.node_sync_enabled` by `NodeManagerBuilder.ignore_node_health`;
 - Use new `RentStructureDto` and `ProtocolParametersDto` types;
+- ClientBuilder no longer has `#[serde(deny_unknown_fields)]` for backwards compatibility;
 
 ### Removed
 

--- a/client/src/client/builder.rs
+++ b/client/src/client/builder.rs
@@ -109,7 +109,6 @@ fn default_tips_interval() -> u64 {
 
 /// Builder to construct client instance with sensible default values
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
 #[must_use]
 pub struct ClientBuilder {
     /// Node manager builder


### PR DESCRIPTION
# Description of change

Fix client builder deserialization with older versions
When trying to import a stronghold backup from Firefly 2.0.1 in the latest wallet.rs version, it fails with `Error: JsonError(Error("unknown field `nodeSyncEnabled`", line: 1, column: 562))`
This change ignores the unknown field so it work again

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Restored a backup in wallet.rs with this change, which didn't work before

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
