### PR TITLE
Update prepublish commands to dasel v2

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -13,13 +13,19 @@
       "getPublishedVersion": "npm view ${ pkgFile.pkg.name } version",
       "prepublish": [
         {
-          "command": "false || dasel put object -f Cargo.toml '.dependencies.iota-client' -t string -t string git='https://github.com/iotaledger/iota.rs' rev=$GITHUB_SHA"
+          "command": "false || dasel put -f Cargo.toml '.dependencies.iota-client.rev' -v $GITHUB_SHA"
         },
         {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-client.features.[0]' message_interface"
+          "command": "dasel put -f Cargo.toml '.dependencies.iota-client.git' -v https://github.com/iotaledger/iota.rs"
         },
         {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-client.features.[1]' mqtt"
+          "command": "dasel put -t json -f Cargo.toml '.dependencies.iota-client.features' -v '[\"message_interface\", \"mqtt\"]'"
+        },
+        {
+          "command": "dasel delete -f Cargo.toml '.dependencies.iota-client.path'"
+        },
+        {
+          "command": "dasel delete -f Cargo.toml '.dependencies.iota-client.default-features'"
         },
         {
           "command": "yarn --ignore-scripts"

--- a/.github/workflows/covector.yml
+++ b/.github/workflows/covector.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install Dasel
         run: |
-          curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/80229218 | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
+          curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
           mv ./dasel /usr/local/bin/dasel
 
       - name: Configure the Git User to Use


### PR DESCRIPTION
# Description of change

This PR updates the `dasel` commands so they work with v2. After the `dasel` commands are run, the `Cargo.toml` looks like this:

```toml
  [dependencies.iota-client]
    features = ["message_interface", "mqtt"]
    git = "https://github.com/iotaledger/iota.rs"
    rev = "some-git-rev"
```

This matches what is [currently published](https://www.runpkg.com/?@iota/client@3.0.0-rc.5/Cargo.toml#20)


## Links to any relevant issues

iotaledger/iota-sdk#52 

## Type of change

- Chore

## How the change has been tested

Tested commands locally:

```bash
cd client/bindings/nodejs
export GITHUB_SHA=some-git-rev
dasel put -f Cargo.toml '.dependencies.iota-client.rev' -v $GITHUB_SHA
dasel put -f Cargo.toml '.dependencies.iota-client.git' -v https://github.com/iotaledger/iota.rs
dasel put -t json -f Cargo.toml '.dependencies.iota-client.features' -v '["message_interface", "mqtt"]'
dasel delete -f Cargo.toml '.dependencies.iota-client.path'
dasel delete -f Cargo.toml '.dependencies.iota-client.default-features'
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
