### PR TITLE
Adds sign_ed25519 to SecretManage

### DIFF
--- a/client/src/secret/ledger_nano.rs
+++ b/client/src/secret/ledger_nano.rs
@@ -8,6 +8,7 @@
 use std::{collections::HashMap, ops::Range};
 
 use async_trait::async_trait;
+use crypto::keys::slip10::Chain;
 use iota_ledger_nano::{
     get_app_config, get_buffer_size, get_ledger, get_opened_app, LedgerBIP32Index, Packable as LedgerNanoPackable,
     TransportTypes,
@@ -21,6 +22,7 @@ use iota_types::block::{
 };
 use packable::{unpacker::SliceUnpacker, Packable, PackableExt};
 use tokio::sync::Mutex;
+use iota_types::block::signature::Ed25519Signature;
 
 use super::{types::InputSigningData, GenerateAddressOptions, SecretManage, SecretManageExt};
 use crate::{
@@ -106,6 +108,10 @@ impl SecretManage for LedgerSecretManager {
         _metadata: &Option<RemainderData>,
     ) -> crate::Result<Unlock> {
         panic!("signature_unlock is not supported with ledger")
+    }
+
+    async fn sign_ed25519(&self, _msg: &[u8], _chain: &Chain) -> crate::Result<Ed25519Signature> {
+        panic!("sign_ed25519 is not supported with ledger")
     }
 }
 

--- a/client/src/secret/ledger_nano.rs
+++ b/client/src/secret/ledger_nano.rs
@@ -17,12 +17,11 @@ use iota_types::block::{
     address::{Address, AliasAddress, Ed25519Address, NftAddress},
     output::Output,
     payload::transaction::TransactionEssence,
-    signature::Signature,
+    signature::{Ed25519Signature, Signature},
     unlock::{AliasUnlock, NftUnlock, ReferenceUnlock, Unlock, Unlocks},
 };
 use packable::{unpacker::SliceUnpacker, Packable, PackableExt};
 use tokio::sync::Mutex;
-use iota_types::block::signature::Ed25519Signature;
 
 use super::{types::InputSigningData, GenerateAddressOptions, SecretManage, SecretManageExt};
 use crate::{

--- a/client/src/secret/mnemonic.rs
+++ b/client/src/secret/mnemonic.rs
@@ -71,20 +71,18 @@ impl SecretManage for MnemonicSecretManager {
     ) -> crate::Result<Unlock> {
         // The signature unlock block needs to sign the hash of the entire transaction essence of the
         // transaction payload
-        let chain = input.chain.clone().unwrap();
-        let ed25519_sig = self.sign_ed25519(essence_hash, &chain).await.unwrap();
+        let chain = input.chain.as_ref().unwrap();
+        let ed25519_sig = self.sign_ed25519(essence_hash, chain).await?;
 
         Ok(Unlock::Signature(SignatureUnlock::new(Signature::Ed25519(ed25519_sig))))
     }
 
     async fn sign_ed25519(&self, msg: &[u8], chain: &Chain) -> crate::Result<Ed25519Signature> {
         // Get the private and public key for this Ed25519 address
-        let private_key = self
-            .0
-            .derive(Curve::Ed25519, chain)?
-            .secret_key();
+        let private_key = self.0.derive(Curve::Ed25519, chain)?.secret_key();
         let public_key = private_key.public_key().to_bytes();
         let signature = private_key.sign(msg).to_bytes();
+
         Ok(Ed25519Signature::new(public_key, signature))
     }
 }

--- a/client/src/secret/mnemonic.rs
+++ b/client/src/secret/mnemonic.rs
@@ -81,7 +81,7 @@ impl SecretManage for MnemonicSecretManager {
         // Get the private and public key for this Ed25519 address
         let private_key = self
             .0
-            .derive(Curve::Ed25519, &chain)?
+            .derive(Curve::Ed25519, chain)?
             .secret_key();
         let public_key = private_key.public_key().to_bytes();
         let signature = private_key.sign(msg).to_bytes();

--- a/client/src/secret/mod.rs
+++ b/client/src/secret/mod.rs
@@ -27,10 +27,10 @@ use iota_types::block::{
     address::Address,
     output::Output,
     payload::transaction::TransactionEssence,
+    signature::Ed25519Signature,
     unlock::{AliasUnlock, NftUnlock, ReferenceUnlock, Unlock, Unlocks},
 };
 use zeroize::ZeroizeOnDrop;
-use iota_types::block::signature::Ed25519Signature;
 
 #[cfg(feature = "ledger_nano")]
 use self::ledger_nano::LedgerSecretManager;

--- a/client/src/secret/mod.rs
+++ b/client/src/secret/mod.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use std::{collections::HashMap, ops::Range, str::FromStr};
 
 use async_trait::async_trait;
+use crypto::keys::slip10::Chain;
 use iota_types::block::{
     address::Address,
     output::Output,
@@ -29,6 +30,7 @@ use iota_types::block::{
     unlock::{AliasUnlock, NftUnlock, ReferenceUnlock, Unlock, Unlocks},
 };
 use zeroize::ZeroizeOnDrop;
+use iota_types::block::signature::Ed25519Signature;
 
 #[cfg(feature = "ledger_nano")]
 use self::ledger_nano::LedgerSecretManager;
@@ -69,6 +71,9 @@ pub trait SecretManage: Send + Sync {
         essence_hash: &[u8; 32],
         remainder: &Option<RemainderData>,
     ) -> crate::Result<Unlock>;
+
+    /// Signs `msg` using the given `chain`.
+    async fn sign_ed25519(&self, msg: &[u8], chain: &Chain) -> crate::Result<Ed25519Signature>;
 }
 
 /// An extension to [`SecretManager`].
@@ -266,6 +271,17 @@ impl SecretManage for SecretManager {
             Self::LedgerNano(secret_manager) => secret_manager.signature_unlock(input, essence_hash, metadata).await,
             Self::Mnemonic(secret_manager) => secret_manager.signature_unlock(input, essence_hash, metadata).await,
             Self::Placeholder(secret_manager) => secret_manager.signature_unlock(input, essence_hash, metadata).await,
+        }
+    }
+
+    async fn sign_ed25519(&self, msg: &[u8], chain: &Chain) -> crate::Result<Ed25519Signature> {
+        match self {
+            #[cfg(feature = "stronghold")]
+            Self::Stronghold(secret_manager) => secret_manager.sign_ed25519(msg, chain).await,
+            #[cfg(feature = "ledger_nano")]
+            Self::LedgerNano(secret_manager) => secret_manager.sign_ed25519(msg, chain).await,
+            Self::Mnemonic(secret_manager) => secret_manager.sign_ed25519(msg, chain).await,
+            Self::Placeholder(secret_manager) => secret_manager.sign_ed25519(msg, chain).await,
         }
     }
 }

