### PR TITLE
Update wasm-bindgen version

### DIFF
--- a/.github/workflows/examine-wasm-bindings.yml
+++ b/.github/workflows/examine-wasm-bindings.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install wasm-bindgen-cli
         uses: jetli/wasm-bindgen-action@24ba6f9fff570246106ac3f80f35185600c3f6c9
         with:
-          version: '0.2.83'
+          version: '0.2.84'
 
       - name: Set Up Node.js ${{ matrix.node }} and Yarn Cache
         uses: actions/setup-node@v2

--- a/.github/workflows/release-wasm-bindings-to-npm.yml
+++ b/.github/workflows/release-wasm-bindings-to-npm.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install wasm-bindgen-cli
         uses: jetli/wasm-bindgen-action@24ba6f9fff570246106ac3f80f35185600c3f6c9
         with:
-          version: '0.2.83'
+          version: '0.2.84'
 
       - name: Set up Node.js
         uses: actions/setup-node@v2

--- a/client/bindings/wasm/Cargo.lock
+++ b/client/bindings/wasm/Cargo.lock
@@ -858,9 +858,9 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1644,9 +1644,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "serde",
@@ -1656,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -1671,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1683,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1693,9 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1706,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"

--- a/client/bindings/wasm/Cargo.toml
+++ b/client/bindings/wasm/Cargo.toml
@@ -21,11 +21,11 @@ crate-type = [ "cdylib" ]
 iota-client = { path = "../../", default-features = false, features = [ "message_interface", "tls" ] }
 
 console_error_panic_hook = { version = "0.1.7", default-features = false }
-js-sys = { version = "0.3.60", default-features = false, features = [] }
+js-sys = { version = "0.3.61", default-features = false, features = [] }
 serde_json = { version = "1.0.91", default-features = false }
 tokio = { version = "1.24.2", default-features = false, features = [ "sync" ] }
-wasm-bindgen = { version = "0.2.83", default-features = false, features = [ "spans", "std", "serde-serialize" ] }
-wasm-bindgen-futures = { version = "0.4.33", default-features = false }
+wasm-bindgen = { version = "0.2.84", default-features = false, features = [ "spans", "std", "serde-serialize" ] }
+wasm-bindgen-futures = { version = "0.4.34", default-features = false }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
 getrandom = { version = "0.2.8", default-features = false, features = [ "js" ] }

--- a/client/bindings/wasm/build_scripts/lints.js
+++ b/client/bindings/wasm/build_scripts/lints.js
@@ -1,35 +1,3 @@
-/**
- * Rejects any `<obj>.ptr = 0;` occurrence, excluding `this.ptr = 0;` in `free()` implementations.
- *
- * Prevents generated code that nulls out Wasm pointers without de-registering the finalizer, since they cause
- * runtime errors during automatic garbage collection from WasmRefCell thinking the instance is still borrowed.
- *
- * Functions which take owned parameters cause this situation; the solution is to borrow and clone the parameter
- * instead.
- **/
-function lintPtrNullWithoutFree(content) {
-    // Find line numbers of offending code.
-    const lines = content.split(/\r?\n/);
-    const matches = lines.flatMap(function (line, number) {
-        if (/(?<!this).ptr = 0;/.test(line)) {
-            return [(number + 1) + " " + line.trim()];
-        } else {
-            return [];
-        }
-    });
-    if (matches.length > 0) {
-        throw(`ERROR: generated Javascript should not include 'obj.ptr = 0;'. 
-When weak references are enabled with '--weak-refs', WasmRefCell in wasm-bindgen causes 
-runtime errors from automatic garbage collection trying to free objects taken as owned parameters. 
-
-Matches:
-${matches}
-
-SUGGESTION: change any exported functions which take an owned parameter (excluding flat enums) to use a borrow instead.
-See: https://github.com/rustwasm/wasm-bindgen/pull/2677`);
-    }
-}
-
 /** Rejects any `imports['env']` occurrences, which cause failures at runtime.
  *
  * This is typically due to Wasm compatibility features not being enabled on crate dependencies. **/
@@ -66,7 +34,6 @@ See:
 /** Runs all custom lints on the generated code. Exits the process immediately with code 1 if any fail. **/
 function lintAll(content) {
     try {
-        lintPtrNullWithoutFree(content);
         lintImportEnv(content);
     } catch (err) {
         console.error("Custom lint failed!");


### PR DESCRIPTION
# Description of change
This PR bumps up the `wasm-bindgen` dependency in the Client Wasm bindings to version `0.2.84` (latest) and removes a lint that no longer applies (see [this PR](https://github.com/iotaledger/identity.rs/pull/1111) for more context). 


## How the change has been tested
Builds locally

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
