### PR TITLE
Docs - Update testnet networkName and networkId in expected outputs

### DIFF
--- a/documentation/docs/libraries/java/how_to/_01_get_node_info/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/_01_get_node_info/_expected_output.md
@@ -21,7 +21,7 @@
   ],
   "protocol": {
     "version": 2,
-    "networkName": "testnet",
+    "networkName": "testnet-1",
     "bech32Hrp": "rms",
     "minPowScore": 1500.0,
     "rentStructure": {

--- a/documentation/docs/libraries/nodejs/how_to/_01_get_node_info/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/_01_get_node_info/_expected_output.md
@@ -12,7 +12,7 @@ Node info:  {
     supportedProtocolVersions: [ 2 ],
     protocol: {
       version: 2,
-      networkName: 'testnet',
+      networkName: 'testnet-1',
       bech32Hrp: 'rms',
       minPowScore: 1500,
       rentStructure: [Object],

--- a/documentation/docs/libraries/python/how_to/_01_get_node_info/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/_01_get_node_info/_expected_output.md
@@ -22,7 +22,7 @@
     ],
     'protocol': {
       'version': 2,
-      'networkName': 'testnet',
+      'networkName': 'testnet-1',
       'bech32Hrp': 'rms',
       'minPowScore': 1500.0,
       'rentStructure': {

--- a/documentation/docs/libraries/python/how_to/_10_prepare_signed_transaction/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/_10_prepare_signed_transaction/_expected_output.md
@@ -13,7 +13,7 @@
       'type': 6,
       'essence': {
         'type': 1,
-        'networkId': '8342982141227064571',
+        'networkId': '1856588631910923207',
         'inputs': [
           {
             'type': 0,

--- a/documentation/docs/libraries/python/how_to/_11_nft_output/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/_11_nft_output/_expected_output.md
@@ -13,7 +13,7 @@
       'type': 6,
       'essence': {
         'type': 1,
-        'networkId': '8342982141227064571',
+        'networkId': '1856588631910923207',
         'inputs': [
           {
             'type': 0,

--- a/documentation/docs/libraries/rust/how_to/_01_get_node_info/_expected_output.md
+++ b/documentation/docs/libraries/rust/how_to/_01_get_node_info/_expected_output.md
@@ -22,7 +22,7 @@ NodeInfoWrapper {
         ],
         protocol: ProtocolResponse {
             version: 2,
-            network_name: "testnet",
+            network_name: "testnet-1",
             bech32_hrp: "rms",
             min_pow_score: 1500.0,
             rent_structure: RentStructureResponse {

--- a/documentation/docs/libraries/rust/how_to/_09_get_block/_expected_output.md
+++ b/documentation/docs/libraries/rust/how_to/_09_get_block/_expected_output.md
@@ -15,7 +15,7 @@ Block {
                 TransactionPayload {
                     essence: Regular(
                         RegularTransactionEssence {
-                            network_id: 8342982141227064571,
+                            network_id: 1856588631910923207,
                             inputs: BoxedSlicePrefix([
                                 Utxo(
                                     UtxoInput(0xcb664cb88dcb4182df622fb82661e2d82e81ff95f3f04d5f3b071484a10fdc490100),

--- a/documentation/docs/libraries/rust/how_to/_14_mqtt/_expected_output.md
+++ b/documentation/docs/libraries/rust/how_to/_14_mqtt/_expected_output.md
@@ -9,7 +9,7 @@ Topic: blocksBlock{
   ])),
   payload: OptionalPayload(Some(Transaction(TransactionPayload{
     essence: Regular(RegularTransactionEssence{
-      network_id: 8342982141227064571,
+      network_id: 1856588631910923207,
       inputs: BoxedSlicePrefix([
         Utxo(UtxoInput(0x8e7b59a567f0f439ef7d3b01de094ce2f81aa8e68e09f26705dfd1d39ddf471b0000)),
         Utxo(UtxoInput(0x60e8afa096f3705b6f1a694f5496d51721ea4b4e9876b219dfecdf99586949fd0100)),


### PR DESCRIPTION
# Description of change

Updated testnet `networkName` to `testnet-1` and `networkId` to  `1856588631910923207` in expected outputs.

## Type of change

- Documentation Fix

## Related Issues

partially addresses https://github.com/iotaledger/guild-devx/issues/8

## How the change has been tested

Wiki was built locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have made corresponding changes to the documentation
