### PR TITLE
Update README.md

### DIFF
--- a/client/bindings/nodejs/README.md
+++ b/client/bindings/nodejs/README.md
@@ -10,6 +10,13 @@ Node.js binding to the iota.rs client library.
 $ npm i @iota/client
 ```
 
+If you have some install errors, maybe you are trying to install an older version from the library from npm,
+try download latests version in an imperative way, like this
+
+```bash
+npm i @iota/client@3.0.0-rc.9
+```
+
 - Using yarn:
 
 ```bash


### PR DESCRIPTION
How to fix npm install @iota/client with wrong version errors

# Description of change

Add how to install node client if there are some error because wrong version from npm

## Type of change

- Documentation Fix

## Change checklist

- [ x ] I have followed the contribution guidelines for this project
