### PR TITLE
Use workflows to use ubuntu-latest

### DIFF
--- a/.github/workflows/covector.yml
+++ b/.github/workflows/covector.yml
@@ -81,8 +81,7 @@ jobs:
         # XXX: The GitHub hosted Windows 2022 image comes with Visual Studio 2022, but node-gyp
         # (which is used by neon-sys) sadly fails to recognize it. As a mitigation, we still run the
         # tests on Windows 2019, until we can figure out a way to fix the problem.
-        # NOTE: Using Ubuntu 18.04 to provide glibc compatibility. (#588)
-        os: [ubuntu-18.04, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-2019]
         node: ['12', '14', '16']
         exclude:
           # FIXME: fatal error C1083: Cannot open include file: 'node.h': No such file or directory
@@ -129,8 +128,7 @@ jobs:
         # XXX: The GitHub hosted Windows 2022 image comes with Visual Studio 2022, but node-gyp
         # (which is used by neon-sys) sadly fails to recognize it. As a mitigation, we still run the
         # tests on Windows 2019, until we can figure out a way to fix the problem.
-        # NOTE: Using Ubuntu 18.04 to provide glibc compatibility. (#588)
-        os: [ubuntu-18.04, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-2019]
 
     steps:
       - name: Checkout the Source Code

--- a/.github/workflows/python-bindings-publish.yml
+++ b/.github/workflows/python-bindings-publish.yml
@@ -21,11 +21,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Using Ubuntu 18.04 to provide glibc compatibility. (#588)
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: ['3.9']
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             identifier: linux
           - os: macos-latest
             identifier: macos


### PR DESCRIPTION
# Description of change

Updated all workflows to use `ubuntu-latest` as 18.04 is [depreciated](https://github.com/actions/runner-images/issues/6002).
Seems like #588 isn't a Problem anymore? At least python wheels were build perfectly fine in my [fork](https://github.com/Dr-Electron/iota.rs/actions/runs/5236856752).

But I'm not sure how to run the covector action and it fails for me, because it can't find `iotaledger/create-pull-request`

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run the python workflow in my fork

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
