### PR TITLE
Fixes `GovernorAddressUnlockCondition` links

### DIFF
--- a/types/src/block/output/unlock_condition/governor_address.rs
+++ b/types/src/block/output/unlock_condition/governor_address.rs
@@ -12,16 +12,16 @@ use crate::block::address::Address;
 pub struct GovernorAddressUnlockCondition(Address);
 
 impl GovernorAddressUnlockCondition {
-    /// The [`UnlockCondition`](crate::block::output::UnlockCondition) kind of an [ GovernorAddressUnlockCondition`].
+    /// The [`UnlockCondition`](crate::block::output::UnlockCondition) kind of an [`GovernorAddressUnlockCondition`].
     pub const KIND: u8 = 5;
 
-    /// Creates a new [ GovernorAddressUnlockCondition`].
+    /// Creates a new [`GovernorAddressUnlockCondition`].
     #[inline(always)]
     pub fn new(address: Address) -> Self {
         Self(address)
     }
 
-    /// Returns the address of a [ GovernorAddressUnlockCondition`].
+    /// Returns the address of a [`GovernorAddressUnlockCondition`].
     #[inline(always)]
     pub fn address(&self) -> &Address {
         &self.0


### PR DESCRIPTION
# Description of change
The documentation for `iota-types` currently doesn't build under `cargo +nightly doc` (rustc 1.69.0-nightly 2023-02-12).  This PR fixes that.  

## Links to any relevant issues

Related to [#107995](https://github.com/rust-lang/rust/issues/107995). See [this comment](https://github.com/rust-lang/rust/issues/107995#issuecomment-1428501788)

## Type of change

- Documentation Fix

## How the change has been tested
Succeeds under `cargo +nightly doc` locally. 

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
