### PR TITLE
fix: participation event type query parameter

### DIFF
--- a/client/src/node_api/participation/routes.rs
+++ b/client/src/node_api/participation/routes.rs
@@ -20,8 +20,8 @@ impl Client {
 
         let query = if let Some(event_type) = event_type {
             let query_string = match event_type {
-                ParticipationEventType::Voting => "0",
-                ParticipationEventType::Staking => "1",
+                ParticipationEventType::Voting => "type=0",
+                ParticipationEventType::Staking => "type=1",
             };
             Some(query_string)
         } else {


### PR DESCRIPTION
# Description of change

When adding this optional query param to filter specific types of participation events, it was not working because the query string was wrong.

## Links to any relevant issues

N/a

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Used in test examples by `wallet.rs`.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes