### PR TITLE
fix: correct workflows

### DIFF
--- a/.github/workflows/covector.yml
+++ b/.github/workflows/covector.yml
@@ -124,6 +124,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install libudev-dev libusb-1.0-0-dev
 
+        # Temporary fix for "ValueError: invalid mode: 'rU' while trying to load binding.gyp"
+        # This can be removed when "prebuild" updates "node-gyp"
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Run Yarn Install
         working-directory: client/bindings/nodejs/
         run: yarn install


### PR DESCRIPTION
# Description of change

The prebuild on macOS fail at the moment, because prebuild relies on an outdated `node-gyp` version that requires python 3.10 to work correctly. The python versions on the CI machine for macOS defaults to 3.11 which causes these issues.

Copy of work done in wallet.rs: 
https://github.com/iotaledger/wallet.rs/pull/1613

## Links to any relevant issues

closes: #1522 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
