### PR TITLE
Use OutputMetadataDto instead of OutputMetadata

### DIFF
--- a/.changes/input-signing-data.md
+++ b/.changes/input-signing-data.md
@@ -1,0 +1,6 @@
+
+---
+"nodejs-binding": patch
+---
+
+Fix IInputSigningData;

--- a/.changes/input-signing-data.md
+++ b/.changes/input-signing-data.md
@@ -3,4 +3,6 @@
 "nodejs-binding": patch
 ---
 
-Fix IInputSigningData;
+Fixed returned JSON value for `IInputSigningData`;
+Renamed `IInputSigningData::outputMetaData` to `IInputSigningData::outputMetadata`;
+Changed `ISegment::bs` from `Uint8Array` to `number[]` so that the serialization corresponds to what is expected;

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Error::Pow` to `Error::NonceNotFound`;
 - `finish_nonce` takes a `F: Fn(&[u8]) -> Option<u64>` instead of a `F: Fn(&[u8]) -> Result<u64, PowError>`;
 - Remove `Error` suffix on some `Error` variants;
+- `InputSigningDataDto::output_metadata` from `OutputMetadata` to `OutputMetadataDto`;
 
 ### Removed
 

--- a/client/bindings/nodejs/Cargo.lock
+++ b/client/bindings/nodejs/Cargo.lock
@@ -806,6 +806,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ghash"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1181,7 @@ dependencies = [
  "bitflags",
  "bytemuck",
  "derive_more",
+ "getset",
  "hashbrown 0.13.2",
  "hex",
  "iota-crypto",
@@ -1180,6 +1193,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
+ "serde_repr",
  "thiserror",
 ]
 
@@ -2052,6 +2066,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/client/bindings/nodejs/examples/offline_signing/0_address_generation.ts
+++ b/client/bindings/nodejs/examples/offline_signing/0_address_generation.ts
@@ -9,7 +9,7 @@ import {
 } from '@iota/client';
 import { writeFile } from 'fs/promises';
 
-require('dotenv').config({ path: '../../../.env' });
+require('dotenv').config({ path: '../../../../.env' });
 
 // From examples directory, run with:
 // node ./dist/offline_signing/0_address_generation.js

--- a/client/bindings/nodejs/examples/offline_signing/1_transaction_preparation.ts
+++ b/client/bindings/nodejs/examples/offline_signing/1_transaction_preparation.ts
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { Client, initLogger, IPreparedTransactionData } from '@iota/client';
+import { Client, initLogger } from '@iota/client';
 import { writeFile, readFile } from 'fs/promises';
 
 require('dotenv').config({ path: '../../../../.env' });

--- a/client/bindings/nodejs/examples/offline_signing/1_transaction_preparation.ts
+++ b/client/bindings/nodejs/examples/offline_signing/1_transaction_preparation.ts
@@ -1,10 +1,10 @@
 // Copyright 2021-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { Client, initLogger } from '@iota/client';
+import { Client, initLogger, IPreparedTransactionData } from '@iota/client';
 import { writeFile, readFile } from 'fs/promises';
 
-require('dotenv').config({ path: '../../../.env' });
+require('dotenv').config({ path: '../../../../.env' });
 
 // From examples directory, run with:
 // node ./dist/offline_signing/1_transaction_preparation.js

--- a/client/bindings/nodejs/examples/offline_signing/2_transaction_signing.ts
+++ b/client/bindings/nodejs/examples/offline_signing/2_transaction_signing.ts
@@ -4,7 +4,7 @@
 import { Client, initLogger } from '@iota/client';
 import { writeFile, readFile } from 'fs/promises';
 
-require('dotenv').config({ path: '../../../.env' });
+require('dotenv').config({ path: '../../../../.env' });
 
 // From examples directory, run with:
 // node ./dist/offline_signing/2_transaction_signing.js

--- a/client/bindings/nodejs/examples/offline_signing/3_send_block.ts
+++ b/client/bindings/nodejs/examples/offline_signing/3_send_block.ts
@@ -4,7 +4,7 @@
 import { Client, initLogger } from '@iota/client';
 import { readFile } from 'fs/promises';
 
-require('dotenv').config({ path: '../../../.env' });
+require('dotenv').config({ path: '../../../../.env' });
 
 // From examples directory, run with:
 // node ./dist/offline_signing/3_send_block.js

--- a/client/bindings/nodejs/types/preparedTransactionData.ts
+++ b/client/bindings/nodejs/types/preparedTransactionData.ts
@@ -37,7 +37,7 @@ export interface IInputSigningData {
     /**
      * The output metadata
      */
-    outputMetaData: IOutputMetadataResponse;
+    outputMetadata: IOutputMetadataResponse;
     /**
      * The chain derived from seed, only for ed25519 addresses
      */
@@ -65,5 +65,5 @@ export interface IRemainder {
 }
 export interface ISegment {
     hardened: boolean;
-    bs: Uint8Array;
+    bs: number[];
 }

--- a/client/bindings/wasm/CHANGELOG.md
+++ b/client/bindings/wasm/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated dependencies;
 
+### Fixed
+
+- `IInputSigningData`;
+
 ## 1.0.0-alpha.1 - YYYY-MM-DD
 
 Initial release of the wasm bindings.

--- a/client/bindings/wasm/CHANGELOG.md
+++ b/client/bindings/wasm/CHANGELOG.md
@@ -32,10 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated dependencies;
+- Renamed `IInputSigningData::outputMetaData` to `IInputSigningData::outputMetadata`;
+- Changed `ISegment::bs` from `Uint8Array` to `number[]` so that the serialization corresponds to what is expected;
 
 ### Fixed
 
-- `IInputSigningData`;
+- Returned JSON value for `IInputSigningData`;
 
 ## 1.0.0-alpha.1 - YYYY-MM-DD
 

--- a/client/examples/offline_signing/addresses.json
+++ b/client/examples/offline_signing/addresses.json
@@ -1,3 +1,0 @@
-[
-  "rms1qp7qtadk5gz88fq2khpjdxzwf7yw0er4km38grtuegkx4a9d68ymxklghyn"
-]

--- a/client/src/secret/types.rs
+++ b/client/src/secret/types.rs
@@ -6,7 +6,10 @@
 use crypto::keys::slip10::Chain;
 use iota_types::block::{
     address::Address,
-    output::{dto::OutputDto, Output, OutputId, OutputMetadata},
+    output::{
+        dto::{OutputDto, OutputMetadataDto},
+        Output, OutputId, OutputMetadata,
+    },
 };
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "stronghold")]
@@ -156,7 +159,7 @@ pub struct InputSigningDataDto {
     pub output: OutputDto,
     /// The output metadata
     #[serde(rename = "outputMetadata")]
-    pub output_metadata: OutputMetadata,
+    pub output_metadata: OutputMetadataDto,
     /// The chain derived from seed, only for ed25519 addresses
     pub chain: Option<Chain>,
     /// The bech32 encoded address, required because of alias outputs where we have multiple possible unlock
@@ -169,7 +172,7 @@ impl InputSigningData {
     pub(crate) fn try_from_dto(input: &InputSigningDataDto, token_supply: u64) -> Result<Self> {
         Ok(Self {
             output: Output::try_from_dto(&input.output, token_supply)?,
-            output_metadata: input.output_metadata.clone(),
+            output_metadata: OutputMetadata::try_from(&input.output_metadata)?,
             chain: input.chain.clone(),
             bech32_address: input.bech32_address.clone(),
         })
@@ -178,7 +181,7 @@ impl InputSigningData {
     pub(crate) fn try_from_dto_unverified(input: &InputSigningDataDto) -> Result<Self> {
         Ok(Self {
             output: Output::try_from_dto_unverified(&input.output)?,
-            output_metadata: input.output_metadata.clone(),
+            output_metadata: OutputMetadata::try_from(&input.output_metadata)?,
             chain: input.chain.clone(),
             bech32_address: input.bech32_address.clone(),
         })
@@ -189,7 +192,7 @@ impl From<&InputSigningData> for InputSigningDataDto {
     fn from(input: &InputSigningData) -> Self {
         Self {
             output: OutputDto::from(&input.output),
-            output_metadata: input.output_metadata.clone(),
+            output_metadata: OutputMetadataDto::from(&input.output_metadata),
             chain: input.chain.clone(),
             bech32_address: input.bech32_address.clone(),
         }

--- a/documentation/docs/libraries/nodejs/references/interfaces/IInputSigningData.md
+++ b/documentation/docs/libraries/nodejs/references/interfaces/IInputSigningData.md
@@ -7,7 +7,7 @@ Data for transaction inputs for signing and ordering of unlock blocks
 ### Properties
 
 - [output](IInputSigningData.md#output)
-- [outputMetaData](IInputSigningData.md#outputmetadata)
+- [outputMetadata](IInputSigningData.md#outputmetadata)
 - [chain](IInputSigningData.md#chain)
 - [bech32Address](IInputSigningData.md#bech32address)
 
@@ -21,9 +21,9 @@ The output
 
 ___
 
-### outputMetaData
+### outputMetadata
 
-• **outputMetaData**: `IOutputMetadataResponse`
+• **outputMetadata**: `IOutputMetadataResponse`
 
 The output metadata
 


### PR DESCRIPTION
# Description of change

Use OutputMetadataDto instead of OutputMetadata

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota.rs/issues/1547

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Running offline signing examples

Philipp wrote `Trying to deserialize anything outside the byte range into [u8; 4] would be caught by serde, but double checking that would be good.` in the issue, so I tried to run it with `"bs": [128, 0, 0, 44, 1]` instead of `"bs": [128, 0, 0, 44]` and it returned `Error("trailing characters", line: 1, column: 1644)`, so should be good

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
