### PR TITLE
Allow requesting output ids without pagination

### DIFF
--- a/.changes/outputIds.md
+++ b/.changes/outputIds.md
@@ -1,0 +1,12 @@
+
+---
+"nodejs-binding": patch
+---
+
+### Added
+
+- `OutputIdsResponse`;
+
+### Changed
+
+- `Client::{aliasOutputIds, basicOutputIds, foundryOutputIds, nftOutputIds}` will not do automatic pagination if `QueryParameter::Cursor(_)` is provided and return type from `string[]` to `OutputIdsResponse`;

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -20,12 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security -->
 
 ## 2.0.1-rc.8 - 2023-XX-XX
+### Added
+
+- `QueryParameters::empty()`;
 
 ### Changed
 
 - `Client::{alias_output_ids, basic_output_ids, foundry_output_ids, nft_output_ids}` will not do automatic pagination if `QueryParameter::Cursor(_)` is provided and return `OutputIdsResponse`;
 - `Message::{AliasOutputIds, BasicOutputIds, FoundryOutputIds, NftOutputIds}` return `OutputIdsResponse`;
 - `Response::OutputIds` to `Response::OutputIdsResponse`;
+- Renamed `Client::get_output_ids_with_pagination()` to `Client::get_output_ids()`;
 
 ## 2.0.1-rc.7 - 2023-03-09
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -23,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `OutputIdsResponse::items` from `Vec<String>` to `Vec<OutputId>`;
 - `Client::{alias_output_ids, basic_output_ids, foundry_output_ids, nft_output_ids}` will not do automatic pagination if `QueryParameter::Cursor(_)` is provided and return `OutputIdsResponse`;
 - `Message::{AliasOutputIds, BasicOutputIds, FoundryOutputIds, NftOutputIds}` return `OutputIdsResponse`;
 - `Response::OutputIds` to `Response::OutputIdsResponse`;

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 2.0.1-rc.8 - 2023-XX-XX
+
+### Changed
+
+- `OutputIdsResponse::items` from `Vec<String>` to `Vec<OutputId>`;
+- `Client::{alias_output_ids, basic_output_ids, foundry_output_ids, nft_output_ids}` will not do automatic pagination if `QueryParameter::Cursor(_)` is provided and return `OutputIdsResponse`;
+- `Message::{AliasOutputIds, BasicOutputIds, FoundryOutputIds, NftOutputIds}` return `OutputIdsResponse`;
+- `Response::OutputIds` to `Response::OutputIdsResponse`;
+
 ## 2.0.1-rc.7 - 2023-03-09
 
 ### Added

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security -->
 
 ## 2.0.1-rc.8 - 2023-XX-XX
+
 ### Added
 
 - `QueryParameters::empty()`;

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -234,6 +234,10 @@ path = "examples/node_api_indexer/05_get_nft_output.rs"
 name = "node_api_indexer_get_nft_outputs"
 path = "examples/node_api_indexer/06_get_nft_outputs.rs"
 
+[[example]]
+name = "node_api_indexer_get_random_basic_outputs"
+path = "examples/node_api_indexer/07_get_random_basic_outputs.rs"
+
 #######
 
 [[example]]

--- a/client/bindings/java/CHANGELOG.md
+++ b/client/bindings/java/CHANGELOG.md
@@ -21,10 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.0.0-rc.3 - 2023-MM-DD
 
+### Added
+
+- `OutputIdsResponse`;
+
 ### Changed
 
 - Changes from the Rust library;
 - `AliasOutputBuilderParams::stateMetadata` from `byte[]` to `String`;
+- `Client::{getAliasOutputIds, getBasicOutputIds, getFoundryOutputIds, getNftOutputIds}` will not do automatic pagination if `QueryParameter::Cursor(_)` is provided and return type from `OutputId[]` to `OutputIdsResponse`;
 
 ## 1.0.0-rc.2 - 2023-02-09
 

--- a/client/bindings/java/examples/src/ExampleUtils.java
+++ b/client/bindings/java/examples/src/ExampleUtils.java
@@ -28,6 +28,6 @@ public class ExampleUtils {
     }
 
     public static OutputId setUpOutputId(Client client) throws ClientException {
-        return client.getBasicOutputIds(new NodeIndexerApi.QueryParams())[0];
+        return client.getBasicOutputIds(new NodeIndexerApi.QueryParams()).getItems()[0];
     }
 }

--- a/client/bindings/java/examples/src/GetAddressBalance.java
+++ b/client/bindings/java/examples/src/GetAddressBalance.java
@@ -31,7 +31,7 @@ public class GetAddressBalance {
                 .withParam("hasExpiration", false)
                 .withParam("hasTimelock", false)
                 .withParam("hasStorageDepositReturn", false)
-        );
+        ).getItems();
 
         // Get the outputs.
         List<Map.Entry<Output, OutputMetadata>> outputs = client.getOutputs(outputIds);

