### PR TITLE
Docs - Develop - Remove Bee

### DIFF
--- a/documentation/docs/overview.md
+++ b/documentation/docs/overview.md
@@ -49,7 +49,9 @@ a [network for testing purposes (devnet)](https://wiki.iota.org/introduction/ref
 
 Different nodes can run on different software, but they always expose the same interface to clients. For example, one
 node could be a [Hornet](https://wiki.iota.org/shimmer/hornet/welcome) node, and the other could be
-a [Bee](https://wiki.iota.org/bee/welcome) node, and they both would appear the same for any client.
+a different implementation of the
+[core REST API](https://wiki.iota.org/shimmer/develop/nodes/core-rest-api/iota-core-rest-api/), and they both would
+appear the same for any client.
 
 ![A diagram that illustrates the text above. It has three layers: the application layer that includes iota.rs and its bindings, communication layer (the Internet network), and IOTA network layer with nodes that operate on one of the IOTA networks.](/img/overview/layered_overview.svg "An overview of IOTA layers.")
 


### PR DESCRIPTION
# Description

Removed bee from docs as it's no longer relevant.

fixes https://github.com/iotaledger/guild-devx/issues/89

## Type of change

- [x] Documentation Fix

# How Has This Been Tested?

Wiki was built locally.

# Checklist:

- [x] I have made corresponding changes to the documentation