### PR TITLE
Expose signature unlock in NodeJS & Wasm bindings

### DIFF
--- a/.changes/signatureUnlock.md
+++ b/.changes/signatureUnlock.md
@@ -1,0 +1,6 @@
+
+---
+"nodejs-binding": patch
+---
+
+Add `signatureUnlock()`.

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `#[derive(Eq, PartialEq, Deserialize)]` to `TopicEvent, MqttPayload`;
 - `#[derive(Serialize)]` to ` Topic`;
 - `impl<'de> Deserialize<'de> for Topic`;
+- Added `Message::SignatureUnlock`;
 
 ### Changed
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `#[derive(Eq, PartialEq, Deserialize)]` to `TopicEvent, MqttPayload`;
 - `#[derive(Serialize)]` to ` Topic`;
 - `impl<'de> Deserialize<'de> for Topic`;
-- Added `Message::SignatureUnlock`;
+- `Message::SignatureUnlock`;
 
 ### Changed
 

--- a/client/bindings/nodejs/examples/package.json
+++ b/client/bindings/nodejs/examples/package.json
@@ -8,8 +8,7 @@
     },
     "dependencies": {
         "@iota/client": "../",
-        "dotenv": "^16.0.0",
-        "@iota/iota.js": "^2.0.0-rc.2"
+        "dotenv": "^16.0.0"
     },
     "devDependencies": {
         "@types/node": "^17.0.26",

--- a/client/bindings/nodejs/examples/package.json
+++ b/client/bindings/nodejs/examples/package.json
@@ -8,7 +8,8 @@
     },
     "dependencies": {
         "@iota/client": "../",
-        "dotenv": "^16.0.0"
+        "dotenv": "^16.0.0",
+        "@iota/iota.js": "^2.0.0-rc.2"
     },
     "devDependencies": {
         "@types/node": "^17.0.26",

--- a/client/bindings/nodejs/lib/Client.ts
+++ b/client/bindings/nodejs/lib/Client.ts
@@ -20,6 +20,7 @@ import type {
     NftQueryParameter,
     AliasQueryParameter,
     LedgerNanoStatus,
+    IInputSigningData,
 } from '../types';
 import type {
     IUTXOInput,
@@ -39,6 +40,7 @@ import type {
     IFoundryOutput,
     INftOutput,
     INodeInfoProtocol,
+    UnlockTypes,
 } from '@iota/types';
 import type { INodeInfoWrapper } from '../types/nodeInfo';
 
@@ -367,6 +369,29 @@ export class Client {
             data: {
                 secretManager,
                 preparedTransactionData,
+            },
+        });
+
+        return JSON.parse(response).payload;
+    }
+
+    /**
+     * Create a signature unlock using the provided `secretManager`.
+     */
+    async signatureUnlock(
+        secretManager: SecretManager,
+        inputSigningData: IInputSigningData,
+        // Uses `Array<number>` instead of `Uint8Array` because the latter serializes
+        // as an object rather than an array, which results in errors with serde.
+        transactionEssenceHash: Array<number>,
+    ): Promise<UnlockTypes> {
+        const response = await this.messageHandler.sendMessage({
+            name: 'signatureUnlock',
+            data: {
+                secretManager,
+                inputSigningData,
+                transactionEssenceHash,
+                remainderData: undefined,
             },
         });
 

--- a/client/bindings/nodejs/package.json
+++ b/client/bindings/nodejs/package.json
@@ -33,6 +33,7 @@
     "@types/jest": "^27.5.2",
     "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@typescript-eslint/parser": "^5.31.0",
+    "@iota/iota.js": "^2.0.0-rc.2",
     "dotenv": "^16.0.1",
     "electron-build-env": "^0.2.0",
     "eslint": "^8.20.0",

--- a/client/bindings/nodejs/test/client/offlineSigningExamples.spec.ts
+++ b/client/bindings/nodejs/test/client/offlineSigningExamples.spec.ts
@@ -1,9 +1,11 @@
-import { Client, SHIMMER_TESTNET_BECH32_HRP } from '../../lib';
+import { Client, IInputSigningData, initLogger, IPreparedTransactionData, SHIMMER_TESTNET_BECH32_HRP } from '../../lib';
 import '../customMatchers';
 import 'dotenv/config';
 import { addresses } from '../fixtures/addresses';
 import * as signedTransactionJson from '../fixtures/signedTransaction.json';
-import type { PayloadTypes } from '@iota/types';
+import * as sigUnlockPreparedTx from '../fixtures/sigUnlockPreparedTx.json';
+import type { ITransactionEssence, PayloadTypes } from '@iota/types';
+import { TransactionHelper } from "@iota/iota.js";
 
 const onlineClient = new Client({
     nodes: [
@@ -78,5 +80,29 @@ describe('Offline signing examples', () => {
 
         expect(blockId).toBe(blockIdAndBlock[0]);
         expect(blockId).toBeValidBlockId;
+    });
+    it('create a signature unlock', async () => {
+        // Verifies that an unlock created in Rust matches that created by the binding when the mnemonic is identical.
+        const secretManager = {
+            mnemonic:
+                "good reason pipe keen price glory mystery illegal loud isolate wolf trash raise guilt inflict guide modify bachelor length galaxy lottery there mango comfort",
+        };
+        const preparedTx  = sigUnlockPreparedTx as IPreparedTransactionData;
+        const txHash = Array.from(TransactionHelper.getTransactionEssenceHash(preparedTx.essence));
+
+        const unlock = await offlineClient.signatureUnlock(
+            secretManager,
+            preparedTx.inputsData[0],
+            txHash,
+        )
+
+        expect(unlock).toStrictEqual({
+            "type": 0,
+            "signature": {
+                "type": 0,
+                "publicKey": "0xb76a23de43b8132ae18a4a479cb158563e76d89bd1e20d3ccdc7fd1db2a009d4",
+                "signature": "0xcd905dae45010980e95ddddaebede830d9b8d7489c67e4d91a0cbfbdb03b02d337dc8162f15582ad18ee0e953cd517e32f809d533f9ccfb4beee5cb2cba16d0c"
+            }
+        });
     });
 });

--- a/client/bindings/nodejs/test/client/offlineSigningExamples.spec.ts
+++ b/client/bindings/nodejs/test/client/offlineSigningExamples.spec.ts
@@ -1,11 +1,17 @@
-import { Client, IInputSigningData, initLogger, IPreparedTransactionData, SHIMMER_TESTNET_BECH32_HRP } from '../../lib';
+import {
+    Client,
+    IInputSigningData,
+    initLogger,
+    IPreparedTransactionData,
+    SHIMMER_TESTNET_BECH32_HRP,
+} from '../../lib';
 import '../customMatchers';
 import 'dotenv/config';
 import { addresses } from '../fixtures/addresses';
 import * as signedTransactionJson from '../fixtures/signedTransaction.json';
 import * as sigUnlockPreparedTx from '../fixtures/sigUnlockPreparedTx.json';
 import type { ITransactionEssence, PayloadTypes } from '@iota/types';
-import { TransactionHelper } from "@iota/iota.js";
+import { TransactionHelper } from '@iota/iota.js';
 
 const onlineClient = new Client({
     nodes: [
@@ -85,24 +91,28 @@ describe('Offline signing examples', () => {
         // Verifies that an unlock created in Rust matches that created by the binding when the mnemonic is identical.
         const secretManager = {
             mnemonic:
-                "good reason pipe keen price glory mystery illegal loud isolate wolf trash raise guilt inflict guide modify bachelor length galaxy lottery there mango comfort",
+                'good reason pipe keen price glory mystery illegal loud isolate wolf trash raise guilt inflict guide modify bachelor length galaxy lottery there mango comfort',
         };
-        const preparedTx  = sigUnlockPreparedTx as IPreparedTransactionData;
-        const txHash = Array.from(TransactionHelper.getTransactionEssenceHash(preparedTx.essence));
+        const preparedTx = sigUnlockPreparedTx as IPreparedTransactionData;
+        const txHash = Array.from(
+            TransactionHelper.getTransactionEssenceHash(preparedTx.essence),
+        );
 
         const unlock = await offlineClient.signatureUnlock(
             secretManager,
             preparedTx.inputsData[0],
             txHash,
-        )
+        );
 
         expect(unlock).toStrictEqual({
-            "type": 0,
-            "signature": {
-                "type": 0,
-                "publicKey": "0xb76a23de43b8132ae18a4a479cb158563e76d89bd1e20d3ccdc7fd1db2a009d4",
-                "signature": "0xcd905dae45010980e95ddddaebede830d9b8d7489c67e4d91a0cbfbdb03b02d337dc8162f15582ad18ee0e953cd517e32f809d533f9ccfb4beee5cb2cba16d0c"
-            }
+            type: 0,
+            signature: {
+                type: 0,
+                publicKey:
+                    '0xb76a23de43b8132ae18a4a479cb158563e76d89bd1e20d3ccdc7fd1db2a009d4',
+                signature:
+                    '0xcd905dae45010980e95ddddaebede830d9b8d7489c67e4d91a0cbfbdb03b02d337dc8162f15582ad18ee0e953cd517e32f809d533f9ccfb4beee5cb2cba16d0c',
+            },
         });
     });
 });

--- a/client/bindings/nodejs/test/client/offlineSigningExamples.spec.ts
+++ b/client/bindings/nodejs/test/client/offlineSigningExamples.spec.ts
@@ -1,7 +1,5 @@
 import {
     Client,
-    IInputSigningData,
-    initLogger,
     IPreparedTransactionData,
     SHIMMER_TESTNET_BECH32_HRP,
 } from '../../lib';
@@ -10,7 +8,7 @@ import 'dotenv/config';
 import { addresses } from '../fixtures/addresses';
 import * as signedTransactionJson from '../fixtures/signedTransaction.json';
 import * as sigUnlockPreparedTx from '../fixtures/sigUnlockPreparedTx.json';
-import type { ITransactionEssence, PayloadTypes } from '@iota/types';
+import type { PayloadTypes } from '@iota/types';
 import { TransactionHelper } from '@iota/iota.js';
 
 const onlineClient = new Client({

--- a/client/bindings/nodejs/test/fixtures/sigUnlockPreparedTx.json
+++ b/client/bindings/nodejs/test/fixtures/sigUnlockPreparedTx.json
@@ -1,0 +1,182 @@
+{
+  "essence": {
+    "type": 1,
+    "networkId": "8342982141227064571",
+    "inputs": [
+      {
+        "type": 0,
+        "transactionId": "0xa973c248bcd1cd230f1d36952f69d59e20371aef10a0c6aa4e7c8f9b14fa13e0",
+        "transactionOutputIndex": 0
+      }
+    ],
+    "inputsCommitment": "0x300fe5b1ed771286c608574e0372a1c936bed1c43725f462ca6d90e11afad005",
+    "outputs": [
+      {
+        "type": 3,
+        "amount": "1000000",
+        "unlockConditions": [
+          {
+            "type": 0,
+            "address": {
+              "type": 0,
+              "pubKeyHash": "0xf8208cdcda8b1afc710fbcb2e822fe70661c3213172189b845d49a64dd52a7a4"
+            }
+          }
+        ]
+      },
+      {
+        "type": 3,
+        "amount": "999000000",
+        "unlockConditions": [
+          {
+            "type": 0,
+            "address": {
+              "type": 0,
+              "pubKeyHash": "0x9f618504d1a5a0f9b61a0a68fb8479c838ce29ef1eac377e077e8f1260c41c47"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "inputsData": [
+    {
+      "output": {
+        "type": 3,
+        "amount": "1000000000",
+        "unlockConditions": [
+          {
+            "type": 0,
+            "address": {
+              "type": 0,
+              "pubKeyHash": "0x9f618504d1a5a0f9b61a0a68fb8479c838ce29ef1eac377e077e8f1260c41c47"
+            }
+          }
+        ]
+      },
+      "outputMetadata": {
+        "blockId": "0x7b7b0b7f5f8e04e052e3d9c2f3f8a67a6a1724b6afbde50a1804c5fa9800f282",
+        "transactionId": "0xa973c248bcd1cd230f1d36952f69d59e20371aef10a0c6aa4e7c8f9b14fa13e0",
+        "outputIndex": 0,
+        "isSpent": false,
+        "milestoneIndexBooked": 3422369,
+        "milestoneTimestampBooked": 1675248149,
+        "ledgerIndex": 3527507
+      },
+      "chain": [
+        {
+          "hardened": true,
+          "bs": [
+            128,
+            0,
+            0,
+            44
+          ]
+        },
+        {
+          "hardened": true,
+          "bs": [
+            128,
+            0,
+            16,
+            123
+          ]
+        },
+        {
+          "hardened": true,
+          "bs": [
+            128,
+            0,
+            0,
+            0
+          ]
+        },
+        {
+          "hardened": true,
+          "bs": [
+            128,
+            0,
+            0,
+            0
+          ]
+        },
+        {
+          "hardened": true,
+          "bs": [
+            128,
+            0,
+            0,
+            0
+          ]
+        }
+      ],
+      "bech32Address": "rms1qz0krpgy6xj6p7dkrg9x37uy08yr3n3fau02cdm7qalg7ynqcswywncmd9p"
+    }
+  ],
+  "remainder": {
+    "output": {
+      "type": 3,
+      "amount": "999000000",
+      "unlockConditions": [
+        {
+          "type": 0,
+          "address": {
+            "type": 0,
+            "pubKeyHash": "0x9f618504d1a5a0f9b61a0a68fb8479c838ce29ef1eac377e077e8f1260c41c47"
+          }
+        }
+      ]
+    },
+    "chain": [
+      {
+        "hardened": true,
+        "bs": [
+          128,
+          0,
+          0,
+          44
+        ]
+      },
+      {
+        "hardened": true,
+        "bs": [
+          128,
+          0,
+          16,
+          123
+        ]
+      },
+      {
+        "hardened": true,
+        "bs": [
+          128,
+          0,
+          0,
+          0
+        ]
+      },
+      {
+        "hardened": true,
+        "bs": [
+          128,
+          0,
+          0,
+          0
+        ]
+      },
+      {
+        "hardened": true,
+        "bs": [
+          128,
+          0,
+          0,
+          0
+        ]
+      }
+    ],
+    "address": {
+      "type": 0,
+      "pubKeyHash": "0x9f618504d1a5a0f9b61a0a68fb8479c838ce29ef1eac377e077e8f1260c41c47"
+    }
+  }
+}

--- a/client/bindings/nodejs/test/fixtures/sigUnlockPreparedTx.json
+++ b/client/bindings/nodejs/test/fixtures/sigUnlockPreparedTx.json
@@ -1,182 +1,132 @@
 {
-  "essence": {
-    "type": 1,
-    "networkId": "8342982141227064571",
-    "inputs": [
-      {
-        "type": 0,
-        "transactionId": "0xa973c248bcd1cd230f1d36952f69d59e20371aef10a0c6aa4e7c8f9b14fa13e0",
-        "transactionOutputIndex": 0
-      }
-    ],
-    "inputsCommitment": "0x300fe5b1ed771286c608574e0372a1c936bed1c43725f462ca6d90e11afad005",
-    "outputs": [
-      {
-        "type": 3,
-        "amount": "1000000",
-        "unlockConditions": [
-          {
-            "type": 0,
-            "address": {
-              "type": 0,
-              "pubKeyHash": "0xf8208cdcda8b1afc710fbcb2e822fe70661c3213172189b845d49a64dd52a7a4"
+    "essence": {
+        "type": 1,
+        "networkId": "8342982141227064571",
+        "inputs": [
+            {
+                "type": 0,
+                "transactionId": "0xa973c248bcd1cd230f1d36952f69d59e20371aef10a0c6aa4e7c8f9b14fa13e0",
+                "transactionOutputIndex": 0
             }
-          }
-        ]
-      },
-      {
-        "type": 3,
-        "amount": "999000000",
-        "unlockConditions": [
-          {
-            "type": 0,
-            "address": {
-              "type": 0,
-              "pubKeyHash": "0x9f618504d1a5a0f9b61a0a68fb8479c838ce29ef1eac377e077e8f1260c41c47"
+        ],
+        "inputsCommitment": "0x300fe5b1ed771286c608574e0372a1c936bed1c43725f462ca6d90e11afad005",
+        "outputs": [
+            {
+                "type": 3,
+                "amount": "1000000",
+                "unlockConditions": [
+                    {
+                        "type": 0,
+                        "address": {
+                            "type": 0,
+                            "pubKeyHash": "0xf8208cdcda8b1afc710fbcb2e822fe70661c3213172189b845d49a64dd52a7a4"
+                        }
+                    }
+                ]
+            },
+            {
+                "type": 3,
+                "amount": "999000000",
+                "unlockConditions": [
+                    {
+                        "type": 0,
+                        "address": {
+                            "type": 0,
+                            "pubKeyHash": "0x9f618504d1a5a0f9b61a0a68fb8479c838ce29ef1eac377e077e8f1260c41c47"
+                        }
+                    }
+                ]
             }
-          }
         ]
-      }
-    ]
-  },
-  "inputsData": [
-    {
-      "output": {
-        "type": 3,
-        "amount": "1000000000",
-        "unlockConditions": [
-          {
-            "type": 0,
-            "address": {
-              "type": 0,
-              "pubKeyHash": "0x9f618504d1a5a0f9b61a0a68fb8479c838ce29ef1eac377e077e8f1260c41c47"
-            }
-          }
-        ]
-      },
-      "outputMetadata": {
-        "blockId": "0x7b7b0b7f5f8e04e052e3d9c2f3f8a67a6a1724b6afbde50a1804c5fa9800f282",
-        "transactionId": "0xa973c248bcd1cd230f1d36952f69d59e20371aef10a0c6aa4e7c8f9b14fa13e0",
-        "outputIndex": 0,
-        "isSpent": false,
-        "milestoneIndexBooked": 3422369,
-        "milestoneTimestampBooked": 1675248149,
-        "ledgerIndex": 3527507
-      },
-      "chain": [
+    },
+    "inputsData": [
         {
-          "hardened": true,
-          "bs": [
-            128,
-            0,
-            0,
-            44
-          ]
-        },
-        {
-          "hardened": true,
-          "bs": [
-            128,
-            0,
-            16,
-            123
-          ]
-        },
-        {
-          "hardened": true,
-          "bs": [
-            128,
-            0,
-            0,
-            0
-          ]
-        },
-        {
-          "hardened": true,
-          "bs": [
-            128,
-            0,
-            0,
-            0
-          ]
-        },
-        {
-          "hardened": true,
-          "bs": [
-            128,
-            0,
-            0,
-            0
-          ]
+            "output": {
+                "type": 3,
+                "amount": "1000000000",
+                "unlockConditions": [
+                    {
+                        "type": 0,
+                        "address": {
+                            "type": 0,
+                            "pubKeyHash": "0x9f618504d1a5a0f9b61a0a68fb8479c838ce29ef1eac377e077e8f1260c41c47"
+                        }
+                    }
+                ]
+            },
+            "outputMetadata": {
+                "blockId": "0x7b7b0b7f5f8e04e052e3d9c2f3f8a67a6a1724b6afbde50a1804c5fa9800f282",
+                "transactionId": "0xa973c248bcd1cd230f1d36952f69d59e20371aef10a0c6aa4e7c8f9b14fa13e0",
+                "outputIndex": 0,
+                "isSpent": false,
+                "milestoneIndexBooked": 3422369,
+                "milestoneTimestampBooked": 1675248149,
+                "ledgerIndex": 3527507
+            },
+            "chain": [
+                {
+                    "hardened": true,
+                    "bs": [128, 0, 0, 44]
+                },
+                {
+                    "hardened": true,
+                    "bs": [128, 0, 16, 123]
+                },
+                {
+                    "hardened": true,
+                    "bs": [128, 0, 0, 0]
+                },
+                {
+                    "hardened": true,
+                    "bs": [128, 0, 0, 0]
+                },
+                {
+                    "hardened": true,
+                    "bs": [128, 0, 0, 0]
+                }
+            ],
+            "bech32Address": "rms1qz0krpgy6xj6p7dkrg9x37uy08yr3n3fau02cdm7qalg7ynqcswywncmd9p"
         }
-      ],
-      "bech32Address": "rms1qz0krpgy6xj6p7dkrg9x37uy08yr3n3fau02cdm7qalg7ynqcswywncmd9p"
-    }
-  ],
-  "remainder": {
-    "output": {
-      "type": 3,
-      "amount": "999000000",
-      "unlockConditions": [
-        {
-          "type": 0,
-          "address": {
+    ],
+    "remainder": {
+        "output": {
+            "type": 3,
+            "amount": "999000000",
+            "unlockConditions": [
+                {
+                    "type": 0,
+                    "address": {
+                        "type": 0,
+                        "pubKeyHash": "0x9f618504d1a5a0f9b61a0a68fb8479c838ce29ef1eac377e077e8f1260c41c47"
+                    }
+                }
+            ]
+        },
+        "chain": [
+            {
+                "hardened": true,
+                "bs": [128, 0, 0, 44]
+            },
+            {
+                "hardened": true,
+                "bs": [128, 0, 16, 123]
+            },
+            {
+                "hardened": true,
+                "bs": [128, 0, 0, 0]
+            },
+            {
+                "hardened": true,
+                "bs": [128, 0, 0, 0]
+            },
+            {
+                "hardened": true,
+                "bs": [128, 0, 0, 0]
+            }
+        ],
+        "address": {
             "type": 0,
             "pubKeyHash": "0x9f618504d1a5a0f9b61a0a68fb8479c838ce29ef1eac377e077e8f1260c41c47"
-          }
         }
-      ]
-    },
-    "chain": [
-      {
-        "hardened": true,
-        "bs": [
-          128,
-          0,
-          0,
-          44
-        ]
-      },
-      {
-        "hardened": true,
-        "bs": [
-          128,
-          0,
-          16,
-          123
-        ]
-      },
-      {
-        "hardened": true,
-        "bs": [
-          128,
-          0,
-          0,
-          0
-        ]
-      },
-      {
-        "hardened": true,
-        "bs": [
-          128,
-          0,
-          0,
-          0
-        ]
-      },
-      {
-        "hardened": true,
-        "bs": [
-          128,
-          0,
-          0,
-          0
-        ]
-      }
-    ],
-    "address": {
-      "type": 0,
-      "pubKeyHash": "0x9f618504d1a5a0f9b61a0a68fb8479c838ce29ef1eac377e077e8f1260c41c47"
     }
-  }
 }

--- a/client/bindings/nodejs/types/bridge/client.ts
+++ b/client/bindings/nodejs/types/bridge/client.ts
@@ -3,7 +3,10 @@ import type { SecretManager } from '../secretManager';
 import type { IGenerateAddressesOptions } from '../generateAddressesOptions';
 import type { IBuildBlockOptions } from '../buildBlockOptions';
 import type { BlockId } from '../blockId';
-import type { IInputSigningData, IPreparedTransactionData } from '../preparedTransactionData';
+import type {
+    IInputSigningData,
+    IPreparedTransactionData,
+} from '../preparedTransactionData';
 import type {
     AliasQueryParameter,
     FoundryQueryParameter,
@@ -163,11 +166,11 @@ export interface __SignatureUnlockMessage__ {
     name: 'signatureUnlock';
     data: {
         secretManager: SecretManager;
-        inputSigningData: IInputSigningData,
-        transactionEssenceHash: Array<number>,
+        inputSigningData: IInputSigningData;
+        transactionEssenceHash: Array<number>;
         //TODO: Expose `RemainderData`.
-        remainderData: undefined
-    }
+        remainderData: undefined;
+    };
 }
 
 export interface __StoreMnemonicMessage__ {

--- a/client/bindings/nodejs/types/bridge/client.ts
+++ b/client/bindings/nodejs/types/bridge/client.ts
@@ -3,7 +3,7 @@ import type { SecretManager } from '../secretManager';
 import type { IGenerateAddressesOptions } from '../generateAddressesOptions';
 import type { IBuildBlockOptions } from '../buildBlockOptions';
 import type { BlockId } from '../blockId';
-import type { IPreparedTransactionData } from '../preparedTransactionData';
+import type { IInputSigningData, IPreparedTransactionData } from '../preparedTransactionData';
 import type {
     AliasQueryParameter,
     FoundryQueryParameter,
@@ -157,6 +157,17 @@ export interface __SignTransactionMessage__ {
         secretManager: SecretManager;
         preparedTransactionData: IPreparedTransactionData;
     };
+}
+
+export interface __SignatureUnlockMessage__ {
+    name: 'signatureUnlock';
+    data: {
+        secretManager: SecretManager;
+        inputSigningData: IInputSigningData,
+        transactionEssenceHash: Array<number>,
+        //TODO: Expose `RemainderData`.
+        remainderData: undefined
+    }
 }
 
 export interface __StoreMnemonicMessage__ {

--- a/client/bindings/nodejs/types/bridge/index.ts
+++ b/client/bindings/nodejs/types/bridge/index.ts
@@ -73,6 +73,7 @@ import type {
     __BuildFoundryOutputMessage__,
     __BuildNftOutputMessage__,
     __ClearListenersMessage__,
+    __SignatureUnlockMessage__,
 } from './client';
 
 export type __ClientMessages__ =
@@ -97,6 +98,7 @@ export type __ClientMessages__ =
     | __GetLedgerNanoStatusMessage__
     | __PrepareTransactionMessage__
     | __SignTransactionMessage__
+    | __SignatureUnlockMessage__
     | __StoreMnemonicMessage__
     | __PostBlockPayloadMessage__
     | __ParseBech32AddressMessage__

--- a/client/src/message_interface/message.rs
+++ b/client/src/message_interface/message.rs
@@ -23,11 +23,11 @@ use crate::Topic;
 use crate::{
     api::{
         ClientBlockBuilderOptions as BuildBlockOptions, GetAddressesBuilderOptions as GenerateAddressesOptions,
-        PreparedTransactionDataDto,
+        PreparedTransactionDataDto, RemainderDataDto,
     },
     node_api::indexer::query_parameters::QueryParameter,
     node_manager::node::NodeAuth,
-    secret::SecretManagerDto,
+    secret::{types::InputSigningDataDto, SecretManagerDto},
 };
 
 /// Each public client method.
@@ -170,6 +170,21 @@ pub enum Message {
         /// Prepared transaction data
         #[serde(rename = "preparedTransactionData")]
         prepared_transaction_data: PreparedTransactionDataDto,
+    },
+    /// Create a single Signature Unlock.
+    SignatureUnlock {
+        /// Secret manager
+        #[serde(rename = "secretManager")]
+        secret_manager: SecretManagerDto,
+        /// Input Signing Data
+        #[serde(rename = "inputSigningData")]
+        input_signing_data: InputSigningDataDto,
+        /// Transaction Essence Hash
+        #[serde(rename = "transactionEssenceHash")]
+        transaction_essence_hash: Vec<u8>,
+        /// Metadata for Ledger Nano signing
+        #[serde(rename = "remainderData")]
+        remainder_data: Option<RemainderDataDto>,
     },
     /// Store a mnemonic in the Stronghold vault
     #[cfg(feature = "stronghold")]

--- a/client/src/message_interface/message.rs
+++ b/client/src/message_interface/message.rs
@@ -177,8 +177,9 @@ pub enum Message {
         #[serde(rename = "secretManager")]
         secret_manager: SecretManagerDto,
         /// Input Signing Data
+        // This field is boxed to not inflate the enum's size.
         #[serde(rename = "inputSigningData")]
-        input_signing_data: InputSigningDataDto,
+        input_signing_data: Box<InputSigningDataDto>,
         /// Transaction Essence Hash
         #[serde(rename = "transactionEssenceHash")]
         transaction_essence_hash: Vec<u8>,

--- a/client/src/message_interface/message_handler.rs
+++ b/client/src/message_interface/message_handler.rs
@@ -30,7 +30,6 @@ use {
 
 #[cfg(feature = "ledger_nano")]
 use crate::secret::ledger_nano::LedgerSecretManager;
-#[cfg(feature = "stronghold")]
 use crate::secret::SecretManager;
 use crate::{
     api::{PreparedTransactionData, PreparedTransactionDataDto, RemainderData},

--- a/client/src/message_interface/message_handler.rs
+++ b/client/src/message_interface/message_handler.rs
@@ -30,12 +30,11 @@ use {
 
 #[cfg(feature = "ledger_nano")]
 use crate::secret::ledger_nano::LedgerSecretManager;
-use crate::secret::SecretManager;
 use crate::{
     api::{PreparedTransactionData, PreparedTransactionDataDto, RemainderData},
     message_interface::{message::Message, response::Response},
     request_funds_from_faucet,
-    secret::{types::InputSigningData, SecretManage},
+    secret::{types::InputSigningData, SecretManage, SecretManager},
     Client, Result,
 };
 

--- a/client/src/message_interface/response.rs
+++ b/client/src/message_interface/response.rs
@@ -24,6 +24,7 @@ use iota_types::{
             transaction::TransactionId,
         },
         protocol::dto::ProtocolParametersDto,
+        unlock::dto::UnlockDto,
         BlockDto, BlockId,
     },
 };
@@ -83,6 +84,9 @@ pub enum Response {
     /// Response for:
     /// - [`SignTransaction`](crate::message_interface::Message::SignTransaction)
     SignedTransaction(PayloadDto),
+    /// Response for:
+    /// - [`SignatureUnlock`](crate::message_interface::Message::SignatureUnlock)
+    SignatureUnlock(UnlockDto),
     /// Response for:
     /// - [`UnhealthyNodes`](crate::message_interface::Message::UnhealthyNodes)
     #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
# Description of change

To facilitate more fine-grained signing capabilities where multiple parties contribute different inputs to a transaction, I exposed the `SecretManage::signature_unlock` to the NodeJS bindings, and therefore indirectly also to Wasm.

Two potentially open questions:
- Is there a built-in replacement for `TransactionHelper.getTransactionEssenceHash` that would avoid the dependency on `@iota/iota.js`?
- I did not expose `RemainderData` for now, is that fine?

## Links to any relevant issues

n/a

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added a test in the offlineSigningExamples.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
