### PR TITLE
Fix dasel installation

### DIFF
--- a/.github/workflows/covector.yml
+++ b/.github/workflows/covector.yml
@@ -45,15 +45,18 @@ jobs:
           node-version: '14'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install Dasel
-        run: |
-          curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
-          mv ./dasel /usr/local/bin/dasel
-
       - name: Configure the Git User to Use
         run: |
           git config --global user.name "${{ github.event.pusher.name }}"
           git config --global user.email "${{ github.event.pusher.email }}"
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      
+      - name: Install Dasel
+        run: |
+          brew update --preinstall
+          brew install dasel
 
       # Publish when no change file is present.
       - id: covector


### PR DESCRIPTION
# Description of change

Installs `dasel` using Homebrew instead of using the GitHub API. Requests through the GitHub API seem to have stopped working for some reason, and I can't reproduce the issue locally with `act` so it seems to be specific to GitHub-hosted Actions runners.

## Links to any relevant issues

N/A

## Type of change

- Chore

## How the change has been tested

Installation succeeds: https://github.com/iotaledger/wallet.rs/actions/runs/3895104995/jobs/6649992925#step:5:11

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
