### PR TITLE
IOTA - Docs  - fix links production

### DIFF
--- a/documentation/docs/_admonitions/_dust_protection.md
+++ b/documentation/docs/_admonitions/_dust_protection.md
@@ -1,6 +1,6 @@
 :::note Dust Protection
 
-Due to the [dust protection](https://wiki.iota.org/chrysalis-docs/faq#what-is-dust-protection-and-how-does-it-work)
+Due to the [dust protection](https://wiki.iota.org/introduction/explanations/faq/#what-is-dust-protection-and-how-does-it-work)
 mechanism implemented in the network protocol, microtransactions below 1Mi of IOTA tokens can only be sent to another
 address if there is already at least 1Mi on that address
 

--- a/documentation/docs/_admonitions/_faucet_service.md
+++ b/documentation/docs/_admonitions/_faucet_service.md
@@ -1,6 +1,6 @@
 :::note Faucet Service
 
 You can use the [faucet service](https://faucet.chrysalis-devnet.iota.cafe/) to send test tokens to any Chrysalis
-[devnet](https://wiki.iota.org/chrysalis-docs/devnet) address.
+[devnet](https://wiki.iota.org/introduction/reference/networks/devnet) address.
 
 :::

--- a/documentation/docs/_partials/examples/01_get_info/outputs/camelCase.md
+++ b/documentation/docs/_partials/examples/01_get_info/outputs/camelCase.md
@@ -28,6 +28,6 @@ The most important properties are:
   that it should be aware of all transactions in the Tangle. It is better to avoid interacting with nodes which are not
   fully synced.
 * `bech32HRP`: Indicates whether the given node is a part of [devnet](https://wiki.iota.org/introduction/reference/networks/devnet)
-  (`atoi`) or [mainnet](hhttps://wiki.iota.org/introduction/reference/networks/mainnet) (`iota`). You can find more info regarding the
+  (`atoi`) or [mainnet](https://wiki.iota.org/introduction/reference/networks/mainnet) (`iota`). You can find more info regarding the
   [IOTA address format](https://wiki.iota.org/introduction/reference/details/#iota-15-address-anatomy) in the official
   [Chrysalis documentation](https://wiki.iota.org/introduction/welcome).

--- a/documentation/docs/_partials/examples/01_get_info/outputs/camelCase.md
+++ b/documentation/docs/_partials/examples/01_get_info/outputs/camelCase.md
@@ -27,7 +27,7 @@ The most important properties are:
   up and running, it may not be fully prepared to process your API calls properly. The node should be "synced", meaning
   that it should be aware of all transactions in the Tangle. It is better to avoid interacting with nodes which are not
   fully synced.
-* `bech32HRP`: Indicates whether the given node is a part of [devnet](https://wiki.iota.org/chrysalis-docs/devnet)
-  (`atoi`) or [mainnet](https://wiki.iota.org/chrysalis-docs/mainnet) (`iota`). You can find more info regarding the
-  [IOTA address format](https://wiki.iota.org/chrysalis-docs/guides/developer/#iota-15-address-anatom) in the official
-  [Chrysalis documentation](https://wiki.iota.org/chrysalis-docs/welcome).
+* `bech32HRP`: Indicates whether the given node is a part of [devnet](https://wiki.iota.org/introduction/reference/networks/devnet)
+  (`atoi`) or [mainnet](hhttps://wiki.iota.org/introduction/reference/networks/mainnet) (`iota`). You can find more info regarding the
+  [IOTA address format](https://wiki.iota.org/introduction/reference/details/#iota-15-address-anatomy) in the official
+  [Chrysalis documentation](https://wiki.iota.org/introduction/welcome).

--- a/documentation/docs/_partials/examples/01_get_info/outputs/snake_case.md
+++ b/documentation/docs/_partials/examples/01_get_info/outputs/snake_case.md
@@ -28,6 +28,6 @@ The most important properties are:
   that it should be aware of all transactions in the Tangle. It is better to avoid interacting with nodes which are not
   fully synced.
 * `bech32_hrp`: Indicates whether the given node is a part of [devnet](https://wiki.iota.org/introduction/reference/networks/devnet)
-  (`atoi`) or [mainnet](hhttps://wiki.iota.org/introduction/reference/networks/mainnet) (`iota`). You can find more info regarding the
+  (`atoi`) or [mainnet](https://wiki.iota.org/introduction/reference/networks/mainnet) (`iota`). You can find more info regarding the
   [IOTA address format](https://wiki.iota.org/chrysalis-docs/guides/developer/#iota-15-address-anatom) in the official
   [Chrysalis documentation](https://wiki.iota.org/chrysalis-docs/welcome).

--- a/documentation/docs/_partials/examples/01_get_info/outputs/snake_case.md
+++ b/documentation/docs/_partials/examples/01_get_info/outputs/snake_case.md
@@ -27,7 +27,7 @@ The most important properties are:
   up and running, it may not be fully prepared to process your API calls properly. The node should be "synced", meaning
   that it should be aware of all transactions in the Tangle. It is better to avoid interacting with nodes which are not
   fully synced.
-* `bech32_hrp`: Indicates whether the given node is a part of [devnet](https://wiki.iota.org/chrysalis-docs/devnet)
-  (`atoi`) or [mainnet](https://wiki.iota.org/chrysalis-docs/mainnet) (`iota`). You can find more info regarding the
+* `bech32_hrp`: Indicates whether the given node is a part of [devnet](https://wiki.iota.org/introduction/reference/networks/devnet)
+  (`atoi`) or [mainnet](hhttps://wiki.iota.org/introduction/reference/networks/mainnet) (`iota`). You can find more info regarding the
   [IOTA address format](https://wiki.iota.org/chrysalis-docs/guides/developer/#iota-15-address-anatom) in the official
   [Chrysalis documentation](https://wiki.iota.org/chrysalis-docs/welcome).

--- a/documentation/docs/contribute.md
+++ b/documentation/docs/contribute.md
@@ -1,6 +1,6 @@
 ---
 description: Contribute to the IOTA Client Library joining the IOTA Libraries Initiative, contributing to the official GitHub repository or sharing your knowledge on Discord.  
-image: /img/logo/iota_mark_light.png
+image: /img/logo/libraries.png
 keywords:
 - join
 - documentation

--- a/documentation/docs/examples/get_info.mdx
+++ b/documentation/docs/examples/get_info.mdx
@@ -29,11 +29,11 @@ import WasmGetInfo from '../libraries/wasm/examples/_01_get_info.mdx';
 You can access all the features of the `iota.rs` library using an instance of the `Client` class. The `Client` class
 provides high-level abstraction to all interactions over IOTA network (Tangle). You have to instantiate this class
 before you start any interactions with the library, or more precisely with the
-[IOTA nodes](https://wiki.iota.org/chrysalis-docs/node_software) that power IOTA network.
+[IOTA nodes](https://wiki.iota.org/introduction/explanations/node_software) that power IOTA network.
 
 The library is designed to automatically choose a starting IOTA node based on the network type you would like to
-participate in: [`devnet`](https://wiki.iota.org/chrysalis-docs/devnet) or
-[`mainnet`](https://wiki.iota.org/chrysalis-docs/mainnet).
+participate in: [`devnet`](https://wiki.iota.org/introduction/reference/networks/devnet) or
+[`mainnet`](https://wiki.iota.org/introduction/reference/networks/mainnet).
 
 <WarningPasswordStorage/>
 

--- a/documentation/docs/explanations/address_key_space.md
+++ b/documentation/docs/explanations/address_key_space.md
@@ -58,7 +58,7 @@ And there are few additional interesting notes:
 planning on using many multiple accounts then you may be interested in our stateful library
 [wallet.rs](https://wiki.iota.org/wallet.rs/welcome) that incorporates all business logic needed to efficiently manage
 independent accounts.
-Our [exchange guide](https://wiki.iota.org/docs/build/exchange-integration/exchange-integration-guide)
+Our [exchange guide](https://wiki.iota.org/introduction/how_tos/exchange)
 provides some useful tips on how different accounts may be leveraged.
 
 ![address_generation](/img/libraries/address_generation.svg)

--- a/documentation/docs/getting_started/nodejs.md
+++ b/documentation/docs/getting_started/nodejs.md
@@ -1,6 +1,6 @@
 ---
 description: Getting started with the official IOTA Client Library Node.js binding.
-image: /img/logo/iota_mark_light.png
+image: /img/logo/libraries.png
 keywords:
 - Node.js
 - dotenv

--- a/documentation/docs/getting_started/rust.md
+++ b/documentation/docs/getting_started/rust.md
@@ -1,6 +1,6 @@
 ---
 description: Getting started with the official IOTA Client Library Rust library.
-image: /img/logo/iota_mark_light.png
+image: /img/logo/libraries.png
 keywords:
 - Rust
 - install

--- a/documentation/docs/getting_started/wasm.md
+++ b/documentation/docs/getting_started/wasm.md
@@ -1,6 +1,6 @@
 ---
 description: Getting started with the official IOTA Client Library Wasm binding.
-image: /img/logo/iota_mark_light.png
+image: /img/logo/libraries.png
 keywords:
 - Rust
 - install

--- a/documentation/docs/libraries/java/api_reference.md
+++ b/documentation/docs/libraries/java/api_reference.md
@@ -1,7 +1,7 @@
 ---
 title: API Reference
 description: Official IOTA Client Library Java API reference.
-image: /img/logo/iota_mark_light.png
+image: /img/logo/libraries.png
 keywords:
 - api
 - Java

--- a/documentation/docs/libraries/nodejs/api_reference.md
+++ b/documentation/docs/libraries/nodejs/api_reference.md
@@ -1,6 +1,6 @@
 ---
 description: Official IOTA Client Library Node.js API reference.
-image: /img/logo/iota_mark_light.png
+image: /img/logo/libraries.png
 keywords:
 - api
 - nodejs

--- a/documentation/docs/libraries/python/api_reference.md
+++ b/documentation/docs/libraries/python/api_reference.md
@@ -1,6 +1,6 @@
 ---
 description: Official IOTA Client Library Python API reference.
-image: /img/logo/iota_mark_light.png
+image: /img/logo/libraries.png
 keywords:
 - api
 - python

--- a/documentation/docs/libraries/rust/api_reference.md
+++ b/documentation/docs/libraries/rust/api_reference.md
@@ -1,6 +1,6 @@
 ---
 description: Official IOTA Client Library Rust API reference.
-image: /img/logo/iota_mark_light.png
+image: /img/logo/libraries.png
 keywords:
 - api
 - rust

--- a/documentation/docs/overview.md
+++ b/documentation/docs/overview.md
@@ -43,8 +43,8 @@ powerful no matter which language you choose.
 Your application communicates with iota.rs either directly in Rust or through one of the language bindings. The iota.rs
 library turns your requests into REST API calls and sends them to a node through the Internet. The node, in turn,
 interacts with the rest of an IOTA network, which could be
-the [main operational network (mainnet)](https://wiki.iota.org/chrysalis-docs/mainnet) or
-a [network for testing purposes (devnet)](https://wiki.iota.org/chrysalis-docs/devnet).
+the [main operational network (mainnet)](hhttps://wiki.iota.org/introduction/reference/networks/mainnet) or
+a [network for testing purposes (devnet)](https://wiki.iota.org/introduction/reference/networks/devnet).
 
 Different nodes can run on different software, but they always expose the same interface to clients. For example, one
 node could be a [Hornet](https://wiki.iota.org/hornet/welcome) node, and the other could be

--- a/documentation/docs/overview.md
+++ b/documentation/docs/overview.md
@@ -43,7 +43,7 @@ powerful no matter which language you choose.
 Your application communicates with iota.rs either directly in Rust or through one of the language bindings. The iota.rs
 library turns your requests into REST API calls and sends them to a node through the Internet. The node, in turn,
 interacts with the rest of an IOTA network, which could be
-the [main operational network (mainnet)](hhttps://wiki.iota.org/introduction/reference/networks/mainnet) or
+the [main operational network (mainnet)](https://wiki.iota.org/introduction/reference/networks/mainnet) or
 a [network for testing purposes (devnet)](https://wiki.iota.org/introduction/reference/networks/devnet).
 
 Different nodes can run on different software, but they always expose the same interface to clients. For example, one

--- a/documentation/docs/troubleshooting.md
+++ b/documentation/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 description: Troubleshooting the IOTA Client Library.  
-image: /img/logo/iota_mark_light.png
+image: /img/logo/libraries.png
 keywords:
 - discussion
 - channel


### PR DESCRIPTION
# Description of change

Fixed the following links:

 - [x] https://wiki.iota.org/img/logo/iota_mark_light.pngSocial meta tag
    * Linked From: https://wiki.iota.org/iota.rs/getting_started/rust/ and 10+ more
 - [x] https://wiki.iota.org/chrysalis-docs/node_software<a href>Redirected
    * Linked From: https://wiki.iota.org/iota.rs/examples/get_info/ and 2 more
 - [x] https://wiki.iota.org/chrysalis-docs/devnet<a href>Redirected
    * Linked From: https://wiki.iota.org/iota.rs/examples/get_info/ and 2 more
 - [x] https://wiki.iota.org/chrysalis-docs/mainnet<a href>Redirected
    * Linked From: https://wiki.iota.org/iota.rs/examples/get_info/ and 1 more
 - [x] https://wiki.iota.org/chrysalis-docs/guides/developer/<a href>Redirected
    * Linked From: https://wiki.iota.org/iota.rs/examples/get_info/ and 1 more
 - [x] https://wiki.iota.org/docs/build/exchange-integration/exchange-integration-guide<a href>
    * Linked From: https://wiki.iota.org/iota.rs/explanations/address_key_space/
 - [x] https://wiki.iota.org/chrysalis-docs/faq<a href>Redirected
    * Linked From: https://wiki.iota.org/iota.rs/examples/get_balance/ and 2 more
   

## Links to any relevant issues

fixes https://github.com/iotaledger/guild-devx/issues/109

## Type of change

- Documentation Fix

## How the change has been tested

wiki was built locally

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

