### PR TITLE
Add workflow_dispatch to python workflow

### DIFF
--- a/.github/workflows/python-bindings-publish.yml
+++ b/.github/workflows/python-bindings-publish.yml
@@ -1,6 +1,7 @@
 name: Build and Upload Wheels for the Python Bindings
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - develop


### PR DESCRIPTION
# Description of change

Add workflow_dispatch to python workflow so we can run it manually without the need of pushing a commit