--- a/client/src/secret/placeholder.rs
+++ b/client/src/secret/placeholder.rs
@@ -9,9 +9,9 @@ use async_trait::async_trait;
 use crypto::keys::slip10::Chain;
 use iota_types::block::{
     address::Address,
+    signature::Ed25519Signature,
     unlock::{Unlock, Unlocks},
 };
-use iota_types::block::signature::Ed25519Signature;
 
 use super::{types::InputSigningData, GenerateAddressOptions, SecretManage, SecretManageExt};
 use crate::secret::{PreparedTransactionData, RemainderData};
@@ -42,10 +42,7 @@ impl SecretManage for PlaceholderSecretManager {
         return Err(crate::Error::PlaceholderSecretManager);
     }
 
-    async fn sign_ed25519(&self,
-                          _msg: &[u8],
-                          _chain: &Chain,
-    ) -> crate::Result<Ed25519Signature> {
+    async fn sign_ed25519(&self, _msg: &[u8], _chain: &Chain) -> crate::Result<Ed25519Signature> {
         return Err(crate::Error::PlaceholderSecretManager);
     }
 }

--- a/client/src/secret/placeholder.rs
+++ b/client/src/secret/placeholder.rs
@@ -6,10 +6,12 @@
 use std::ops::Range;
 
 use async_trait::async_trait;
+use crypto::keys::slip10::Chain;
 use iota_types::block::{
     address::Address,
     unlock::{Unlock, Unlocks},
 };
+use iota_types::block::signature::Ed25519Signature;
 
 use super::{types::InputSigningData, GenerateAddressOptions, SecretManage, SecretManageExt};
 use crate::secret::{PreparedTransactionData, RemainderData};
