### PR TITLE
Add alias_id_to_bech32() to Node.Js and Python bindings

### DIFF
--- a/.changes/aliasIdToBech32.md
+++ b/.changes/aliasIdToBech32.md
@@ -1,0 +1,6 @@
+
+---
+"nodejs-binding": patch
+---
+
+Add `aliasIdToBech32()`.

--- a/client/bindings/nodejs/lib/Client.ts
+++ b/client/bindings/nodejs/lib/Client.ts
@@ -671,6 +671,24 @@ export class Client {
     }
 
     /**
+     * Transforms an alias id to a bech32 encoded address.
+     */
+    async aliasIdToBech32(
+        aliasId: string,
+        bech32Hrp?: string,
+    ): Promise<string> {
+        const response = await this.messageHandler.sendMessage({
+            name: 'aliasIdToBech32',
+            data: {
+                aliasId,
+                bech32Hrp,
+            },
+        });
+
+        return JSON.parse(response).payload;
+    }
+
+    /**
      * Transforms a hex encoded public key to a bech32 encoded address.
      */
     async hexPublicKeyToBech32Address(

--- a/client/bindings/nodejs/types/bridge/client.ts
+++ b/client/bindings/nodejs/types/bridge/client.ts
@@ -294,6 +294,14 @@ export interface __HexToBech32Message__ {
     };
 }
 
+export interface __AliasIdToBech32Message__ {
+    name: 'aliasIdToBech32';
+    data: {
+        aliasId: string;
+        bech32Hrp?: string;
+    };
+}
+
 export interface __HexPublicKeyToBech32AddressMessage__ {
     name: 'hexPublicKeyToBech32Address';
     data: {

--- a/client/bindings/nodejs/types/bridge/index.ts
+++ b/client/bindings/nodejs/types/bridge/index.ts
@@ -39,6 +39,7 @@ import type {
     __GetIncludedBlockMessage__,
     __Bech32ToHexMessage__,
     __HexToBech32Message__,
+    __AliasIdToBech32Message__,
     __HexPublicKeyToBech32AddressMessage__,
     __IsAddressValidMessage__,
     __AliasOutputIdsMessage__,
@@ -114,6 +115,7 @@ export type __ClientMessages__ =
     | __GetIncludedBlockMessage__
     | __Bech32ToHexMessage__
     | __HexToBech32Message__
+    | __AliasIdToBech32Message__
     | __HexPublicKeyToBech32AddressMessage__
     | __IsAddressValidMessage__
     | __AliasOutputIdsMessage__

--- a/client/bindings/python/iota_client/_utils.py
+++ b/client/bindings/python/iota_client/_utils.py
@@ -18,7 +18,15 @@ class Utils(BaseAPI):
             'bech32Hrp': bech32_hrp
         })
 
-    def hex_public_key_to_beh32_address(self, hex, bech32_hrp=None):
+    def alias_id_to_bech32(self, alias_id, bech32_hrp):
+        """Transforms a hex encoded address to a bech32 encoded address.
+        """
+        return self.send_message('aliasIdToBech32', {
+            'aliasId': alias_id,
+            'bech32Hrp': bech32_hrp
+        })
+
+    def hex_public_key_to_bech32_address(self, hex, bech32_hrp=None):
         """Transforms a hex encoded public key to a bech32 encoded address.
         """
         return self.send_message('hexPublicKeyToBech32Address', {

--- a/client/bindings/python/iota_client/_utils.py
+++ b/client/bindings/python/iota_client/_utils.py
@@ -19,7 +19,7 @@ class Utils(BaseAPI):
         })
 
     def alias_id_to_bech32(self, alias_id, bech32_hrp):
-        """Transforms a hex encoded address to a bech32 encoded address.
+        """Transforms an alias id to a bech32 encoded address.
         """
         return self.send_message('aliasIdToBech32', {
             'aliasId': alias_id,

--- a/documentation/docs/libraries/nodejs/references/classes/Client.md
+++ b/documentation/docs/libraries/nodejs/references/classes/Client.md
@@ -52,6 +52,7 @@ The Client to interact with nodes.
 - [getIncludedBlock](Client.md#getincludedblock)
 - [bech32ToHex](Client.md#bech32tohex)
 - [hexToBech32](Client.md#hextobech32)
+- [aliasIdToBech32](Client.md#aliasidtobech32)
 - [hexPublicKeyToBech32Address](Client.md#hexpublickeytobech32address)
 - [isAddressValid](Client.md#isaddressvalid)
 - [aliasOutputIds](Client.md#aliasoutputids)
@@ -814,6 +815,25 @@ Transforms a hex encoded address to a bech32 encoded address.
 | Name | Type |
 | :------ | :------ |
 | `hex` | `string` |
+| `bech32Hrp?` | `string` |
+
+#### Returns
+
+`Promise`<`string`\>
+
+___
+
+### aliasIdToBech32
+
+▸ **aliasIdToBech32**(`aliasId`, `bech32Hrp?`): `Promise`<`string`\>
+
+Transforms an alias id to a bech32 encoded address.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `aliasId` | `string` |
 | `bech32Hrp?` | `string` |
 
 #### Returns

--- a/documentation/docs/libraries/python/api_reference.md
+++ b/documentation/docs/libraries/python/api_reference.md
@@ -34,12 +34,22 @@ def hex_to_bech32(hex, bech32_hrp)
 
 Transforms a hex encoded address to a bech32 encoded address.
 
-<a id="iota_client._utils.Utils.hex_public_key_to_beh32_address"></a>
+<a id="iota_client._utils.Utils.alias_id_to_bech32"></a>
 
-#### hex\_public\_key\_to\_beh32\_address
+#### alias\_id\_to\_bech32
 
 ```python
-def hex_public_key_to_beh32_address(hex, bech32_hrp=None)
+def alias_id_to_bech32(alias_id, bech32_hrp)
+```
+
+Transforms a hex encoded address to a bech32 encoded address.
+
+<a id="iota_client._utils.Utils.hex_public_key_to_bech32_address"></a>
+
+#### hex\_public\_key\_to\_bech32\_address
+
+```python
+def hex_public_key_to_bech32_address(hex, bech32_hrp=None)
 ```
 
 Transforms a hex encoded public key to a bech32 encoded address.

--- a/documentation/docs/libraries/python/api_reference.md
+++ b/documentation/docs/libraries/python/api_reference.md
@@ -42,7 +42,7 @@ Transforms a hex encoded address to a bech32 encoded address.
 def alias_id_to_bech32(alias_id, bech32_hrp)
 ```
 
-Transforms a hex encoded address to a bech32 encoded address.
+Transforms an alias id to a bech32 encoded address.
 
 <a id="iota_client._utils.Utils.hex_public_key_to_bech32_address"></a>
 


### PR DESCRIPTION
# Description of change

Add alias_id_to_bech32() to Node.Js and Python bindings, fix typo in Python hex_public_key_to_bech32_address

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota.rs/issues/1429

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
