### PR TITLE
Fix link to "full specification" in line 67

### DIFF
--- a/documentation/docs/overview.md
+++ b/documentation/docs/overview.md
@@ -64,4 +64,4 @@ Operations from the first group tend to be too atomic and basic to use convenien
 higher-level helper functions. These functions represent an actual task and combine multiple basic operations
 internally. For example, you can get your token balance by calling `getBalance`. It will first call `getAddresses`, then
 call `getAddressBalances` for each address, and add the results together to return the total balance. See
-the [full specification](../specs) for details.
+the [full specification](./specs.mdx) for details.

--- a/documentation/docs/overview.md
+++ b/documentation/docs/overview.md
@@ -64,4 +64,4 @@ Operations from the first group tend to be too atomic and basic to use convenien
 higher-level helper functions. These functions represent an actual task and combine multiple basic operations
 internally. For example, you can get your token balance by calling `getBalance`. It will first call `getAddresses`, then
 call `getAddressBalances` for each address, and add the results together to return the total balance. See
-the [full specification](./specs) for details.
+the [full specification](../specs) for details.


### PR DESCRIPTION
# Description of change

Link to full specification is broken. Needs to go one folder up

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## How the change has been tested
Has not been tested