@@ -37,6 +39,13 @@ impl SecretManage for PlaceholderSecretManager {
         _essence_hash: &[u8; 32],
         _: &Option<RemainderData>,
     ) -> crate::Result<Unlock> {
+        return Err(crate::Error::PlaceholderSecretManager);
+    }
+
+    async fn sign_ed25519(&self,
+                          _msg: &[u8],
+                          _chain: &Chain,
+    ) -> crate::Result<Ed25519Signature> {
         return Err(crate::Error::PlaceholderSecretManager);
     }
 }

--- a/client/src/stronghold/secret.rs
+++ b/client/src/stronghold/secret.rs
@@ -83,8 +83,8 @@ impl SecretManage for StrongholdAdapter {
         essence_hash: &[u8; 32],
         _: &Option<RemainderData>,
     ) -> Result<Unlock> {
-        let chain = input.chain.clone().unwrap();
-        let ed25519_sig = self.sign_ed25519(essence_hash, &chain).await?;
+        let chain = input.chain.as_ref().unwrap();
+        let ed25519_sig = self.sign_ed25519(essence_hash, chain).await?;
 
         // Convert the raw bytes into [Unlock].
         let unlock = Unlock::Signature(SignatureUnlock::new(Signature::Ed25519(ed25519_sig)));
@@ -125,6 +125,7 @@ impl SecretManage for StrongholdAdapter {
         // Get the Ed25519 public key from the derived SLIP-10 private key in the vault.
         let public_key = self.ed25519_public_key(derive_location.clone()).await?;
         let signature = self.ed25519_sign(derive_location, msg).await?;
+
         Ok(Ed25519Signature::new(public_key, signature))
     }
 }

--- a/client/src/stronghold/secret.rs
+++ b/client/src/stronghold/secret.rs
@@ -83,6 +83,16 @@ impl SecretManage for StrongholdAdapter {
         essence_hash: &[u8; 32],
         _: &Option<RemainderData>,
     ) -> Result<Unlock> {
+        let chain = input.chain.clone().unwrap();
+        let ed25519_sig = self.sign_ed25519(essence_hash, &chain).await?;
+
+        // Convert the raw bytes into [Unlock].
+        let unlock = Unlock::Signature(SignatureUnlock::new(Signature::Ed25519(ed25519_sig)));
+
+        Ok(unlock)
+    }
+
+    async fn sign_ed25519(&self, msg: &[u8], chain: &Chain) -> Result<Ed25519Signature> {
         // Prevent the method from being invoked when the key has been cleared from the memory. Do note that Stronghold
         // only asks for a key for reading / writing a snapshot, so without our cached key this method is invocable, but
         // it doesn't make sense when it comes to our user (signing transactions / generating addresses without a key).
@@ -98,10 +108,7 @@ impl SecretManage for StrongholdAdapter {
 
         // Stronghold asks for an older version of [Chain], so we have to perform a conversion here.
         let chain = {
-            let raw: Vec<u32> = input
-                .chain
-                .as_ref()
-                .unwrap()
+            let raw: Vec<u32> = chain
                 .segments()
                 .iter()
                 // XXX: "ser32(i)". RTFSC: [crypto::keys::slip10::Segment::from_u32()]
@@ -117,16 +124,8 @@ impl SecretManage for StrongholdAdapter {
 
         // Get the Ed25519 public key from the derived SLIP-10 private key in the vault.
         let public_key = self.ed25519_public_key(derive_location.clone()).await?;
-
-        // Sign the essence hash with the derived SLIP-10 private key in the vault.
-        let signature = self.ed25519_sign(derive_location, essence_hash).await?;
-
-        // Convert the raw bytes into [Unlock].
-        let unlock = Unlock::Signature(SignatureUnlock::new(Signature::Ed25519(Ed25519Signature::new(
-            public_key, signature,
-        ))));
-
-        Ok(unlock)
+        let signature = self.ed25519_sign(derive_location, msg).await?;
+        Ok(Ed25519Signature::new(public_key, signature))
     }
 }
 


### PR DESCRIPTION
# Description of change

Adds `sign_ed25519(&self, msg: &[u8], chain: &Chain) -> crate::Result<Ed25519Signature>` to `SecretManage` in order for people to be able to sign arbitrary `msg` given a `chain`. One use case for this is for example signing IRC27/30 metadata for the token whitelist submission. Implementations available for stronghold and mnemonic secret managers.

## Links to any relevant issues

fixes issue #856 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Ran tests locally

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that new and existing unit tests pass locally with my changes