--- a/client/bindings/java/examples/src/WrongSeedConversionSecretManager.java
+++ b/client/bindings/java/examples/src/WrongSeedConversionSecretManager.java
@@ -37,7 +37,7 @@ public class WrongSeedConversionSecretManager {
         // Get the affected outputs.
         List<OutputId> affectedOutputIds = new ArrayList<>();
         for (String address : affectedAddresses) {
-            OutputId[] outputIds = client.getBasicOutputIds(new NodeIndexerApi.QueryParams().withParam("address", address));
+            OutputId[] outputIds = client.getBasicOutputIds(new NodeIndexerApi.QueryParams().withParam("address", address)).getItems();
             affectedOutputIds.addAll(List.of(outputIds));
         }
 

--- a/client/bindings/java/lib/src/main/java/org/iota/Client.java
+++ b/client/bindings/java/lib/src/main/java/org/iota/Client.java
@@ -15,6 +15,7 @@ import org.iota.types.output_builder.BasicOutputBuilderParams;
 import org.iota.types.output_builder.FoundryOutputBuilderParams;
 import org.iota.types.output_builder.NftOutputBuilderParams;
 import org.iota.types.responses.NodeInfoResponse;
+import org.iota.types.responses.OutputIdsResponse;
 import org.iota.types.responses.ProtocolParametersResponse;
 import org.iota.types.responses.TreasuryResponse;
 import org.iota.types.responses.UtxoChangesResponse;
@@ -304,10 +305,10 @@ public class Client extends NativeApi {
      * Returns the basic output ids that match the given query parameters
      *
      * @param params a QueryParams object that contains the following fields:
-     * @return An array of OutputIds.
+     * @return OutputIdsResponse.
      * @throws ClientException on error.
      */
-    public OutputId[] getBasicOutputIds(NodeIndexerApi.QueryParams params) throws ClientException {
+    public OutputIdsResponse getBasicOutputIds(NodeIndexerApi.QueryParams params) throws ClientException {
         return nodeIndexerApi.getBasicOutputIds(params);
     }
 
@@ -315,10 +316,10 @@ public class Client extends NativeApi {
      * Returns the alias output ids that match the given query parameters
      *
      * @param params a QueryParams object that contains the following fields:
-     * @return An array of OutputIds.
+     * @return OutputIdsResponse.
      * @throws ClientException on error.
      */
-    public OutputId[] getAliasOutputIds(NodeIndexerApi.QueryParams params) throws ClientException {
+    public OutputIdsResponse getAliasOutputIds(NodeIndexerApi.QueryParams params) throws ClientException {
         return nodeIndexerApi.getAliasOutputIds(params);
     }
 
@@ -326,10 +327,10 @@ public class Client extends NativeApi {
      * Returns the NFT output ids that match the given query parameters
      *
      * @param params a QueryParams object that contains the following fields:
-     * @return An array of OutputIds.
+     * @return OutputIdsResponse.
      * @throws ClientException on error.
      */
-    public OutputId[] getNftOutputIds(NodeIndexerApi.QueryParams params) throws ClientException {
+    public OutputIdsResponse getNftOutputIds(NodeIndexerApi.QueryParams params) throws ClientException {
         return nodeIndexerApi.getNftOutputIds(params);
     }
 
@@ -337,10 +338,10 @@ public class Client extends NativeApi {
      * Returns the Foundry output ids that match the given query parameters
      *
      * @param params a QueryParams object that contains the following fields:
-     * @return An array of OutputIds.
+     * @return OutputIdsResponse.
      * @throws ClientException on error.
      */
-    public OutputId[] getFoundryOutputIds(NodeIndexerApi.QueryParams params) throws ClientException {
+    public OutputIdsResponse getFoundryOutputIds(NodeIndexerApi.QueryParams params) throws ClientException {
         return nodeIndexerApi.getFoundryOutputIds(params);
     }
 
@@ -936,7 +937,7 @@ public class Client extends NativeApi {
                 String response2 = utilsApi.requestFundsFromFaucet(TESTNET_FAUCET_URL, address);
                 System.out.println(response2);
             }
-            if(getBasicOutputIds(new NodeIndexerApi.QueryParams().withParam("address", address)).length == 0) {
+            if(getBasicOutputIds(new NodeIndexerApi.QueryParams().withParam("address", address)).getItems().length == 0) {
                 try {
                     Thread.sleep(1000);
                 } catch (InterruptedException e) {
@@ -946,7 +947,7 @@ public class Client extends NativeApi {
                 return;
         }
 
-        if(getBasicOutputIds(new NodeIndexerApi.QueryParams().withParam("address", address)).length == 0)
+        if(getBasicOutputIds(new NodeIndexerApi.QueryParams().withParam("address", address)).getItems().length == 0)
             throw new NoFundsReceivedFromFaucetException();
     }
 

--- a/client/bindings/java/lib/src/main/java/org/iota/apis/NodeIndexerApi.java
+++ b/client/bindings/java/lib/src/main/java/org/iota/apis/NodeIndexerApi.java
@@ -12,7 +12,7 @@ import org.iota.types.ids.AliasId;
 import org.iota.types.ids.FoundryId;
 import org.iota.types.ids.NftId;
 import org.iota.types.ids.OutputId;
-
+import org.iota.types.responses.OutputIdsResponse;
 
 public class NodeIndexerApi {
 
@@ -22,60 +22,40 @@ public class NodeIndexerApi {
         this.nativeApi = nativeApi;
     }
 
-    public OutputId[] getBasicOutputIds(QueryParams params) throws ClientException {
+    public OutputIdsResponse getBasicOutputIds(QueryParams params) throws ClientException {
         JsonObject o = new JsonObject();
         o.add("queryParameters", params.queryParams);
 
-        JsonArray responsePayload = (JsonArray) nativeApi.sendCommand(new ClientCommand("basicOutputIds", o));
+        JsonObject responsePayload = (JsonObject) nativeApi.sendCommand(new ClientCommand("basicOutputIds", o));
 
-        OutputId[] outputIds = new OutputId[responsePayload.size()];
-        for (int i = 0; i < responsePayload.size(); i++) {
-            outputIds[i] = new OutputId(responsePayload.get(i).getAsString());
-        }
-
-        return outputIds;
+        return new OutputIdsResponse(responsePayload);
     }
 
-    public OutputId[] getAliasOutputIds(QueryParams params) throws ClientException {
+    public OutputIdsResponse getAliasOutputIds(QueryParams params) throws ClientException {
         JsonObject o = new JsonObject();
         o.add("queryParameters", params.queryParams);
 
-        JsonArray responsePayload = (JsonArray) nativeApi.sendCommand(new ClientCommand("aliasOutputIds", o));
+        JsonObject responsePayload = (JsonObject) nativeApi.sendCommand(new ClientCommand("aliasOutputIds", o));
 
-        OutputId[] outputIds = new OutputId[responsePayload.size()];
-        for (int i = 0; i < responsePayload.size(); i++) {
-            outputIds[i] = new OutputId(responsePayload.get(i).getAsString());
-        }
-
-        return outputIds;
+        return new OutputIdsResponse(responsePayload);
     }
 
-    public OutputId[] getNftOutputIds(QueryParams params) throws ClientException {
+    public OutputIdsResponse getNftOutputIds(QueryParams params) throws ClientException {
         JsonObject o = new JsonObject();
         o.add("queryParameters", params.queryParams);
 
-        JsonArray responsePayload = (JsonArray) nativeApi.sendCommand(new ClientCommand("nftOutputIds", o));
+        JsonObject responsePayload = (JsonObject) nativeApi.sendCommand(new ClientCommand("nftOutputIds", o));
 
-        OutputId[] outputIds = new OutputId[responsePayload.size()];
-        for (int i = 0; i < responsePayload.size(); i++) {
-            outputIds[i] = new OutputId(responsePayload.get(i).getAsString());
-        }
-
-        return outputIds;
+        return new OutputIdsResponse(responsePayload);
     }
 
-    public OutputId[] getFoundryOutputIds(QueryParams params) throws ClientException {
+    public OutputIdsResponse getFoundryOutputIds(QueryParams params) throws ClientException {
         JsonObject o = new JsonObject();
         o.add("queryParameters", params.queryParams);
 
-        JsonArray responsePayload = (JsonArray) nativeApi.sendCommand(new ClientCommand("foundryOutputIds", o));
+        JsonObject responsePayload = (JsonObject) nativeApi.sendCommand(new ClientCommand("foundryOutputIds", o));
 
-        OutputId[] outputIds = new OutputId[responsePayload.size()];
-        for (int i = 0; i < responsePayload.size(); i++) {
-            outputIds[i] = new OutputId(responsePayload.get(i).getAsString());
-        }
-
-        return outputIds;
+        return new OutputIdsResponse(responsePayload);
     }
 
     public OutputId getAliasOutputIdByAliasId(AliasId aliasId) throws ClientException {

--- a/client/bindings/java/lib/src/main/java/org/iota/types/responses/OutputIdsResponse.java
+++ b/client/bindings/java/lib/src/main/java/org/iota/types/responses/OutputIdsResponse.java
@@ -1,0 +1,41 @@
+// Copyright 2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package org.iota.types.responses;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.iota.types.ids.OutputId;
+
+public class OutputIdsResponse {
+
+    private int ledgerIndex;
+    private String cursor;
+    private OutputId[] items;
+
+    public OutputIdsResponse(JsonObject response) {
+        this.ledgerIndex = response.get("ledgerIndex").getAsInt();
+        if (!response.get("cursor").isJsonNull()) { 
+            this.cursor = response.get("cursor").getAsString();
+        }
+
+        JsonArray items = response.getAsJsonArray("items");
+        this.items = new OutputId[items.size()];
+        for (int i = 0; i < items.size(); i++) {
+            this.items[i] = new OutputId(items.get(i).getAsString());
+        }
+    }
+
+    public int getLedgerIndex() {
+        return ledgerIndex;
+    }
+
+    public String getCursor() {
+        return cursor;
+    }
+
+    public OutputId[] getItems() {
+        return items;
+    }
+
+}

--- a/client/bindings/java/lib/src/test/java/org/iota/ApiTest.java
+++ b/client/bindings/java/lib/src/test/java/org/iota/ApiTest.java
@@ -48,7 +48,7 @@ public abstract class ApiTest {
 
     protected OutputId setupBasicOutput(String address) throws ClientException, InitializeClientException, NoFundsReceivedFromFaucetException {
         client.requestTestFundsFromFaucet(address);
-        return client.getBasicOutputIds(new NodeIndexerApi.QueryParams().withParam("address", address))[0];
+        return client.getBasicOutputIds(new NodeIndexerApi.QueryParams().withParam("address", address)).getItems()[0];
     }
 
     protected String generateAddress(String mnemonic) throws ClientException {

--- a/client/bindings/java/lib/src/test/java/org/iota/IndexerApiTest.java
+++ b/client/bindings/java/lib/src/test/java/org/iota/IndexerApiTest.java
@@ -26,7 +26,7 @@ public class IndexerApiTest extends ApiTest {
     public void testGetBasicOutputIds() throws ClientException, NoFundsReceivedFromFaucetException {
         String address = generateAddress(client.generateMnemonic());
         client.requestTestFundsFromFaucet(address);
-        for (OutputId outputId : client.getBasicOutputIds(new NodeIndexerApi.QueryParams().withParam("address", address)))
+        for (OutputId outputId : client.getBasicOutputIds(new NodeIndexerApi.QueryParams().withParam("address", address)).getItems())
             System.out.println(outputId);
     }
 
@@ -51,7 +51,7 @@ public class IndexerApiTest extends ApiTest {
         Map.Entry<BlockId, Block> entry = client.buildAndPostBlock(s, new BuildBlockOptions().withOutputs(new Output[] { aliasOutput }));
         client.retryUntilIncluded(entry.getKey(), 2, 15);
 
-        for (OutputId outputId : client.getAliasOutputIds(new NodeIndexerApi.QueryParams().withParam("governor", address)))
+        for (OutputId outputId : client.getAliasOutputIds(new NodeIndexerApi.QueryParams().withParam("governor", address)).getItems())
             System.out.println(outputId);
     }
 
@@ -75,7 +75,7 @@ public class IndexerApiTest extends ApiTest {
         Map.Entry<BlockId, Block> entry = client.buildAndPostBlock(s, new BuildBlockOptions().withOutputs(new Output[] { aliasOutput }));
         client.retryUntilIncluded(entry.getKey(), 2, 15);
 
-        for (OutputId outputId : client.getNftOutputIds(new NodeIndexerApi.QueryParams().withParam("address", address)))
+        for (OutputId outputId : client.getNftOutputIds(new NodeIndexerApi.QueryParams().withParam("address", address)).getItems())
             System.out.println(outputId);
     }
 
@@ -130,7 +130,7 @@ public class IndexerApiTest extends ApiTest {
 
         client.retryUntilIncluded(entry.getKey(), 2, 15);
 
-        for (OutputId outputId : client.getFoundryOutputIds(new NodeIndexerApi.QueryParams().withParam("aliasAddress", client.aliasIdToBech32(aliasId, client.getBech32Hrp()))))
+        for (OutputId outputId : client.getFoundryOutputIds(new NodeIndexerApi.QueryParams().withParam("aliasAddress", client.aliasIdToBech32(aliasId, client.getBech32Hrp()))).getItems())
             System.out.println(outputId);
     }
 
@@ -138,7 +138,7 @@ public class IndexerApiTest extends ApiTest {
     @Disabled
     public void testGetAliasOutputIdByAliasId() throws ClientException {
         OutputId outputId = null;
-        for (OutputId id : client.getAliasOutputIds(new NodeIndexerApi.QueryParams())) {
+        for (OutputId id : client.getAliasOutputIds(new NodeIndexerApi.QueryParams()).getItems()) {
             if (client.getOutput(id).getKey().toJson().get("aliasId").getAsString().equals("0x0000000000000000000000000000000000000000000000000000000000000000")) {
                 outputId = id;
                 break;
@@ -151,7 +151,7 @@ public class IndexerApiTest extends ApiTest {
     @Test
     @Disabled
     public void testGetFoundryOutputIdByFoundryId() throws ClientException {
-        OutputId foundryOutputId = client.getFoundryOutputIds(new NodeIndexerApi.QueryParams())[0];
+        OutputId foundryOutputId = client.getFoundryOutputIds(new NodeIndexerApi.QueryParams()).getItems()[0];
         Output foundryOutput = client.getOutput(foundryOutputId).getKey();
         String aliasId = foundryOutput.toJson().get("unlockConditions").getAsJsonArray().get(0).getAsJsonObject().get("address").getAsJsonObject().get("aliasId").getAsString();
         int serialNumber = foundryOutput.toJson().get("serialNumber").getAsInt();
@@ -164,7 +164,7 @@ public class IndexerApiTest extends ApiTest {
     @Disabled
     public void testGetNftOutputIdByNftId() throws ClientException {
         OutputId nftOutputId = null;
-        for (OutputId id : client.getNftOutputIds(new NodeIndexerApi.QueryParams())) {
+        for (OutputId id : client.getNftOutputIds(new NodeIndexerApi.QueryParams()).getItems()) {
             if (client.getOutput(id).getKey().toJson().get("nftId").getAsString().equals("0x0000000000000000000000000000000000000000000000000000000000000000")) {
                 nftOutputId = id;
                 break;

--- a/client/bindings/nodejs/examples/03_get_address_outputs.ts
+++ b/client/bindings/nodejs/examples/03_get_address_outputs.ts
@@ -21,7 +21,7 @@ async function run() {
 
     try {
         // Get output ids of basic outputs that can be controlled by this address without further unlock constraints
-        const outputIds = await client.basicOutputIds([
+        const outputIdsResponse = await client.basicOutputIds([
             {
                 address:
                     'rms1qpllaj0pyveqfkwxmnngz2c488hfdtmfrj3wfkgxtk4gtyrax0jaxzt70zy',
@@ -30,9 +30,9 @@ async function run() {
             { hasTimelock: false },
             { hasStorageDepositReturn: false },
         ]);
-        console.log('Output ids: ', outputIds, '\n');
+        console.log('Output ids: ', outputIdsResponse, '\n');
 
-        const addressOutputs = await client.getOutputs(outputIds);
+        const addressOutputs = await client.getOutputs(outputIdsResponse.items);
         console.log('Address outputs: ', addressOutputs);
     } catch (error) {
         console.error('Error: ', error);

--- a/client/bindings/nodejs/examples/05_get_address_balance.ts
+++ b/client/bindings/nodejs/examples/05_get_address_balance.ts
@@ -38,7 +38,7 @@ async function run() {
         });
 
         // Get output ids of basic outputs that can be controlled by this address without further unlock constraints
-        const outputIds = await client.basicOutputIds([
+        const outputIdsResponse = await client.basicOutputIds([
             { address: addresses[0] },
             { hasExpiration: false },
             { hasTimelock: false },
@@ -46,7 +46,7 @@ async function run() {
         ]);
 
         // Get outputs by their IDs
-        const addressOutputs = await client.getOutputs(outputIds);
+        const addressOutputs = await client.getOutputs(outputIdsResponse.items);
 
         // Calculate the total amount and native tokens
         let totalAmount = 0;

--- a/client/bindings/nodejs/lib/Client.ts
+++ b/client/bindings/nodejs/lib/Client.ts
@@ -21,6 +21,7 @@ import type {
     AliasQueryParameter,
     LedgerNanoStatus,
     IInputSigningData,
+    OutputIdsResponse,
 } from '../types';
 import type {
     IUTXOInput,
@@ -76,7 +77,9 @@ export class Client {
     }
 
     /** Fetch basic output IDs based on query parameters */
-    async basicOutputIds(queryParameters: QueryParameter[]): Promise<string[]> {
+    async basicOutputIds(
+        queryParameters: QueryParameter[],
+    ): Promise<OutputIdsResponse> {
         const response = await this.messageHandler.sendMessage({
             name: 'basicOutputIds',
             data: {
@@ -827,7 +830,7 @@ export class Client {
      */
     async aliasOutputIds(
         queryParameters: AliasQueryParameter[],
-    ): Promise<string[]> {
+    ): Promise<OutputIdsResponse> {
         const response = await this.messageHandler.sendMessage({
             name: 'aliasOutputIds',
             data: {
@@ -857,7 +860,7 @@ export class Client {
      */
     async nftOutputIds(
         queryParameters: NftQueryParameter[],
-    ): Promise<string[]> {
+    ): Promise<OutputIdsResponse> {
         const response = await this.messageHandler.sendMessage({
             name: 'nftOutputIds',
             data: {
@@ -887,7 +890,7 @@ export class Client {
      */
     async foundryOutputIds(
         queryParameters: FoundryQueryParameter[],
-    ): Promise<string[]> {
+    ): Promise<OutputIdsResponse> {
         const response = await this.messageHandler.sendMessage({
             name: 'foundryOutputIds',
             data: {

--- a/client/bindings/nodejs/test/client/examples.spec.ts
+++ b/client/bindings/nodejs/test/client/examples.spec.ts
@@ -51,7 +51,7 @@ describe.skip('Main examples', () => {
     });
 
     it('gets address outputs', async () => {
-        const outputIds = await client.basicOutputIds([
+        const outputIdsResponse = await client.basicOutputIds([
             {
                 address:
                     'rms1qpllaj0pyveqfkwxmnngz2c488hfdtmfrj3wfkgxtk4gtyrax0jaxzt70zy',
@@ -61,9 +61,9 @@ describe.skip('Main examples', () => {
             { hasStorageDepositReturn: false },
         ]);
 
-        outputIds.forEach((id) => expect(id).toBeValidOutputId());
+        outputIdsResponse.items.forEach((id) => expect(id).toBeValidOutputId());
 
-        const addressOutputs = await client.getOutputs(outputIds);
+        const addressOutputs = await client.getOutputs(outputIdsResponse.items);
 
         expect(addressOutputs).toBeDefined();
 
@@ -92,16 +92,16 @@ describe.skip('Main examples', () => {
         expect(addresses[0]).toBeValidAddress();
 
         // Get output ids of outputs that can be controlled by this address without further unlock constraints
-        const outputIds = await client.basicOutputIds([
+        const outputIdsResponse = await client.basicOutputIds([
             { address: addresses[0] },
             { hasExpiration: false },
             { hasTimelock: false },
             { hasStorageDepositReturn: false },
         ]);
-        outputIds.forEach((id) => expect(id).toBeValidOutputId());
+        outputIdsResponse.items.forEach((id) => expect(id).toBeValidOutputId());
 
         // Get outputs by their IDs
-        const addressOutputs = await client.getOutputs(outputIds);
+        const addressOutputs = await client.getOutputs(outputIdsResponse.items);
         expect(addressOutputs).toBeDefined();
     });
 

--- a/client/bindings/nodejs/types/index.ts
+++ b/client/bindings/nodejs/types/index.ts
@@ -7,6 +7,7 @@ export * from './generateAddressesOptions';
 export * from './ledgerNanoStatus';
 export * from './network';
 export * from './nodeInfo';
+export * from './outputIdsResponse';
 export * from './outputBuilderOptions';
 export * from './preparedTransactionData';
 export * from './queryParameters';

--- a/client/bindings/nodejs/types/outputIdsResponse.ts
+++ b/client/bindings/nodejs/types/outputIdsResponse.ts
@@ -1,0 +1,11 @@
+// Copyright 2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * OutputIdsResponse.
+ */
+export interface OutputIdsResponse {
+    ledgerIndex: number;
+    cursor?: string;
+    items: string[];
+}

--- a/client/bindings/python/examples/03_get_address_outputs.py
+++ b/client/bindings/python/examples/03_get_address_outputs.py
@@ -4,12 +4,12 @@ from iota_client import IotaClient
 client = IotaClient({'nodes': ['https://api.testnet.shimmer.network']})
 
 # Get output ids of basic outputs that can be controlled by this address without further unlock constraints
-output_ids = client.basic_output_ids([{"address": 'rms1qpllaj0pyveqfkwxmnngz2c488hfdtmfrj3wfkgxtk4gtyrax0jaxzt70zy'},
+output_ids_response = client.basic_output_ids([{"address": 'rms1qpllaj0pyveqfkwxmnngz2c488hfdtmfrj3wfkgxtk4gtyrax0jaxzt70zy'},
                                       {"hasExpiration": False},
                                       {"hasTimelock": False},
                                       {"hasStorageDepositReturn": False}, ])
-print(f'{output_ids}')
+print(f'{output_ids_response}')
 
 # Get the outputs by their id
-outputs = client.get_outputs(output_ids)
+outputs = client.get_outputs(output_ids_response['items'])
 print(f'{outputs}')

--- a/client/bindings/python/examples/05_get_address_balance.py
+++ b/client/bindings/python/examples/05_get_address_balance.py
@@ -6,14 +6,14 @@ client = IotaClient({'nodes': ['https://api.testnet.shimmer.network']})
 address = 'rms1qpllaj0pyveqfkwxmnngz2c488hfdtmfrj3wfkgxtk4gtyrax0jaxzt70zy'
 
 # Get output ids of basic outputs that can be controlled by this address without further unlock constraints
-output_ids = client.basic_output_ids([{"address": address},
+output_ids_response = client.basic_output_ids([{"address": address},
                                       {"hasExpiration": False},
                                       {"hasTimelock": False},
                                       {"hasStorageDepositReturn": False}, ])
-print(f'{output_ids}')
+print(f'{output_ids_response}')
 
 # Get the outputs by their id
-outputs = client.get_outputs(output_ids)
+outputs = client.get_outputs(output_ids_response['items'])
 print(f'{outputs}')
 
 

--- a/client/bindings/python/iota_client/_node_indexer_api.py
+++ b/client/bindings/python/iota_client/_node_indexer_api.py
@@ -7,14 +7,14 @@ class NodeIndexerAPI(BaseAPI):
         """Fetch basic output IDs.
         """
         return self.send_message('basicOutputIds', {
-            'queryParameters': query_parameters
+            'queryParameters': query_parameters,
         })
 
     def alias_output_ids(self, query_parameters):
         """Fetch alias output IDs.
         """
         return self.send_message('aliasOutputIds', {
-            'queryParameters': query_parameters
+            'queryParameters': query_parameters,
         })
 
     def alias_output_id(self, alias_id):
@@ -28,7 +28,7 @@ class NodeIndexerAPI(BaseAPI):
         """Fetch NFT output IDs.
         """
         return self.send_message('nftOutputIds', {
-            'queryParameters': query_parameters
+            'queryParameters': query_parameters,
         })
 
     def nft_output_id(self, nft_id):
@@ -42,7 +42,7 @@ class NodeIndexerAPI(BaseAPI):
         """Fetch foundry Output IDs.
         """
         return self.send_message('foundryOutputIds', {
-            'queryParameters': query_parameters
+            'queryParameters': query_parameters,
         })
 
     def foundry_output_id(self, foundry_id):

--- a/client/bindings/wasm/CHANGELOG.md
+++ b/client/bindings/wasm/CHANGELOG.md
@@ -21,12 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.0.0-rc.3 - 2023-MM-DD
 
+### Added
+
+- `OutputIdsResponse`;
+
 ### Changed
 
 - Changes from the Rust library;
 - Merged `IAuth::{username, password}` into `IAuth::basicAuthNamePwd`;
 - `Burn` fields are now optional;
 - `Burn::nativeTokens` is now an array;
+- `Client::{aliasOutputIds, basicOutputIds, foundryOutputIds, nftOutputIds}` will not do automatic pagination if `QueryParameter::Cursor(_)` is provided and return type from `string[]` to `OutputIdsResponse`;
 
 ### Removed
 

--- a/client/examples/02_get_address_balance.rs
+++ b/client/examples/02_get_address_balance.rs
@@ -39,15 +39,12 @@ async fn main() -> Result<()> {
 
     // Get output ids of outputs that can be controlled by this address without further unlock constraints
     let output_ids_response = client
-        .basic_output_ids(
-            vec![
-                QueryParameter::Address(addresses[0].clone()),
-                QueryParameter::HasExpiration(false),
-                QueryParameter::HasTimelock(false),
-                QueryParameter::HasStorageDepositReturn(false),
-            ],
-            true,
-        )
+        .basic_output_ids(vec![
+            QueryParameter::Address(addresses[0].clone()),
+            QueryParameter::HasExpiration(false),
+            QueryParameter::HasTimelock(false),
+            QueryParameter::HasStorageDepositReturn(false),
+        ])
         .await?;
 
     // Get the outputs by their id

--- a/client/examples/02_get_address_balance.rs
+++ b/client/examples/02_get_address_balance.rs
@@ -38,17 +38,20 @@ async fn main() -> Result<()> {
         .await?;
 
     // Get output ids of outputs that can be controlled by this address without further unlock constraints
-    let output_ids = client
-        .basic_output_ids(vec![
-            QueryParameter::Address(addresses[0].clone()),
-            QueryParameter::HasExpiration(false),
-            QueryParameter::HasTimelock(false),
-            QueryParameter::HasStorageDepositReturn(false),
-        ])
+    let output_ids_response = client
+        .basic_output_ids(
+            vec![
+                QueryParameter::Address(addresses[0].clone()),
+                QueryParameter::HasExpiration(false),
+                QueryParameter::HasTimelock(false),
+                QueryParameter::HasStorageDepositReturn(false),
+            ],
+            true,
+        )
         .await?;
 
     // Get the outputs by their id
-    let outputs_responses = client.get_outputs(output_ids).await?;
+    let outputs_responses = client.get_outputs(output_ids_response.items).await?;
 
     // Calculate the total amount and native tokens
     let mut total_amount = 0;

--- a/client/examples/block/custom_inputs.rs
+++ b/client/examples/block/custom_inputs.rs
@@ -33,15 +33,15 @@ async fn main() -> Result<()> {
     println!("{}", request_funds_from_faucet(&faucet_url, &addresses[0]).await?);
     tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
-    let output_ids = client
-        .basic_output_ids(vec![QueryParameter::Address(addresses[0].clone())])
+    let output_ids_response = client
+        .basic_output_ids(vec![QueryParameter::Address(addresses[0].clone())], true)
         .await?;
-    println!("{output_ids:?}");
+    println!("{output_ids_response:?}");
 
     let block = client
         .block()
         .with_secret_manager(&secret_manager)
-        .with_input(UtxoInput::from(output_ids[0]))?
+        .with_input(UtxoInput::from(output_ids_response.items[0]))?
         //.with_input_range(20..25)
         .with_output(
             "atoi1qzt0nhsf38nh6rs4p6zs5knqp6psgha9wsv74uajqgjmwc75ugupx3y7x0r",

--- a/client/examples/block/custom_inputs.rs
+++ b/client/examples/block/custom_inputs.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
     tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
     let output_ids_response = client
-        .basic_output_ids(vec![QueryParameter::Address(addresses[0].clone())], true)
+        .basic_output_ids(vec![QueryParameter::Address(addresses[0].clone())])
         .await?;
     println!("{output_ids_response:?}");
 

--- a/client/examples/custom_remainder_address.rs
+++ b/client/examples/custom_remainder_address.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
     let output_ids_response = client
-        .basic_output_ids(vec![QueryParameter::Address(sender_address.clone())], true)
+        .basic_output_ids(vec![QueryParameter::Address(sender_address.clone())])
         .await?;
     println!("{output_ids_response:?}");
 

--- a/client/examples/custom_remainder_address.rs
+++ b/client/examples/custom_remainder_address.rs
@@ -42,10 +42,10 @@ async fn main() -> Result<()> {
     );
     tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
-    let output_ids = client
-        .basic_output_ids(vec![QueryParameter::Address(sender_address.clone())])
+    let output_ids_response = client
+        .basic_output_ids(vec![QueryParameter::Address(sender_address.clone())], true)
         .await?;
-    println!("{output_ids:?}");
+    println!("{output_ids_response:?}");
 
     let block = client
         .block()

--- a/client/examples/node_api_indexer/00_get_basic_outputs.rs
+++ b/client/examples/node_api_indexer/00_get_basic_outputs.rs
@@ -28,15 +28,12 @@ async fn main() -> Result<()> {
 
     // Get output IDs of basic outputs that can be controlled by this address without further unlock constraints.
     let output_ids_response = client
-        .basic_output_ids(
-            vec![
-                QueryParameter::Address(address),
-                QueryParameter::HasExpiration(false),
-                QueryParameter::HasTimelock(false),
-                QueryParameter::HasStorageDepositReturn(false),
-            ],
-            true,
-        )
+        .basic_output_ids(vec![
+            QueryParameter::Address(address),
+            QueryParameter::HasExpiration(false),
+            QueryParameter::HasTimelock(false),
+            QueryParameter::HasStorageDepositReturn(false),
+        ])
         .await?;
 
     println!("Address output IDs {output_ids_response:#?}");

--- a/client/examples/node_api_indexer/00_get_basic_outputs.rs
+++ b/client/examples/node_api_indexer/00_get_basic_outputs.rs
@@ -27,19 +27,22 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|| String::from("rms1qrrdjmdkadtcnuw0ue5n9g4fmkelrj3dl26eyeshkha3w3uu0wheu5z5qqz"));
 
     // Get output IDs of basic outputs that can be controlled by this address without further unlock constraints.
-    let output_ids = client
-        .basic_output_ids(vec![
-            QueryParameter::Address(address),
-            QueryParameter::HasExpiration(false),
-            QueryParameter::HasTimelock(false),
-            QueryParameter::HasStorageDepositReturn(false),
-        ])
+    let output_ids_response = client
+        .basic_output_ids(
+            vec![
+                QueryParameter::Address(address),
+                QueryParameter::HasExpiration(false),
+                QueryParameter::HasTimelock(false),
+                QueryParameter::HasStorageDepositReturn(false),
+            ],
+            true,
+        )
         .await?;
 
-    println!("Address output IDs {output_ids:#?}");
+    println!("Address output IDs {output_ids_response:#?}");
 
     // Get the outputs by their IDs.
-    let outputs_responses = client.get_outputs(output_ids).await?;
+    let outputs_responses = client.get_outputs(output_ids_response.items).await?;
 
     println!("Basic outputs: {outputs_responses:#?}");
 

--- a/client/examples/node_api_indexer/02_get_alias_outputs.rs
+++ b/client/examples/node_api_indexer/02_get_alias_outputs.rs
@@ -27,17 +27,20 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|| String::from("rms1qrrdjmdkadtcnuw0ue5n9g4fmkelrj3dl26eyeshkha3w3uu0wheu5z5qqz"));
 
     // Get output IDs of alias outputs that can be controlled by this address.
-    let output_ids = client
-        .alias_output_ids(vec![
-            QueryParameter::Governor(address.clone()),
-            QueryParameter::StateController(address),
-        ])
+    let output_ids_response = client
+        .alias_output_ids(
+            vec![
+                QueryParameter::Governor(address.clone()),
+                QueryParameter::StateController(address),
+            ],
+            true,
+        )
         .await?;
 
-    println!("Address output IDs {output_ids:#?}");
+    println!("Address output IDs {output_ids_response:#?}");
 
     // Get the outputs by their IDs.
-    let outputs_responses = client.get_outputs(output_ids).await?;
+    let outputs_responses = client.get_outputs(output_ids_response.items).await?;
 
     println!("Alias outputs: {outputs_responses:#?}");
 

--- a/client/examples/node_api_indexer/02_get_alias_outputs.rs
+++ b/client/examples/node_api_indexer/02_get_alias_outputs.rs
@@ -28,13 +28,10 @@ async fn main() -> Result<()> {
 
     // Get output IDs of alias outputs that can be controlled by this address.
     let output_ids_response = client
-        .alias_output_ids(
-            vec![
-                QueryParameter::Governor(address.clone()),
-                QueryParameter::StateController(address),
-            ],
-            true,
-        )
+        .alias_output_ids(vec![
+            QueryParameter::Governor(address.clone()),
+            QueryParameter::StateController(address),
+        ])
         .await?;
 
     println!("Address output IDs {output_ids_response:#?}");

--- a/client/examples/node_api_indexer/04_get_foundry_outputs.rs
+++ b/client/examples/node_api_indexer/04_get_foundry_outputs.rs
@@ -27,14 +27,14 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|| String::from("rms1prd5mdmy84mgzwwklzkrl8ym02p2y3dkr8af7lqclnv0pan7274uyjrmwx5"));
 
     // Get output IDs of foundry outputs that can be controlled by this address.
-    let output_ids = client
-        .foundry_output_ids(vec![QueryParameter::AliasAddress(alias_address)])
+    let output_ids_response = client
+        .foundry_output_ids(vec![QueryParameter::AliasAddress(alias_address)], true)
         .await?;
 
-    println!("Address output IDs {output_ids:#?}");
+    println!("Address output IDs {output_ids_response:#?}");
 
     // Get the outputs by their IDs.
-    let outputs_responses = client.get_outputs(output_ids).await?;
+    let outputs_responses = client.get_outputs(output_ids_response.items).await?;
 
     println!("Foundry outputs: {outputs_responses:#?}");
 

--- a/client/examples/node_api_indexer/06_get_nft_outputs.rs
+++ b/client/examples/node_api_indexer/06_get_nft_outputs.rs
@@ -27,19 +27,22 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|| String::from("rms1qrrdjmdkadtcnuw0ue5n9g4fmkelrj3dl26eyeshkha3w3uu0wheu5z5qqz"));
 
     // Get output IDs of NFT outputs that can be controlled by this address without further unlock constraints.
-    let output_ids = client
-        .nft_output_ids(vec![
-            QueryParameter::Address(address),
-            QueryParameter::HasExpiration(false),
-            QueryParameter::HasTimelock(false),
-            QueryParameter::HasStorageDepositReturn(false),
-        ])
+    let output_ids_response = client
+        .nft_output_ids(
+            vec![
+                QueryParameter::Address(address),
+                QueryParameter::HasExpiration(false),
+                QueryParameter::HasTimelock(false),
+                QueryParameter::HasStorageDepositReturn(false),
+            ],
+            true,
+        )
         .await?;
 
-    println!("Address output IDs {output_ids:#?}");
+    println!("Address output IDs {output_ids_response:#?}");
 
     // Get the outputs by their IDs.
-    let outputs_responses = client.get_outputs(output_ids).await?;
+    let outputs_responses = client.get_outputs(output_ids_response.items).await?;
 
     println!("NFT outputs: {outputs_responses:#?}");
 

--- a/client/examples/node_api_indexer/06_get_nft_outputs.rs
+++ b/client/examples/node_api_indexer/06_get_nft_outputs.rs
@@ -28,15 +28,12 @@ async fn main() -> Result<()> {
 
     // Get output IDs of NFT outputs that can be controlled by this address without further unlock constraints.
     let output_ids_response = client
-        .nft_output_ids(
-            vec![
-                QueryParameter::Address(address),
-                QueryParameter::HasExpiration(false),
-                QueryParameter::HasTimelock(false),
-                QueryParameter::HasStorageDepositReturn(false),
-            ],
-            true,
-        )
+        .nft_output_ids(vec![
+            QueryParameter::Address(address),
+            QueryParameter::HasExpiration(false),
+            QueryParameter::HasTimelock(false),
+            QueryParameter::HasStorageDepositReturn(false),
+        ])
         .await?;
 
     println!("Address output IDs {output_ids_response:#?}");

--- a/client/examples/node_api_indexer/07_get_random_basic_outputs.rs
+++ b/client/examples/node_api_indexer/07_get_random_basic_outputs.rs
@@ -1,8 +1,8 @@
-// Copyright 2022 IOTA Stiftung
+// Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Calls `GET api/indexer/v1/outputs/foundry`.
-//! Run: `cargo run --example node_api_indexer_get_foundry_outputs --release -- [NODE URL] [ADDRESS]`.
+//! Calls `GET api/indexer/v1/outputs/basic`.
+//! Run: `cargo run --example node_api_indexer_get_random_basic_outputs --release -- [NODE URL]`.
 
 use iota_client::{node_api::indexer::query_parameters::QueryParameter, Client, Result};
 
@@ -21,14 +21,9 @@ async fn main() -> Result<()> {
         .with_node(&node_url)?
         .finish()?;
 
-    // Take the address from command line argument or use a default one.
-    let alias_address = std::env::args()
-        .nth(2)
-        .unwrap_or_else(|| String::from("rms1prd5mdmy84mgzwwklzkrl8ym02p2y3dkr8af7lqclnv0pan7274uyjrmwx5"));
-
-    // Get output IDs of foundry outputs that can be controlled by this address.
+    // Get a single page with random output IDs by providing only `QueryParameter::Cursor(_)`.
     let output_ids_response = client
-        .foundry_output_ids(vec![QueryParameter::AliasAddress(alias_address)])
+        .basic_output_ids(vec![QueryParameter::Cursor(String::new())])
         .await?;
 
     println!("Address output IDs {output_ids_response:#?}");
@@ -36,7 +31,7 @@ async fn main() -> Result<()> {
     // Get the outputs by their IDs.
     let outputs_responses = client.get_outputs(output_ids_response.items).await?;
 
-    println!("Foundry outputs: {outputs_responses:#?}");
+    println!("Basic outputs: {outputs_responses:#?}");
 
     Ok(())
 }

--- a/client/examples/output/all.rs
+++ b/client/examples/output/all.rs
@@ -201,19 +201,22 @@ async fn main() -> Result<()> {
     ];
 
     // get additional input for the new basic output without extra unlock conditions
-    let output_ids = client
-        .basic_output_ids(vec![
-            QueryParameter::Address(address.to_bech32(client.get_bech32_hrp().await?)),
-            QueryParameter::HasStorageDepositReturn(false),
-            QueryParameter::HasTimelock(false),
-            QueryParameter::HasExpiration(false),
-        ])
+    let output_ids_response = client
+        .basic_output_ids(
+            vec![
+                QueryParameter::Address(address.to_bech32(client.get_bech32_hrp().await?)),
+                QueryParameter::HasStorageDepositReturn(false),
+                QueryParameter::HasTimelock(false),
+                QueryParameter::HasExpiration(false),
+            ],
+            true,
+        )
         .await?;
 
     let block = client
         .block()
         .with_secret_manager(&secret_manager)
-        .with_input(output_ids[0].into())?
+        .with_input(output_ids_response.items[0].into())?
         .with_input(nft_output_id.into())?
         .with_input(alias_output_id.into())?
         .with_input(foundry_output_id.into())?

--- a/client/examples/output/all.rs
+++ b/client/examples/output/all.rs
@@ -202,15 +202,12 @@ async fn main() -> Result<()> {
 
     // get additional input for the new basic output without extra unlock conditions
     let output_ids_response = client
-        .basic_output_ids(
-            vec![
-                QueryParameter::Address(address.to_bech32(client.get_bech32_hrp().await?)),
-                QueryParameter::HasStorageDepositReturn(false),
-                QueryParameter::HasTimelock(false),
-                QueryParameter::HasExpiration(false),
-            ],
-            true,
-        )
+        .basic_output_ids(vec![
+            QueryParameter::Address(address.to_bech32(client.get_bech32_hrp().await?)),
+            QueryParameter::HasStorageDepositReturn(false),
+            QueryParameter::HasTimelock(false),
+            QueryParameter::HasExpiration(false),
+        ])
         .await?;
 
     let block = client

--- a/client/examples/output/foundry.rs
+++ b/client/examples/output/foundry.rs
@@ -200,16 +200,19 @@ async fn main() -> Result<()> {
     ];
 
     // get additional input for the new basic output
-    let output_ids = client
-        .basic_output_ids(vec![QueryParameter::Address(
-            address.to_bech32(client.get_bech32_hrp().await?),
-        )])
+    let output_ids_response = client
+        .basic_output_ids(
+            vec![QueryParameter::Address(
+                address.to_bech32(client.get_bech32_hrp().await?),
+            )],
+            true,
+        )
         .await?;
 
     let block = client
         .block()
         .with_secret_manager(&secret_manager)
-        .with_input(output_ids[0].into())?
+        .with_input(output_ids_response.items[0].into())?
         .with_input(alias_output_id.into())?
         .with_input(foundry_output_id.into())?
         .with_outputs(outputs)?

--- a/client/examples/output/foundry.rs
+++ b/client/examples/output/foundry.rs
@@ -201,12 +201,9 @@ async fn main() -> Result<()> {
 
     // get additional input for the new basic output
     let output_ids_response = client
-        .basic_output_ids(
-            vec![QueryParameter::Address(
-                address.to_bech32(client.get_bech32_hrp().await?),
-            )],
-            true,
-        )
+        .basic_output_ids(vec![QueryParameter::Address(
+            address.to_bech32(client.get_bech32_hrp().await?),
+        )])
         .await?;
 
     let block = client

--- a/client/examples/output/nft.rs
+++ b/client/examples/output/nft.rs
@@ -84,17 +84,17 @@ async fn main() -> Result<()> {
     );
     tokio::time::sleep(std::time::Duration::from_secs(20)).await;
 
-    let output_ids = client
-        .basic_output_ids(vec![QueryParameter::Address(bech32_nft_address)])
+    let output_ids_response = client
+        .basic_output_ids(vec![QueryParameter::Address(bech32_nft_address)], true)
         .await?;
-    let output_response = client.get_output(&output_ids[0]).await?;
+    let output_response = client.get_output(&output_ids_response.items[0]).await?;
     let output = Output::try_from_dto(&output_response.output, token_supply)?;
 
     let block = client
         .block()
         .with_secret_manager(&secret_manager)
         .with_input(nft_output_id.into())?
-        .with_input(output_ids[0].into())?
+        .with_input(output_ids_response.items[0].into())?
         .with_outputs(vec![
             NftOutputBuilder::new_with_amount(1_000_000 + output.amount(), nft_id)?
                 .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(address)))

--- a/client/examples/output/nft.rs
+++ b/client/examples/output/nft.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
     tokio::time::sleep(std::time::Duration::from_secs(20)).await;
 
     let output_ids_response = client
-        .basic_output_ids(vec![QueryParameter::Address(bech32_nft_address)], true)
+        .basic_output_ids(vec![QueryParameter::Address(bech32_nft_address)])
         .await?;
     let output_response = client.get_output(&output_ids_response.items[0]).await?;
     let output = Output::try_from_dto(&output_response.output, token_supply)?;

--- a/client/examples/participation.rs
+++ b/client/examples/participation.rs
@@ -61,16 +61,19 @@ async fn main() -> Result<()> {
     }
 
     // Get outputs for address and request if they're participating
-    let basic_output_ids = client
-        .basic_output_ids(vec![
-            QueryParameter::Address(bech32_address),
-            QueryParameter::HasExpiration(false),
-            QueryParameter::HasTimelock(false),
-            QueryParameter::HasStorageDepositReturn(false),
-        ])
+    let output_ids_response = client
+        .basic_output_ids(
+            vec![
+                QueryParameter::Address(bech32_address),
+                QueryParameter::HasExpiration(false),
+                QueryParameter::HasTimelock(false),
+                QueryParameter::HasStorageDepositReturn(false),
+            ],
+            true,
+        )
         .await?;
 
-    for output_id in basic_output_ids {
+    for output_id in output_ids_response.items {
         if let Ok(output_status) = client.output_status(&output_id).await {
             println!("{output_status:#?}");
         }

--- a/client/examples/participation.rs
+++ b/client/examples/participation.rs
@@ -62,15 +62,12 @@ async fn main() -> Result<()> {
 
     // Get outputs for address and request if they're participating
     let output_ids_response = client
-        .basic_output_ids(
-            vec![
-                QueryParameter::Address(bech32_address),
-                QueryParameter::HasExpiration(false),
-                QueryParameter::HasTimelock(false),
-                QueryParameter::HasStorageDepositReturn(false),
-            ],
-            true,
-        )
+        .basic_output_ids(vec![
+            QueryParameter::Address(bech32_address),
+            QueryParameter::HasExpiration(false),
+            QueryParameter::HasTimelock(false),
+            QueryParameter::HasStorageDepositReturn(false),
+        ])
         .await?;
 
     for output_id in output_ids_response.items {

--- a/client/examples/quorum.rs
+++ b/client/examples/quorum.rs
@@ -34,15 +34,18 @@ async fn main() -> Result<()> {
         .await?;
 
     // Get output ids of outputs that can be controlled by this address without further unlock constraints
-    let output_ids = client
-        .basic_output_ids(vec![
-            QueryParameter::Address(addresses[0].clone()),
-            QueryParameter::HasExpiration(false),
-            QueryParameter::HasTimelock(false),
-            QueryParameter::HasStorageDepositReturn(false),
-        ])
+    let output_ids_response = client
+        .basic_output_ids(
+            vec![
+                QueryParameter::Address(addresses[0].clone()),
+                QueryParameter::HasExpiration(false),
+                QueryParameter::HasTimelock(false),
+                QueryParameter::HasStorageDepositReturn(false),
+            ],
+            true,
+        )
         .await?;
-    println!("Address outputs: {output_ids:?}");
+    println!("Address outputs: {output_ids_response:?}");
 
     Ok(())
 }

--- a/client/examples/quorum.rs
+++ b/client/examples/quorum.rs
@@ -35,15 +35,12 @@ async fn main() -> Result<()> {
 
     // Get output ids of outputs that can be controlled by this address without further unlock constraints
     let output_ids_response = client
-        .basic_output_ids(
-            vec![
-                QueryParameter::Address(addresses[0].clone()),
-                QueryParameter::HasExpiration(false),
-                QueryParameter::HasTimelock(false),
-                QueryParameter::HasStorageDepositReturn(false),
-            ],
-            true,
-        )
+        .basic_output_ids(vec![
+            QueryParameter::Address(addresses[0].clone()),
+            QueryParameter::HasExpiration(false),
+            QueryParameter::HasTimelock(false),
+            QueryParameter::HasStorageDepositReturn(false),
+        ])
         .await?;
     println!("Address outputs: {output_ids_response:?}");
 

--- a/client/examples/send_all.rs
+++ b/client/examples/send_all.rs
@@ -36,24 +36,27 @@ async fn main() -> Result<()> {
     let token_supply = client.get_token_supply().await?;
 
     // Get output ids of outputs that can be controlled by this address without further unlock constraints
-    let output_ids = client
-        .basic_output_ids(vec![
-            QueryParameter::Address(
-                client
-                    .get_addresses(&secret_manager_1)
-                    .with_range(0..1)
-                    .finish()
-                    .await?[0]
-                    .clone(),
-            ),
-            QueryParameter::HasExpiration(false),
-            QueryParameter::HasTimelock(false),
-            QueryParameter::HasStorageDepositReturn(false),
-        ])
+    let output_ids_response = client
+        .basic_output_ids(
+            vec![
+                QueryParameter::Address(
+                    client
+                        .get_addresses(&secret_manager_1)
+                        .with_range(0..1)
+                        .finish()
+                        .await?[0]
+                        .clone(),
+                ),
+                QueryParameter::HasExpiration(false),
+                QueryParameter::HasTimelock(false),
+                QueryParameter::HasStorageDepositReturn(false),
+            ],
+            true,
+        )
         .await?;
 
     // Get the outputs by their id
-    let outputs_responses = client.get_outputs(output_ids).await?;
+    let outputs_responses = client.get_outputs(output_ids_response.items).await?;
 
     // Calculate the total amount and native tokens
     let mut total_amount = 0;

--- a/client/examples/send_all.rs
+++ b/client/examples/send_all.rs
@@ -37,22 +37,19 @@ async fn main() -> Result<()> {
 
     // Get output ids of outputs that can be controlled by this address without further unlock constraints
     let output_ids_response = client
-        .basic_output_ids(
-            vec![
-                QueryParameter::Address(
-                    client
-                        .get_addresses(&secret_manager_1)
-                        .with_range(0..1)
-                        .finish()
-                        .await?[0]
-                        .clone(),
-                ),
-                QueryParameter::HasExpiration(false),
-                QueryParameter::HasTimelock(false),
-                QueryParameter::HasStorageDepositReturn(false),
-            ],
-            true,
-        )
+        .basic_output_ids(vec![
+            QueryParameter::Address(
+                client
+                    .get_addresses(&secret_manager_1)
+                    .with_range(0..1)
+                    .finish()
+                    .await?[0]
+                    .clone(),
+            ),
+            QueryParameter::HasExpiration(false),
+            QueryParameter::HasTimelock(false),
+            QueryParameter::HasStorageDepositReturn(false),
+        ])
         .await?;
 
     // Get the outputs by their id

--- a/client/src/api/block_builder/input_selection/automatic.rs
+++ b/client/src/api/block_builder/input_selection/automatic.rs
@@ -35,13 +35,10 @@ impl<'a> ClientBlockBuilder<'a> {
         // First request to get all basic outputs that can directly be unlocked by the address.
         output_ids.extend(
             self.client
-                .basic_output_ids(
-                    vec![
-                        QueryParameter::Address(address.clone()),
-                        QueryParameter::HasStorageDepositReturn(false),
-                    ],
-                    true,
-                )
+                .basic_output_ids(vec![
+                    QueryParameter::Address(address.clone()),
+                    QueryParameter::HasStorageDepositReturn(false),
+                ])
                 .await?
                 .items,
         );
@@ -49,16 +46,13 @@ impl<'a> ClientBlockBuilder<'a> {
         // Second request to get all basic outputs that can be unlocked by the address through the expiration condition.
         output_ids.extend(
             self.client
-                .basic_output_ids(
-                    vec![
-                        QueryParameter::ExpirationReturnAddress(address),
-                        QueryParameter::HasExpiration(true),
-                        QueryParameter::HasStorageDepositReturn(false),
-                        // Ignore outputs that aren't expired yet
-                        QueryParameter::ExpiresBefore(unix_timestamp_now()),
-                    ],
-                    true,
-                )
+                .basic_output_ids(vec![
+                    QueryParameter::ExpirationReturnAddress(address),
+                    QueryParameter::HasExpiration(true),
+                    QueryParameter::HasStorageDepositReturn(false),
+                    // Ignore outputs that aren't expired yet
+                    QueryParameter::ExpiresBefore(unix_timestamp_now()),
+                ])
                 .await?
                 .items,
         );

--- a/client/src/api/block_builder/input_selection/automatic.rs
+++ b/client/src/api/block_builder/input_selection/automatic.rs
@@ -35,24 +35,32 @@ impl<'a> ClientBlockBuilder<'a> {
         // First request to get all basic outputs that can directly be unlocked by the address.
         output_ids.extend(
             self.client
-                .basic_output_ids(vec![
-                    QueryParameter::Address(address.clone()),
-                    QueryParameter::HasStorageDepositReturn(false),
-                ])
-                .await?,
+                .basic_output_ids(
+                    vec![
+                        QueryParameter::Address(address.clone()),
+                        QueryParameter::HasStorageDepositReturn(false),
+                    ],
+                    true,
+                )
+                .await?
+                .items,
         );
 
         // Second request to get all basic outputs that can be unlocked by the address through the expiration condition.
         output_ids.extend(
             self.client
-                .basic_output_ids(vec![
-                    QueryParameter::ExpirationReturnAddress(address),
-                    QueryParameter::HasExpiration(true),
-                    QueryParameter::HasStorageDepositReturn(false),
-                    // Ignore outputs that aren't expired yet
-                    QueryParameter::ExpiresBefore(unix_timestamp_now()),
-                ])
-                .await?,
+                .basic_output_ids(
+                    vec![
+                        QueryParameter::ExpirationReturnAddress(address),
+                        QueryParameter::HasExpiration(true),
+                        QueryParameter::HasStorageDepositReturn(false),
+                        // Ignore outputs that aren't expired yet
+                        QueryParameter::ExpiresBefore(unix_timestamp_now()),
+                    ],
+                    true,
+                )
+                .await?
+                .items,
         );
 
         self.client.get_outputs(output_ids).await

--- a/client/src/api/consolidation.rs
+++ b/client/src/api/consolidation.rs
@@ -48,16 +48,19 @@ impl Client {
                 let index = index + offset;
 
                 // Get output ids of outputs that can be controlled by this address without further unlock constraints
-                let basic_output_ids = self
-                    .basic_output_ids(vec![
-                        QueryParameter::Address(address.to_string()),
-                        QueryParameter::HasExpiration(false),
-                        QueryParameter::HasTimelock(false),
-                        QueryParameter::HasStorageDepositReturn(false),
-                    ])
+                let output_ids_response = self
+                    .basic_output_ids(
+                        vec![
+                            QueryParameter::Address(address.to_string()),
+                            QueryParameter::HasExpiration(false),
+                            QueryParameter::HasTimelock(false),
+                            QueryParameter::HasStorageDepositReturn(false),
+                        ],
+                        true,
+                    )
                     .await?;
 
-                let basic_outputs_responses = self.get_outputs(basic_output_ids).await?;
+                let basic_outputs_responses = self.get_outputs(output_ids_response.items).await?;
 
                 if !basic_outputs_responses.is_empty() {
                     // If we reach the same index again

--- a/client/src/api/consolidation.rs
+++ b/client/src/api/consolidation.rs
@@ -49,15 +49,12 @@ impl Client {
 
                 // Get output ids of outputs that can be controlled by this address without further unlock constraints
                 let output_ids_response = self
-                    .basic_output_ids(
-                        vec![
-                            QueryParameter::Address(address.to_string()),
-                            QueryParameter::HasExpiration(false),
-                            QueryParameter::HasTimelock(false),
-                            QueryParameter::HasStorageDepositReturn(false),
-                        ],
-                        true,
-                    )
+                    .basic_output_ids(vec![
+                        QueryParameter::Address(address.to_string()),
+                        QueryParameter::HasExpiration(false),
+                        QueryParameter::HasTimelock(false),
+                        QueryParameter::HasStorageDepositReturn(false),
+                    ])
                     .await?;
 
                 let basic_outputs_responses = self.get_outputs(output_ids_response.items).await?;

--- a/client/src/api/high_level.rs
+++ b/client/src/api/high_level.rs
@@ -191,16 +191,19 @@ impl Client {
         let mut available_outputs = Vec::new();
 
         for address in addresses {
-            let basic_output_ids = self
-                .basic_output_ids(vec![
-                    QueryParameter::Address(address.to_string()),
-                    QueryParameter::HasExpiration(false),
-                    QueryParameter::HasTimelock(false),
-                    QueryParameter::HasStorageDepositReturn(false),
-                ])
+            let output_ids_response = self
+                .basic_output_ids(
+                    vec![
+                        QueryParameter::Address(address.to_string()),
+                        QueryParameter::HasExpiration(false),
+                        QueryParameter::HasTimelock(false),
+                        QueryParameter::HasStorageDepositReturn(false),
+                    ],
+                    true,
+                )
                 .await?;
 
-            available_outputs.extend(self.get_outputs(basic_output_ids).await?);
+            available_outputs.extend(self.get_outputs(output_ids_response.items).await?);
         }
 
         let mut basic_outputs = Vec::new();
@@ -258,15 +261,18 @@ impl Client {
         for address in addresses {
             // Get output ids of outputs that can be controlled by this address without further unlock constraints
             let basic_output_ids = self
-                .basic_output_ids(vec![
-                    QueryParameter::Address(address.to_string()),
-                    QueryParameter::HasExpiration(false),
-                    QueryParameter::HasTimelock(false),
-                    QueryParameter::HasStorageDepositReturn(false),
-                ])
+                .basic_output_ids(
+                    vec![
+                        QueryParameter::Address(address.to_string()),
+                        QueryParameter::HasExpiration(false),
+                        QueryParameter::HasTimelock(false),
+                        QueryParameter::HasStorageDepositReturn(false),
+                    ],
+                    true,
+                )
                 .await?;
 
-            output_responses.extend(self.get_outputs(basic_output_ids).await?);
+            output_responses.extend(self.get_outputs(basic_output_ids.items).await?);
         }
 
         Ok(output_responses.clone())

--- a/client/src/api/high_level.rs
+++ b/client/src/api/high_level.rs
@@ -192,15 +192,12 @@ impl Client {
 
         for address in addresses {
             let output_ids_response = self
-                .basic_output_ids(
-                    vec![
-                        QueryParameter::Address(address.to_string()),
-                        QueryParameter::HasExpiration(false),
-                        QueryParameter::HasTimelock(false),
-                        QueryParameter::HasStorageDepositReturn(false),
-                    ],
-                    true,
-                )
+                .basic_output_ids(vec![
+                    QueryParameter::Address(address.to_string()),
+                    QueryParameter::HasExpiration(false),
+                    QueryParameter::HasTimelock(false),
+                    QueryParameter::HasStorageDepositReturn(false),
+                ])
                 .await?;
 
             available_outputs.extend(self.get_outputs(output_ids_response.items).await?);
@@ -261,15 +258,12 @@ impl Client {
         for address in addresses {
             // Get output ids of outputs that can be controlled by this address without further unlock constraints
             let basic_output_ids = self
-                .basic_output_ids(
-                    vec![
-                        QueryParameter::Address(address.to_string()),
-                        QueryParameter::HasExpiration(false),
-                        QueryParameter::HasTimelock(false),
-                        QueryParameter::HasStorageDepositReturn(false),
-                    ],
-                    true,
-                )
+                .basic_output_ids(vec![
+                    QueryParameter::Address(address.to_string()),
+                    QueryParameter::HasExpiration(false),
+                    QueryParameter::HasTimelock(false),
+                    QueryParameter::HasStorageDepositReturn(false),
+                ])
                 .await?;
 
             output_responses.extend(self.get_outputs(basic_output_ids.items).await?);

--- a/client/src/api/high_level.rs
+++ b/client/src/api/high_level.rs
@@ -257,7 +257,7 @@ impl Client {
         // then collect the `UtxoInput` in the HashSet.
         for address in addresses {
             // Get output ids of outputs that can be controlled by this address without further unlock constraints
-            let basic_output_ids = self
+            let output_ids_response = self
                 .basic_output_ids(vec![
                     QueryParameter::Address(address.to_string()),
                     QueryParameter::HasExpiration(false),
@@ -266,7 +266,7 @@ impl Client {
                 ])
                 .await?;
 
-            output_responses.extend(self.get_outputs(basic_output_ids.items).await?);
+            output_responses.extend(self.get_outputs(output_ids_response.items).await?);
         }
 
         Ok(output_responses.clone())

--- a/client/src/message_interface/message.rs
+++ b/client/src/message_interface/message.rs
@@ -331,12 +331,18 @@ pub enum Message {
         /// Query parameters for output requests
         #[serde(rename = "queryParameters")]
         query_parameters: Vec<QueryParameter>,
+        /// Whether automatic pagination should be used
+        #[serde(rename = "automaticPagination", default = "default_true")]
+        automatic_pagination: bool,
     },
     /// Fetch alias output IDs
     AliasOutputIds {
         /// Query parameters for output requests
         #[serde(rename = "queryParameters")]
         query_parameters: Vec<QueryParameter>,
+        /// Whether automatic pagination should be used
+        #[serde(rename = "automaticPagination", default = "default_true")]
+        automatic_pagination: bool,
     },
     /// Fetch alias output ID
     AliasOutputId {
@@ -349,6 +355,9 @@ pub enum Message {
         /// Query parameters for output requests
         #[serde(rename = "queryParameters")]
         query_parameters: Vec<QueryParameter>,
+        /// Whether automatic pagination should be used
+        #[serde(rename = "automaticPagination", default = "default_true")]
+        automatic_pagination: bool,
     },
     /// Fetch NFT output ID
     NftOutputId {
@@ -361,6 +370,9 @@ pub enum Message {
         /// Query parameters for output requests
         #[serde(rename = "queryParameters")]
         query_parameters: Vec<QueryParameter>,
+        /// Whether automatic pagination should be used
+        #[serde(rename = "automaticPagination", default = "default_true")]
+        automatic_pagination: bool,
     },
     /// Fetch foundry Output ID
     FoundryOutputId {
@@ -564,4 +576,8 @@ pub enum Message {
         /// The address for request funds
         address: String,
     },
+}
+
+fn default_true() -> bool {
+    true
 }

--- a/client/src/message_interface/message.rs
+++ b/client/src/message_interface/message.rs
@@ -331,18 +331,12 @@ pub enum Message {
         /// Query parameters for output requests
         #[serde(rename = "queryParameters")]
         query_parameters: Vec<QueryParameter>,
-        /// Whether automatic pagination should be used
-        #[serde(rename = "automaticPagination", default = "default_true")]
-        automatic_pagination: bool,
     },
     /// Fetch alias output IDs
     AliasOutputIds {
         /// Query parameters for output requests
         #[serde(rename = "queryParameters")]
         query_parameters: Vec<QueryParameter>,
-        /// Whether automatic pagination should be used
-        #[serde(rename = "automaticPagination", default = "default_true")]
-        automatic_pagination: bool,
     },
     /// Fetch alias output ID
     AliasOutputId {
@@ -355,9 +349,6 @@ pub enum Message {
         /// Query parameters for output requests
         #[serde(rename = "queryParameters")]
         query_parameters: Vec<QueryParameter>,
-        /// Whether automatic pagination should be used
-        #[serde(rename = "automaticPagination", default = "default_true")]
-        automatic_pagination: bool,
     },
     /// Fetch NFT output ID
     NftOutputId {
@@ -370,9 +361,6 @@ pub enum Message {
         /// Query parameters for output requests
         #[serde(rename = "queryParameters")]
         query_parameters: Vec<QueryParameter>,
-        /// Whether automatic pagination should be used
-        #[serde(rename = "automaticPagination", default = "default_true")]
-        automatic_pagination: bool,
     },
     /// Fetch foundry Output ID
     FoundryOutputId {
@@ -576,8 +564,4 @@ pub enum Message {
         /// The address for request funds
         address: String,
     },
-}
-
-fn default_true() -> bool {
-    true
 }

--- a/client/src/message_interface/message_handler.rs
+++ b/client/src/message_interface/message_handler.rs
@@ -537,19 +537,39 @@ impl ClientMessageHandler {
             Message::GetIncludedBlockMetadata { transaction_id } => Ok(Response::BlockMetadata(
                 self.client.get_included_block_metadata(&transaction_id).await?,
             )),
-            Message::BasicOutputIds { query_parameters } => Ok(Response::OutputIds(
-                self.client.basic_output_ids(query_parameters).await?,
+            Message::BasicOutputIds {
+                query_parameters,
+                automatic_pagination,
+            } => Ok(Response::OutputIdsResponse(
+                self.client
+                    .basic_output_ids(query_parameters, automatic_pagination)
+                    .await?,
             )),
-            Message::AliasOutputIds { query_parameters } => Ok(Response::OutputIds(
-                self.client.alias_output_ids(query_parameters).await?,
+            Message::AliasOutputIds {
+                query_parameters,
+                automatic_pagination,
+            } => Ok(Response::OutputIdsResponse(
+                self.client
+                    .alias_output_ids(query_parameters, automatic_pagination)
+                    .await?,
             )),
             Message::AliasOutputId { alias_id } => Ok(Response::OutputId(self.client.alias_output_id(alias_id).await?)),
-            Message::NftOutputIds { query_parameters } => {
-                Ok(Response::OutputIds(self.client.nft_output_ids(query_parameters).await?))
-            }
+            Message::NftOutputIds {
+                query_parameters,
+                automatic_pagination,
+            } => Ok(Response::OutputIdsResponse(
+                self.client
+                    .nft_output_ids(query_parameters, automatic_pagination)
+                    .await?,
+            )),
             Message::NftOutputId { nft_id } => Ok(Response::OutputId(self.client.nft_output_id(nft_id).await?)),
-            Message::FoundryOutputIds { query_parameters } => Ok(Response::OutputIds(
-                self.client.foundry_output_ids(query_parameters).await?,
+            Message::FoundryOutputIds {
+                query_parameters,
+                automatic_pagination,
+            } => Ok(Response::OutputIdsResponse(
+                self.client
+                    .foundry_output_ids(query_parameters, automatic_pagination)
+                    .await?,
             )),
             Message::FoundryOutputId { foundry_id } => {
                 Ok(Response::OutputId(self.client.foundry_output_id(foundry_id).await?))

--- a/client/src/message_interface/message_handler.rs
+++ b/client/src/message_interface/message_handler.rs
@@ -537,39 +537,19 @@ impl ClientMessageHandler {
             Message::GetIncludedBlockMetadata { transaction_id } => Ok(Response::BlockMetadata(
                 self.client.get_included_block_metadata(&transaction_id).await?,
             )),
-            Message::BasicOutputIds {
-                query_parameters,
-                automatic_pagination,
-            } => Ok(Response::OutputIdsResponse(
-                self.client
-                    .basic_output_ids(query_parameters, automatic_pagination)
-                    .await?,
+            Message::BasicOutputIds { query_parameters } => Ok(Response::OutputIdsResponse(
+                self.client.basic_output_ids(query_parameters).await?,
             )),
-            Message::AliasOutputIds {
-                query_parameters,
-                automatic_pagination,
-            } => Ok(Response::OutputIdsResponse(
-                self.client
-                    .alias_output_ids(query_parameters, automatic_pagination)
-                    .await?,
+            Message::AliasOutputIds { query_parameters } => Ok(Response::OutputIdsResponse(
+                self.client.alias_output_ids(query_parameters).await?,
             )),
             Message::AliasOutputId { alias_id } => Ok(Response::OutputId(self.client.alias_output_id(alias_id).await?)),
-            Message::NftOutputIds {
-                query_parameters,
-                automatic_pagination,
-            } => Ok(Response::OutputIdsResponse(
-                self.client
-                    .nft_output_ids(query_parameters, automatic_pagination)
-                    .await?,
+            Message::NftOutputIds { query_parameters } => Ok(Response::OutputIdsResponse(
+                self.client.nft_output_ids(query_parameters).await?,
             )),
             Message::NftOutputId { nft_id } => Ok(Response::OutputId(self.client.nft_output_id(nft_id).await?)),
-            Message::FoundryOutputIds {
-                query_parameters,
-                automatic_pagination,
-            } => Ok(Response::OutputIdsResponse(
-                self.client
-                    .foundry_output_ids(query_parameters, automatic_pagination)
-                    .await?,
+            Message::FoundryOutputIds { query_parameters } => Ok(Response::OutputIdsResponse(
+                self.client.foundry_output_ids(query_parameters).await?,
             )),
             Message::FoundryOutputId { foundry_id } => {
                 Ok(Response::OutputId(self.client.foundry_output_id(foundry_id).await?))

--- a/client/src/message_interface/response.rs
+++ b/client/src/message_interface/response.rs
@@ -5,12 +5,15 @@
 use std::collections::HashSet;
 
 use iota_types::{
-    api::core::{
-        dto::{PeerDto, ReceiptDto},
-        response::{
-            BlockMetadataResponse, InfoResponse as NodeInfo, OutputWithMetadataResponse, TreasuryResponse,
-            UtxoChangesResponse as MilestoneUTXOChanges,
+    api::{
+        core::{
+            dto::{PeerDto, ReceiptDto},
+            response::{
+                BlockMetadataResponse, InfoResponse as NodeInfo, OutputWithMetadataResponse, TreasuryResponse,
+                UtxoChangesResponse as MilestoneUTXOChanges,
+            },
         },
+        plugins::indexer::OutputIdsResponse,
     },
     block::{
         address::dto::AddressDto,
@@ -162,7 +165,7 @@ pub enum Response {
     /// - [`AliasOutputIds`](crate::message_interface::Message::AliasOutputIds)
     /// - [`NftOutputIds`](crate::message_interface::Message::NftOutputIds)
     /// - [`FoundryOutputIds`](crate::message_interface::Message::FoundryOutputIds)
-    OutputIds(Vec<OutputId>),
+    OutputIdsResponse(OutputIdsResponse),
     /// Response for:
     /// - [`FindBlocks`](crate::message_interface::Message::FindBlocks)
     Blocks(Vec<BlockDto>),

--- a/client/src/node_api/indexer/mod.rs
+++ b/client/src/node_api/indexer/mod.rs
@@ -18,11 +18,10 @@ impl Client {
     pub async fn get_output_ids_with_pagination(
         &self,
         route: &str,
-        query_parameters: Vec<QueryParameter>,
+        mut query_parameters: QueryParameters,
         need_quorum: bool,
         prefer_permanode: bool,
     ) -> Result<Vec<OutputId>> {
-        let mut query_parameters = QueryParameters::new(query_parameters);
         let mut output_ids = Vec::new();
 
         while let Some(cursor) = {

--- a/client/src/node_api/indexer/mod.rs
+++ b/client/src/node_api/indexer/mod.rs
@@ -6,26 +6,29 @@
 pub mod query_parameters;
 pub mod routes;
 
-use std::str::FromStr;
-
-use iota_types::{api::plugins::indexer::OutputIdsResponse, block::output::OutputId};
+use iota_types::api::plugins::indexer::OutputIdsResponse;
 
 pub(crate) use self::query_parameters::{QueryParameter, QueryParameters};
 use crate::{Client, Result};
 
 impl Client {
     /// Get all output ids for a provided URL route and query parameters.
-    pub async fn get_output_ids_with_pagination(
+    pub async fn get_output_ids(
         &self,
         route: &str,
         mut query_parameters: QueryParameters,
         need_quorum: bool,
         prefer_permanode: bool,
-    ) -> Result<Vec<OutputId>> {
-        let mut output_ids = Vec::new();
+        automatic_pagination: bool,
+    ) -> Result<OutputIdsResponse> {
+        let mut merged_output_ids_response = OutputIdsResponse {
+            ledger_index: 0,
+            cursor: None,
+            items: Vec::new(),
+        };
 
         while let Some(cursor) = {
-            let outputs_response = self
+            let output_ids_response = self
                 .node_manager
                 .get_request::<OutputIdsResponse>(
                     route,
@@ -36,15 +39,19 @@ impl Client {
                 )
                 .await?;
 
-            for output_id in outputs_response.items {
-                output_ids.push(OutputId::from_str(&output_id)?);
+            if !automatic_pagination {
+                return Ok(output_ids_response);
             }
 
-            outputs_response.cursor
+            merged_output_ids_response.ledger_index = output_ids_response.ledger_index;
+            merged_output_ids_response.cursor = output_ids_response.cursor;
+            merged_output_ids_response.items.extend(output_ids_response.items);
+
+            &merged_output_ids_response.cursor
         } {
-            query_parameters.replace(QueryParameter::Cursor(cursor));
+            query_parameters.replace(QueryParameter::Cursor(cursor.to_string()));
         }
 
-        Ok(output_ids)
+        Ok(merged_output_ids_response)
     }
 }

--- a/client/src/node_api/indexer/query_parameters.rs
+++ b/client/src/node_api/indexer/query_parameters.rs
@@ -34,6 +34,11 @@ impl QueryParameters {
         }
     }
 
+    /// Returns true if the slice contains an element with the given kind.
+    pub(crate) fn contains(&self, kind: u8) -> bool {
+        self.0.iter().any(|q| q.kind() == kind)
+    }
+
     /// Converts parameters to a single String.
     pub fn to_query_string(&self) -> Option<String> {
         if self.0.is_empty() {
@@ -134,7 +139,7 @@ impl QueryParameter {
         }
     }
 
-    fn kind(&self) -> u8 {
+    pub(crate) fn kind(&self) -> u8 {
         match self {
             Self::Address(_) => 0,
             Self::AliasAddress(_) => 1,
@@ -293,5 +298,9 @@ mod tests {
         // since address2 and address3 are of the same enum variant, we should only have one
         query_parameters.replace(address3);
         assert!(query_parameters.0.len() == 2);
+        // Contains address query parameter
+        assert!(query_parameters.contains(QueryParameter::Address(String::new()).kind()));
+        // Contains no cursor query parameter
+        assert!(!query_parameters.contains(QueryParameter::Cursor(String::new()).kind()));
     }
 }

--- a/client/src/node_api/indexer/query_parameters.rs
+++ b/client/src/node_api/indexer/query_parameters.rs
@@ -23,6 +23,11 @@ impl QueryParameters {
         Self(query_parameters)
     }
 
+    /// Creates new empty QueryParameters.
+    pub fn empty() -> Self {
+        Self(Vec::new())
+    }
+
     /// Replaces or inserts an enum variant in the QueryParameters.
     pub fn replace(&mut self, query_parameter: QueryParameter) {
         match self

--- a/client/src/node_api/indexer/query_parameters.rs
+++ b/client/src/node_api/indexer/query_parameters.rs
@@ -5,6 +5,8 @@
 
 use std::fmt;
 
+use crate::{Error, Result};
+
 // https://github.com/gohornet/hornet/blob/bb1271be9f3a638f6acdeb6de74eab64515f27f1/plugins/indexer/v1/routes.go#L54
 
 /// Query parameters for output_id requests.
@@ -165,6 +167,109 @@ impl fmt::Display for QueryParameter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_query_string())
     }
+}
+
+macro_rules! verify_query_parameters {
+    ($query_parameters:ident, $first:path $(, $rest:path)*) => {
+        if let Some(qp) = $query_parameters.iter().find(|qp| {
+            !matches!(qp, $first(_) $(| $rest(_))*)
+        }) {
+            Err(Error::UnsupportedQueryParameter(qp.clone()))
+        } else {
+            Ok(())
+        }
+    };
+}
+
+pub(crate) fn verify_query_parameters_basic_outputs(query_parameters: Vec<QueryParameter>) -> Result<QueryParameters> {
+    verify_query_parameters!(
+        query_parameters,
+        QueryParameter::Address,
+        QueryParameter::HasNativeTokens,
+        QueryParameter::MinNativeTokenCount,
+        QueryParameter::MaxNativeTokenCount,
+        QueryParameter::HasStorageDepositReturn,
+        QueryParameter::StorageDepositReturnAddress,
+        QueryParameter::HasTimelock,
+        QueryParameter::TimelockedBefore,
+        QueryParameter::TimelockedAfter,
+        QueryParameter::HasExpiration,
+        QueryParameter::ExpiresBefore,
+        QueryParameter::ExpiresAfter,
+        QueryParameter::ExpirationReturnAddress,
+        QueryParameter::Sender,
+        QueryParameter::Tag,
+        QueryParameter::CreatedBefore,
+        QueryParameter::CreatedAfter,
+        QueryParameter::PageSize,
+        QueryParameter::Cursor
+    )?;
+
+    Ok(QueryParameters::new(query_parameters))
+}
+
+pub(crate) fn verify_query_parameters_alias_outputs(query_parameters: Vec<QueryParameter>) -> Result<QueryParameters> {
+    verify_query_parameters!(
+        query_parameters,
+        QueryParameter::StateController,
+        QueryParameter::Governor,
+        QueryParameter::Issuer,
+        QueryParameter::Sender,
+        QueryParameter::HasNativeTokens,
+        QueryParameter::MinNativeTokenCount,
+        QueryParameter::MaxNativeTokenCount,
+        QueryParameter::CreatedBefore,
+        QueryParameter::CreatedAfter,
+        QueryParameter::PageSize,
+        QueryParameter::Cursor
+    )?;
+
+    Ok(QueryParameters::new(query_parameters))
+}
+
+pub(crate) fn verify_query_parameters_foundry_outputs(
+    query_parameters: Vec<QueryParameter>,
+) -> Result<QueryParameters> {
+    verify_query_parameters!(
+        query_parameters,
+        QueryParameter::AliasAddress,
+        QueryParameter::HasNativeTokens,
+        QueryParameter::MinNativeTokenCount,
+        QueryParameter::MaxNativeTokenCount,
+        QueryParameter::CreatedBefore,
+        QueryParameter::CreatedAfter,
+        QueryParameter::PageSize,
+        QueryParameter::Cursor
+    )?;
+
+    Ok(QueryParameters::new(query_parameters))
+}
+
+pub(crate) fn verify_query_parameters_nft_outputs(query_parameters: Vec<QueryParameter>) -> Result<QueryParameters> {
+    verify_query_parameters!(
+        query_parameters,
+        QueryParameter::Address,
+        QueryParameter::HasNativeTokens,
+        QueryParameter::MinNativeTokenCount,
+        QueryParameter::MaxNativeTokenCount,
+        QueryParameter::HasStorageDepositReturn,
+        QueryParameter::StorageDepositReturnAddress,
+        QueryParameter::HasTimelock,
+        QueryParameter::TimelockedBefore,
+        QueryParameter::TimelockedAfter,
+        QueryParameter::HasExpiration,
+        QueryParameter::ExpiresBefore,
+        QueryParameter::ExpiresAfter,
+        QueryParameter::ExpirationReturnAddress,
+        QueryParameter::Sender,
+        QueryParameter::Tag,
+        QueryParameter::CreatedBefore,
+        QueryParameter::CreatedAfter,
+        QueryParameter::PageSize,
+        QueryParameter::Cursor
+    )?;
+
+    Ok(QueryParameters::new(query_parameters))
 }
 
 #[cfg(test)]

--- a/client/src/node_api/indexer/routes.rs
+++ b/client/src/node_api/indexer/routes.rs
@@ -27,43 +27,17 @@ impl Client {
     /// "hasExpiration", "expiresBefore", "expiresAfter", "hasTimelock", "timelockedBefore",
     /// "timelockedAfter", "sender", "tag", "createdBefore" and "createdAfter". Returns an empty Vec if no results
     /// are found. api/indexer/v1/outputs/basic
-    pub async fn basic_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
-        let route = "api/indexer/v1/outputs/basic";
-
-        let query_parameters = verify_query_parameters_basic_outputs(query_parameters)?;
-
-        self.get_output_ids_with_pagination(route, query_parameters, true, false)
-            .await
-    }
-
-    /// Get basic outputs filtered by the given parameters.
-    /// GET with query parameter returns all outputIDs that fit these filter criteria.
-    /// Query parameters: "address", "hasStorageDepositReturn", "storageDepositReturnAddress",
-    /// "hasExpiration", "expiresBefore", "expiresAfter", "hasTimelock", "timelockedBefore",
-    /// "timelockedAfter", "sender", "tag", "createdBefore" and "createdAfter". Returns an empty Vec if no results
-    /// are found. api/indexer/v1/outputs/basic
-    pub async fn basic_output_ids_no_pagination(
+    pub async fn basic_output_ids(
         &self,
         query_parameters: Vec<QueryParameter>,
+        automatic_pagination: bool,
     ) -> Result<OutputIdsResponse> {
         let route = "api/indexer/v1/outputs/basic";
 
         let query_parameters = verify_query_parameters_basic_outputs(query_parameters)?;
 
-        self.node_manager
-            .get_request::<OutputIdsResponse>(
-                route,
-                query_parameters.to_query_string().as_deref(),
-                self.get_timeout(),
-                true,
-                false,
-            )
+        self.get_output_ids(route, query_parameters, true, false, automatic_pagination)
             .await
-    }
-
-    /// The two methods above or alternatively this
-    pub async fn _basic_output_ids(&self, _query_parameters: Vec<QueryParameter>, _automatic_pagination: bool) -> Result<OutputIdsResponse> {
-        todo!("decide which one to use")
     }
 
     /// Get alias outputs filtered by the given parameters.
@@ -71,12 +45,16 @@ impl Client {
     /// Query parameters: "stateController", "governor", "issuer", "sender", "createdBefore", "createdAfter"
     /// Returns an empty list if no results are found.
     /// api/indexer/v1/outputs/alias
-    pub async fn alias_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
+    pub async fn alias_output_ids(
+        &self,
+        query_parameters: Vec<QueryParameter>,
+        automatic_pagination: bool,
+    ) -> Result<OutputIdsResponse> {
         let route = "api/indexer/v1/outputs/alias";
 
         let query_parameters = verify_query_parameters_alias_outputs(query_parameters)?;
 
-        self.get_output_ids_with_pagination(route, query_parameters, true, false)
+        self.get_output_ids(route, query_parameters, true, false, automatic_pagination)
             .await
     }
 
@@ -86,7 +64,7 @@ impl Client {
         let route = format!("api/indexer/v1/outputs/alias/{alias_id}");
 
         Ok(*(self
-            .get_output_ids_with_pagination(&route, QueryParameters::new(Vec::new()), true, false)
+            .get_output_ids(&route, QueryParameters::new(Vec::new()), true, false, false)
             .await?
             .first()
             .ok_or_else(|| crate::Error::Node("no output id for alias".to_string()))?))
@@ -97,12 +75,16 @@ impl Client {
     /// Query parameters: "address", "createdBefore", "createdAfter"
     /// Returns an empty list if no results are found.
     /// api/indexer/v1/outputs/foundry
-    pub async fn foundry_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
+    pub async fn foundry_output_ids(
+        &self,
+        query_parameters: Vec<QueryParameter>,
+        automatic_pagination: bool,
+    ) -> Result<OutputIdsResponse> {
         let route = "api/indexer/v1/outputs/foundry";
 
         let query_parameters = verify_query_parameters_foundry_outputs(query_parameters)?;
 
-        self.get_output_ids_with_pagination(route, query_parameters, true, false)
+        self.get_output_ids(route, query_parameters, true, false, automatic_pagination)
             .await
     }
 
@@ -112,7 +94,7 @@ impl Client {
         let route = format!("api/indexer/v1/outputs/foundry/{foundry_id}");
 
         Ok(*(self
-            .get_output_ids_with_pagination(&route, QueryParameters::new(Vec::new()), true, false)
+            .get_output_ids(&route, QueryParameters::new(Vec::new()), true, false, false)
             .await?
             .first()
             .ok_or_else(|| crate::Error::Node("no output id for foundry".to_string()))?))
@@ -124,12 +106,16 @@ impl Client {
     /// "timelockedAfter", "issuer", "sender", "tag", "createdBefore", "createdAfter"
     /// Returns an empty list if no results are found.
     /// api/indexer/v1/outputs/nft
-    pub async fn nft_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<Vec<OutputId>> {
+    pub async fn nft_output_ids(
+        &self,
+        query_parameters: Vec<QueryParameter>,
+        automatic_pagination: bool,
+    ) -> Result<OutputIdsResponse> {
         let route = "api/indexer/v1/outputs/nft";
 
         let query_parameters = verify_query_parameters_nft_outputs(query_parameters)?;
 
-        self.get_output_ids_with_pagination(route, query_parameters, true, false)
+        self.get_output_ids(route, query_parameters, true, false, automatic_pagination)
             .await
     }
 
@@ -139,7 +125,7 @@ impl Client {
         let route = format!("api/indexer/v1/outputs/nft/{nft_id}");
 
         Ok(*(self
-            .get_output_ids_with_pagination(&route, QueryParameters::new(Vec::new()), true, false)
+            .get_output_ids(&route, QueryParameters::new(Vec::new()), true, false, false)
             .await?
             .first()
             .ok_or_else(|| crate::Error::Node("no output id for nft".to_string()))?))

--- a/client/src/node_api/indexer/routes.rs
+++ b/client/src/node_api/indexer/routes.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! IOTA node indexer routes
+
 use iota_types::{
     api::plugins::indexer::OutputIdsResponse,
     block::output::{AliasId, FoundryId, NftId, OutputId},

--- a/client/src/node_api/indexer/routes.rs
+++ b/client/src/node_api/indexer/routes.rs
@@ -27,17 +27,12 @@ impl Client {
     /// "hasExpiration", "expiresBefore", "expiresAfter", "hasTimelock", "timelockedBefore",
     /// "timelockedAfter", "sender", "tag", "createdBefore" and "createdAfter". Returns an empty Vec if no results
     /// are found. api/indexer/v1/outputs/basic
-    pub async fn basic_output_ids(
-        &self,
-        query_parameters: Vec<QueryParameter>,
-        automatic_pagination: bool,
-    ) -> Result<OutputIdsResponse> {
+    pub async fn basic_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<OutputIdsResponse> {
         let route = "api/indexer/v1/outputs/basic";
 
         let query_parameters = verify_query_parameters_basic_outputs(query_parameters)?;
 
-        self.get_output_ids(route, query_parameters, true, false, automatic_pagination)
-            .await
+        self.get_output_ids(route, query_parameters, true, false).await
     }
 
     /// Get alias outputs filtered by the given parameters.
@@ -45,17 +40,12 @@ impl Client {
     /// Query parameters: "stateController", "governor", "issuer", "sender", "createdBefore", "createdAfter"
     /// Returns an empty list if no results are found.
     /// api/indexer/v1/outputs/alias
-    pub async fn alias_output_ids(
-        &self,
-        query_parameters: Vec<QueryParameter>,
-        automatic_pagination: bool,
-    ) -> Result<OutputIdsResponse> {
+    pub async fn alias_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<OutputIdsResponse> {
         let route = "api/indexer/v1/outputs/alias";
 
         let query_parameters = verify_query_parameters_alias_outputs(query_parameters)?;
 
-        self.get_output_ids(route, query_parameters, true, false, automatic_pagination)
-            .await
+        self.get_output_ids(route, query_parameters, true, false).await
     }
 
     /// Get alias output by its aliasID.
@@ -64,7 +54,7 @@ impl Client {
         let route = format!("api/indexer/v1/outputs/alias/{alias_id}");
 
         Ok(*(self
-            .get_output_ids(&route, QueryParameters::new(Vec::new()), true, false, false)
+            .get_output_ids(&route, QueryParameters::new(Vec::new()), true, false)
             .await?
             .first()
             .ok_or_else(|| crate::Error::Node("no output id for alias".to_string()))?))
@@ -75,17 +65,12 @@ impl Client {
     /// Query parameters: "address", "createdBefore", "createdAfter"
     /// Returns an empty list if no results are found.
     /// api/indexer/v1/outputs/foundry
-    pub async fn foundry_output_ids(
-        &self,
-        query_parameters: Vec<QueryParameter>,
-        automatic_pagination: bool,
-    ) -> Result<OutputIdsResponse> {
+    pub async fn foundry_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<OutputIdsResponse> {
         let route = "api/indexer/v1/outputs/foundry";
 
         let query_parameters = verify_query_parameters_foundry_outputs(query_parameters)?;
 
-        self.get_output_ids(route, query_parameters, true, false, automatic_pagination)
-            .await
+        self.get_output_ids(route, query_parameters, true, false).await
     }
 
     /// Get foundry output by its foundryID.
@@ -94,7 +79,7 @@ impl Client {
         let route = format!("api/indexer/v1/outputs/foundry/{foundry_id}");
 
         Ok(*(self
-            .get_output_ids(&route, QueryParameters::new(Vec::new()), true, false, false)
+            .get_output_ids(&route, QueryParameters::new(Vec::new()), true, false)
             .await?
             .first()
             .ok_or_else(|| crate::Error::Node("no output id for foundry".to_string()))?))
@@ -106,17 +91,12 @@ impl Client {
     /// "timelockedAfter", "issuer", "sender", "tag", "createdBefore", "createdAfter"
     /// Returns an empty list if no results are found.
     /// api/indexer/v1/outputs/nft
-    pub async fn nft_output_ids(
-        &self,
-        query_parameters: Vec<QueryParameter>,
-        automatic_pagination: bool,
-    ) -> Result<OutputIdsResponse> {
+    pub async fn nft_output_ids(&self, query_parameters: Vec<QueryParameter>) -> Result<OutputIdsResponse> {
         let route = "api/indexer/v1/outputs/nft";
 
         let query_parameters = verify_query_parameters_nft_outputs(query_parameters)?;
 
-        self.get_output_ids(route, query_parameters, true, false, automatic_pagination)
-            .await
+        self.get_output_ids(route, query_parameters, true, false).await
     }
 
     /// Get NFT output by its nftID.
@@ -125,7 +105,7 @@ impl Client {
         let route = format!("api/indexer/v1/outputs/nft/{nft_id}");
 
         Ok(*(self
-            .get_output_ids(&route, QueryParameters::new(Vec::new()), true, false, false)
+            .get_output_ids(&route, QueryParameters::new(Vec::new()), true, false)
             .await?
             .first()
             .ok_or_else(|| crate::Error::Node("no output id for nft".to_string()))?))

--- a/client/src/node_api/indexer/routes.rs
+++ b/client/src/node_api/indexer/routes.rs
@@ -55,7 +55,7 @@ impl Client {
         let route = format!("api/indexer/v1/outputs/alias/{alias_id}");
 
         Ok(*(self
-            .get_output_ids(&route, QueryParameters::new(Vec::new()), true, false)
+            .get_output_ids(&route, QueryParameters::empty(), true, false)
             .await?
             .first()
             .ok_or_else(|| crate::Error::Node("no output id for alias".to_string()))?))
@@ -80,7 +80,7 @@ impl Client {
         let route = format!("api/indexer/v1/outputs/foundry/{foundry_id}");
 
         Ok(*(self
-            .get_output_ids(&route, QueryParameters::new(Vec::new()), true, false)
+            .get_output_ids(&route, QueryParameters::empty(), true, false)
             .await?
             .first()
             .ok_or_else(|| crate::Error::Node("no output id for foundry".to_string()))?))
@@ -106,7 +106,7 @@ impl Client {
         let route = format!("api/indexer/v1/outputs/nft/{nft_id}");
 
         Ok(*(self
-            .get_output_ids(&route, QueryParameters::new(Vec::new()), true, false)
+            .get_output_ids(&route, QueryParameters::empty(), true, false)
             .await?
             .first()
             .ok_or_else(|| crate::Error::Node("no output id for nft".to_string()))?))

--- a/client/tests/common/mod.rs
+++ b/client/tests/common/mod.rs
@@ -38,15 +38,12 @@ pub async fn create_client_and_secret_manager_with_funds(mnemonic: Option<&str>)
     for _ in 0..30 {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         let output_ids_response = client
-            .basic_output_ids(
-                vec![
-                    QueryParameter::Address(address.clone()),
-                    QueryParameter::HasExpiration(false),
-                    QueryParameter::HasTimelock(false),
-                    QueryParameter::HasStorageDepositReturn(false),
-                ],
-                true,
-            )
+            .basic_output_ids(vec![
+                QueryParameter::Address(address.clone()),
+                QueryParameter::HasExpiration(false),
+                QueryParameter::HasTimelock(false),
+                QueryParameter::HasStorageDepositReturn(false),
+            ])
             .await?;
 
         if !output_ids_response.is_empty() {

--- a/client/tests/common/mod.rs
+++ b/client/tests/common/mod.rs
@@ -37,16 +37,19 @@ pub async fn create_client_and_secret_manager_with_funds(mnemonic: Option<&str>)
     // Continue only after funds are received
     for _ in 0..30 {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-        let output_ids = client
-            .basic_output_ids(vec![
-                QueryParameter::Address(address.clone()),
-                QueryParameter::HasExpiration(false),
-                QueryParameter::HasTimelock(false),
-                QueryParameter::HasStorageDepositReturn(false),
-            ])
+        let output_ids_response = client
+            .basic_output_ids(
+                vec![
+                    QueryParameter::Address(address.clone()),
+                    QueryParameter::HasExpiration(false),
+                    QueryParameter::HasTimelock(false),
+                    QueryParameter::HasStorageDepositReturn(false),
+                ],
+                true,
+            )
             .await?;
 
-        if !output_ids.is_empty() {
+        if !output_ids_response.is_empty() {
             return Ok((client, secret_manager));
         }
     }

--- a/client/tests/node_api.rs
+++ b/client/tests/node_api.rs
@@ -55,15 +55,12 @@ async fn setup_transaction_block() -> (BlockId, TransactionId) {
     for _ in 0..30 {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         let output_ids_response = client
-            .basic_output_ids(
-                vec![
-                    QueryParameter::Address(address.to_string()),
-                    QueryParameter::HasExpiration(false),
-                    QueryParameter::HasTimelock(false),
-                    QueryParameter::HasStorageDepositReturn(false),
-                ],
-                true,
-            )
+            .basic_output_ids(vec![
+                QueryParameter::Address(address.to_string()),
+                QueryParameter::HasExpiration(false),
+                QueryParameter::HasTimelock(false),
+                QueryParameter::HasStorageDepositReturn(false),
+            ])
             .await
             .unwrap();
 
@@ -192,12 +189,9 @@ async fn test_get_address_outputs() {
         .unwrap()[0];
 
     let output_ids_response = client
-        .basic_output_ids(
-            vec![QueryParameter::Address(
-                address.to_bech32(&client.get_bech32_hrp().await.unwrap()),
-            )],
-            true,
-        )
+        .basic_output_ids(vec![QueryParameter::Address(
+            address.to_bech32(&client.get_bech32_hrp().await.unwrap()),
+        )])
         .await
         .unwrap();
 

--- a/client/tests/node_api.rs
+++ b/client/tests/node_api.rs
@@ -54,17 +54,20 @@ async fn setup_transaction_block() -> (BlockId, TransactionId) {
     // Continue only after funds are received
     for _ in 0..30 {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        let output_ids = client
-            .basic_output_ids(vec![
-                QueryParameter::Address(address.to_string()),
-                QueryParameter::HasExpiration(false),
-                QueryParameter::HasTimelock(false),
-                QueryParameter::HasStorageDepositReturn(false),
-            ])
+        let output_ids_response = client
+            .basic_output_ids(
+                vec![
+                    QueryParameter::Address(address.to_string()),
+                    QueryParameter::HasExpiration(false),
+                    QueryParameter::HasTimelock(false),
+                    QueryParameter::HasStorageDepositReturn(false),
+                ],
+                true,
+            )
             .await
             .unwrap();
 
-        if !output_ids.is_empty() {
+        if !output_ids_response.items.is_empty() {
             break;
         }
     }
@@ -188,14 +191,17 @@ async fn test_get_address_outputs() {
         .await
         .unwrap()[0];
 
-    let address = client
-        .basic_output_ids(vec![QueryParameter::Address(
-            address.to_bech32(&client.get_bech32_hrp().await.unwrap()),
-        )])
+    let output_ids_response = client
+        .basic_output_ids(
+            vec![QueryParameter::Address(
+                address.to_bech32(&client.get_bech32_hrp().await.unwrap()),
+            )],
+            true,
+        )
         .await
         .unwrap();
 
-    let r = client.get_outputs(address).await.unwrap();
+    let r = client.get_outputs(output_ids_response.items).await.unwrap();
 
     println!("{r:#?}");
 }

--- a/client/tests/transactions.rs
+++ b/client/tests/transactions.rs
@@ -57,15 +57,12 @@ async fn send_basic_output() -> Result<()> {
 
     // output can be fetched from the second address
     let output_ids_response = client
-        .basic_output_ids(
-            vec![
-                QueryParameter::Address(second_address.to_bech32(bech32_hrp)),
-                QueryParameter::HasExpiration(false),
-                QueryParameter::HasTimelock(false),
-                QueryParameter::HasStorageDepositReturn(false),
-            ],
-            true,
-        )
+        .basic_output_ids(vec![
+            QueryParameter::Address(second_address.to_bech32(bech32_hrp)),
+            QueryParameter::HasExpiration(false),
+            QueryParameter::HasTimelock(false),
+            QueryParameter::HasStorageDepositReturn(false),
+        ])
         .await?;
 
     assert_eq!(output_ids_response.items, vec![output_id]);

--- a/client/tests/transactions.rs
+++ b/client/tests/transactions.rs
@@ -56,16 +56,19 @@ async fn send_basic_output() -> Result<()> {
     let bech32_hrp = client.get_bech32_hrp().await?;
 
     // output can be fetched from the second address
-    let output_ids = client
-        .basic_output_ids(vec![
-            QueryParameter::Address(second_address.to_bech32(bech32_hrp)),
-            QueryParameter::HasExpiration(false),
-            QueryParameter::HasTimelock(false),
-            QueryParameter::HasStorageDepositReturn(false),
-        ])
+    let output_ids_response = client
+        .basic_output_ids(
+            vec![
+                QueryParameter::Address(second_address.to_bech32(bech32_hrp)),
+                QueryParameter::HasExpiration(false),
+                QueryParameter::HasTimelock(false),
+                QueryParameter::HasStorageDepositReturn(false),
+            ],
+            true,
+        )
         .await?;
 
-    assert_eq!(output_ids, vec![output_id]);
+    assert_eq!(output_ids_response.items, vec![output_id]);
 
     Ok(())
 }

--- a/documentation/docs/libraries/nodejs/references/api_ref.md
+++ b/documentation/docs/libraries/nodejs/references/api_ref.md
@@ -49,6 +49,7 @@
 - [IBasicOutputBuilderOptions](interfaces/IBasicOutputBuilderOptions.md)
 - [IFoundryOutputBuilderOptions](interfaces/IFoundryOutputBuilderOptions.md)
 - [INftOutputBuilderOptions](interfaces/INftOutputBuilderOptions.md)
+- [OutputIdsResponse](interfaces/OutputIdsResponse.md)
 - [IPreparedTransactionData](interfaces/IPreparedTransactionData.md)
 - [IInputSigningData](interfaces/IInputSigningData.md)
 - [IRange](interfaces/IRange.md)

--- a/documentation/docs/libraries/nodejs/references/classes/Client.md
+++ b/documentation/docs/libraries/nodejs/references/classes/Client.md
@@ -114,7 +114,7 @@ ___
 
 ### basicOutputIds
 
-▸ **basicOutputIds**(`queryParameters`): `Promise`<`string`[]\>
+▸ **basicOutputIds**(`queryParameters`): `Promise`<[`OutputIdsResponse`](../interfaces/OutputIdsResponse.md)\>
 
 Fetch basic output IDs based on query parameters
 
@@ -126,7 +126,7 @@ Fetch basic output IDs based on query parameters
 
 #### Returns
 
-`Promise`<`string`[]\>
+`Promise`<[`OutputIdsResponse`](../interfaces/OutputIdsResponse.md)\>
 
 ___
 
@@ -1002,7 +1002,7 @@ ___
 
 ### aliasOutputIds
 
-▸ **aliasOutputIds**(`queryParameters`): `Promise`<`string`[]\>
+▸ **aliasOutputIds**(`queryParameters`): `Promise`<[`OutputIdsResponse`](../interfaces/OutputIdsResponse.md)\>
 
 Fetch alias output IDs
 
@@ -1014,7 +1014,7 @@ Fetch alias output IDs
 
 #### Returns
 
-`Promise`<`string`[]\>
+`Promise`<[`OutputIdsResponse`](../interfaces/OutputIdsResponse.md)\>
 
 ___
 
@@ -1038,7 +1038,7 @@ ___
 
 ### nftOutputIds
 
-▸ **nftOutputIds**(`queryParameters`): `Promise`<`string`[]\>
+▸ **nftOutputIds**(`queryParameters`): `Promise`<[`OutputIdsResponse`](../interfaces/OutputIdsResponse.md)\>
 
 Fetch NFT output IDs
 
@@ -1050,7 +1050,7 @@ Fetch NFT output IDs
 
 #### Returns
 
-`Promise`<`string`[]\>
+`Promise`<[`OutputIdsResponse`](../interfaces/OutputIdsResponse.md)\>
 
 ___
 
@@ -1074,7 +1074,7 @@ ___
 
 ### foundryOutputIds
 
-▸ **foundryOutputIds**(`queryParameters`): `Promise`<`string`[]\>
+▸ **foundryOutputIds**(`queryParameters`): `Promise`<[`OutputIdsResponse`](../interfaces/OutputIdsResponse.md)\>
 
 Fetch Foundry Output IDs
 
@@ -1086,7 +1086,7 @@ Fetch Foundry Output IDs
 
 #### Returns
 
-`Promise`<`string`[]\>
+`Promise`<[`OutputIdsResponse`](../interfaces/OutputIdsResponse.md)\>
 
 ___
 

--- a/documentation/docs/libraries/nodejs/references/interfaces/OutputIdsResponse.md
+++ b/documentation/docs/libraries/nodejs/references/interfaces/OutputIdsResponse.md
@@ -1,0 +1,3 @@
+# Interface: OutputIdsResponse
+
+OutputIdsResponse.

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.0-rc.8 - 2023-XX-XX
+
+### Changed
+
+- `OutputIdsResponse::items` from `Vec<String>` to `Vec<OutputId>`;
+
 ## 1.0.0-rc.7 - 2023-03-09
 
 ### Changed

--- a/types/src/api/plugins/indexer.rs
+++ b/types/src/api/plugins/indexer.rs
@@ -3,7 +3,11 @@
 
 //! Node indexer responses.
 
+use core::ops::Deref;
+
 use serde::{Deserialize, Serialize};
+
+use crate::block::output::OutputId;
 
 /// Response of GET /api/indexer/v1/*
 /// Returns the output_ids for the provided query parameters.
@@ -15,5 +19,12 @@ pub struct OutputIdsResponse {
     /// Cursor confirmationMS+outputId.pageSize
     pub cursor: Option<String>,
     /// The output ids
-    pub items: Vec<String>,
+    pub items: Vec<OutputId>,
+}
+
+impl Deref for OutputIdsResponse {
+    type Target = Vec<OutputId>;
+    fn deref(&self) -> &Self::Target {
+        &self.items
+    }
 }


### PR DESCRIPTION
# Description of change

Allow requesting output ids without pagination, because it wasn't possible before, which could lead to useless requests or even timeouts

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota.rs/issues/1541

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Running examples/tests

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
