### PR TITLE
Fix python bindings folder in getting started doc

### DIFF
--- a/documentation/docs/getting_started/python.mdx
+++ b/documentation/docs/getting_started/python.mdx
@@ -38,7 +38,7 @@ After you have cloned the repository, you should change directory to `iota.rs/bi
 running the following command:
 
 ```bash
-cd iota.rs/client/bindings/python/native
+cd iota.rs/client/bindings/python
 ```
 
 ### Install the Required Dependencies and Build the Wheel


### PR DESCRIPTION
# Description of change

Fixed 
### Change to the Python Binding Directory
path to `cd iota.rs/client/bindings/python/` because `cd iota.rs/client/bindings/python/native` does not exist

## Links to any relevant issues

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

I cloned the repo and tried the documentation out

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
