### PR TITLE
Fix getPublishedVersion

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -10,7 +10,7 @@
     "nodejs-binding": {
       "path": "./client/bindings/nodejs",
       "manager": "javascript",
-      "getPublishedVersion": "npm view ${ pkgFile.pkg.name } version",
+      "getPublishedVersion": "npm view ${ pkgFile.pkg.name }@develop version",
       "prepublish": [
         {
           "command": "false || dasel put -f Cargo.toml '.dependencies.iota-client.rev' -v $GITHUB_SHA"


### PR DESCRIPTION
# Description of change

Fix getPublishedVersion since we use a custom tag now, it by default gets the version for `latest` tag which is an older version and then it think that the version isn't published yet

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota.rs/issues/1504

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running `npm view @iota/client@develop version` returns `3.0.0-rc.6`

