### PR TITLE
Build with Python 3.9

### DIFF
--- a/.github/workflows/python-bindings-publish.yml
+++ b/.github/workflows/python-bindings-publish.yml
@@ -23,9 +23,7 @@ jobs:
       matrix:
         # Using Ubuntu 18.04 to provide glibc compatibility. (#588)
         os: [ubuntu-18.04, macos-latest, windows-latest]
-        # FIXME: Temporary limit to Python 3.6, as this is controlled by the feature gate for PyO3,
-        # which is currently just 3.6. (#782)
-        python: ['3.6']
+        python: ['3.9']
         include:
           - os: ubuntu-18.04
             identifier: linux

--- a/.github/workflows/python-bindings-publish.yml
+++ b/.github/workflows/python-bindings-publish.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+          architecture: 'x64'
 
       - name: Build Wheels
         working-directory: bindings/python/native


### PR DESCRIPTION
Build with Python 3.9 because 3.6 is not available as 64 bit anymore in the windows runner:https://github.com/iotaledger/iota.rs/actions/runs/3678694836/jobs/6222847494

Tested here https://github.com/Thoralf-M/iota.rs/actions/runs/3679367112/jobs/6223740551