### PR TITLE
Add and return StrongholdMnemonicMissing error

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Client::get_included_block_metadata` API endpoint;
 - `Message::GetIncludedBlockMetadata` to message interface;
 - `Serialize_repr`, `Deserialize_repr` and `#[repr(u8)]` to `ParticipationEventType`;
+- `Error::StrongholdMnemonicMissing`;
 
 ### Changed
 

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -323,6 +323,10 @@ pub enum Error {
     #[cfg(feature = "stronghold")]
     #[error("a mnemonic has already been stored in the Stronghold vault")]
     StrongholdMnemonicAlreadyStored,
+    /// No mnemonic has been stored into the Stronghold vault
+    #[cfg(feature = "stronghold")]
+    #[error("no mnemonic has been stored into the Stronghold vault")]
+    StrongholdMnemonicMissing,
     /// Procedure execution error from Stronghold
     #[cfg(feature = "stronghold")]
     #[error("Stronghold reported a procedure error: {0}")]

--- a/client/src/stronghold/secret.rs
+++ b/client/src/stronghold/secret.rs
@@ -157,13 +157,13 @@ impl StrongholdAdapter {
             .execute_procedure(procedures::Slip10Derive { chain, input, output })
         {
             match err {
-                iota_stronghold::procedures::ProcedureError::Engine(e) => {
+                iota_stronghold::procedures::ProcedureError::Engine(ref e) => {
                     // Custom error for missing vault error: https://github.com/iotaledger/stronghold.rs/blob/7f0a2e0637394595e953f9071fa74b1d160f51ec/client/src/types/error.rs#L170
                     if e.to_string().contains("does not exist") {
                         // Actually the seed, derived from the mnemonic, is not stored.
                         return Err(Error::StrongholdMnemonicMissing);
                     } else {
-                        return Err(iota_stronghold::procedures::ProcedureError::Engine(e).into());
+                        return Err(err.into());
                     }
                 }
                 _ => {
@@ -301,12 +301,10 @@ mod tests {
         stronghold_adapter.clear_key().await;
 
         // Address generation returns an error when the key is cleared.
-        assert!(
-            stronghold_adapter
-                .generate_addresses(IOTA_COIN_TYPE, 0, 0..1, false, None,)
-                .await
-                .is_err()
-        );
+        assert!(stronghold_adapter
+            .generate_addresses(IOTA_COIN_TYPE, 0, 0..1, false, None,)
+            .await
+            .is_err());
 
         stronghold_adapter.set_password("drowssap").await.unwrap();
 

--- a/client/src/stronghold/secret.rs
+++ b/client/src/stronghold/secret.rs
@@ -301,10 +301,12 @@ mod tests {
         stronghold_adapter.clear_key().await;
 
         // Address generation returns an error when the key is cleared.
-        assert!(stronghold_adapter
-            .generate_addresses(IOTA_COIN_TYPE, 0, 0..1, false, None,)
-            .await
-            .is_err());
+        assert!(
+            stronghold_adapter
+                .generate_addresses(IOTA_COIN_TYPE, 0, 0..1, false, None,)
+                .await
+                .is_err()
+        );
 
         stronghold_adapter.set_password("drowssap").await.unwrap();
 

--- a/client/src/stronghold/secret.rs
+++ b/client/src/stronghold/secret.rs
@@ -149,11 +149,28 @@ impl StrongholdAdapter {
 
     /// Execute [Procedure::SLIP10Derive] in Stronghold to derive a SLIP-10 private key in the Stronghold vault.
     async fn slip10_derive(&self, chain: Chain, input: Slip10DeriveInput, output: Location) -> Result<()> {
-        self.stronghold
+        if let Err(err) = self
+            .stronghold
             .lock()
             .await
             .get_client(PRIVATE_DATA_CLIENT_PATH)?
-            .execute_procedure(procedures::Slip10Derive { chain, input, output })?;
+            .execute_procedure(procedures::Slip10Derive { chain, input, output })
+        {
+            match err {
+                iota_stronghold::procedures::ProcedureError::Engine(e) => {
+                    // Custom error for missing vault error: https://github.com/iotaledger/stronghold.rs/blob/7f0a2e0637394595e953f9071fa74b1d160f51ec/client/src/types/error.rs#L170
+                    if e.to_string().contains("does not exist") {
+                        // Actually the seed, derived from the mnemonic, is not stored.
+                        return Err(Error::StrongholdMnemonicMissing);
+                    } else {
+                        return Err(iota_stronghold::procedures::ProcedureError::Engine(e).into());
+                    }
+                }
+                _ => {
+                    return Err(err.into());
+                }
+            }
+        };
 
         Ok(())
     }


### PR DESCRIPTION
# Description of change

Add and return StrongholdMnemonicMissing error, because the not existing VaultId error isn't clear to the end user

## Links to any relevant issues

Fixes https://github.com/iotaledger/wallet.rs/issues/1738

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Have run the stronghold example without storing a mnemonic and added a test

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
